### PR TITLE
Feat tab spanners

### DIFF
--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import copy
+
 from typing import overload, TypeVar
 from typing_extensions import Self
 from dataclasses import dataclass, field, replace
@@ -33,6 +35,13 @@ class GTData:
     _formats: Formats
     _options: Options
     _has_built: bool = False
+
+    def _replace(self, **kwargs) -> Self:
+        # TODO: may want to validate that kwargs should be an attribute on GT
+        new_obj = copy.copy(self)
+        new_obj.__dict__.update(kwargs)
+
+        return new_obj
 
     @classmethod
     def from_data(

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -207,6 +207,15 @@ class Boxhead(_Sequence[ColInfo]):
     def vars_from_type(self, type: ColInfoTypeEnum) -> List[str]:
         return [x.var for x in self._d if x.type == type]
 
+    def reorder(self, vars: List[str]) -> Self:
+        boxh_vars = [col.var for col in self]
+        if set(vars) != set(boxh_vars):
+            raise ValueError("Reordering vars must contain all boxhead vars.")
+
+        new_order = [boxh_vars.index(var) for var in vars]
+
+        return self[new_order]
+
     # Get a list of columns
     def _get_columns(self) -> List[str]:
         return [x.var for x in self._d]

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -34,9 +34,6 @@ class GTData:
     _options: Options
     _has_built: bool = False
 
-    def replace(self, **kwargs: Any) -> Self:
-        return replace(self, **kwargs)
-
     @classmethod
     def from_data(
         cls,
@@ -98,6 +95,9 @@ class _Sequence(Sequence[T]):
 
     def __repr__(self):
         return f"{type(self).__name__}({self._d.__repr__()})"
+
+    def __eq__(self, other: Any) -> bool:
+        return (type(self) is type(other)) and (self._d == other._d)
 
 
 # Body ----
@@ -335,23 +335,12 @@ class SpannerInfo:
     spanner_units: str | None = None
     spanner_pattern: str | None = None
     vars: list[str] = field(default_factory=lambda: [])
-    gather: Optional[bool] = None
     built: Optional[str] = None
 
 
 class Spanners(_Sequence[SpannerInfo]):
     _d: list[SpannerInfo]
 
-    # The `spanners` DataFrame is used to handle spanner ID
-    # and text, the spanner level, the association to column names,
-    # whether the spanner is to gather columns, and the built
-    # form of the spanner label (depending on the output context)
-    # 0: `vars` (empty list, str)
-    # 1: `spanner_label` (empty list, str)
-    # 2: `spanner_id` (empty, str)
-    # 3: `spanner_level` (empty, int)
-    # 4: `gather` (empty, bool)
-    # 5: `built` (empty, str)
     @classmethod
     def from_ids(cls, ids: list[str]):
         """Construct an object from a list of spanner_ids"""
@@ -383,8 +372,8 @@ class Spanners(_Sequence[SpannerInfo]):
 
         return max(overlapping_levels, default=-1) + 1
 
-    def append_entry(self, span: SpannerInfo):
-        self.__class__(self._d + [span])
+    def append_entry(self, span: SpannerInfo) -> Self:
+        return self.__class__(self._d + [span])
 
 
 # Heading ---

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Literal, get_origin, get_type_hints
 # resolve generic, but we need to import at runtime, due to singledispatch looking
 # up annotations
 from ._gt_data import GTData, Spanners, ColInfoTypeEnum
+from ._tbl_data import eval_select
 
 
 if TYPE_CHECKING:
@@ -193,9 +194,8 @@ def resolve_cols_i(
         tbl_data = data._tbl_data
         cols_excl = []
 
-
-def eval_select(expr: list[str], data: TblData, strict: bool = True) -> list[str]:
-    """Return a list of column names selected by expr."""
+    selected = eval_select(tbl_data, expr, strict)
+    return [name_pos for name_pos in selected if name_pos[0] not in cols_excl]
 
 
 # Resolve generic ======================================================================

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -146,13 +146,14 @@ def cols_move(data: GTData, columns: list[str], after: str):
     elif not all([col in vars for col in columns]):
         raise ValueError("All `columns` must exist and be visible in the input `data` table.")
 
-    moving_columns = [col for col in columns if col not in after]
+    moving_columns = [col for col in sel_cols if col not in sel_after]
     other_columns = [col for col in vars if col not in moving_columns]
 
     indx = other_columns.index(after)
     final_vars = [*other_columns[: indx + 1], *moving_columns, *other_columns[indx + 1 :]]
 
-    return final_vars
+    new_boxhead = data._boxhead.reorder(final_vars)
+    return data._replace(_boxhead=new_boxhead)
 
 
 def spanners_print_matrix(

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -17,8 +17,8 @@ SpannerMatrix = List[Dict[str, Union[str, None]]]
 def tab_spanner(
     data: GTData,
     label: str,
-    columns: Optional[list[str]] = None,
-    spanners: Optional[list[str]] = None,
+    columns: Union[list[str], str, None] = None,
+    spanners: Union[list[str], str, None] = None,
     level: Optional[int] = None,
     id: Optional[str] = None,
     gather: bool = True,
@@ -55,10 +55,17 @@ def tab_spanner(
     replace:
         Replace existing spanners.
     """
+
     crnt_spanner_ids = [span.spanner_id for span in data._spanners]
 
     if id is None:
         id = label
+
+    if isinstance(columns, str):
+        columns = [columns]
+
+    if isinstance(spanners, str):
+        spanners = [spanners]
 
     # validations ----
     if level is not None and level < 0:

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -130,8 +130,29 @@ def tab_spanner(
 
 
 def cols_move(data: GTData, columns: list[str], after: str):
-    # TODO:
-    raise NotImplementedError()
+    sel_cols = resolve_cols_c(columns, data)
+
+    sel_after = resolve_cols_c([after], data)
+
+    vars = [col.var for col in data._boxhead]
+
+    if len(after) > 1:
+        raise ValueError(f"Only 1 value should be supplied to `after`, recieved argument: {after}")
+    elif after not in vars:
+        raise ValueError(f"Column {after} not found in table.")
+
+    if not len(columns):
+        raise Exception("No columns selected.")
+    elif not all([col in vars for col in columns]):
+        raise ValueError("All `columns` must exist and be visible in the input `data` table.")
+
+    moving_columns = [col for col in columns if col not in after]
+    other_columns = [col for col in vars if col not in moving_columns]
+
+    indx = other_columns.index(after)
+    final_vars = [*other_columns[: indx + 1], *moving_columns, *other_columns[indx + 1 :]]
+
+    return final_vars
 
 
 def spanners_print_matrix(

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, List, cast
+from typing_extensions import Self
 import pkg_resources
 
 import sass
@@ -93,6 +94,13 @@ class GT(
         # This is a bad idea ----
         gtdata = GTData.from_data(data, locale=locale, **kwargs)
         super().__init__(**gtdata.__dict__)
+
+    def _replace(self, **kwargs) -> Self:
+        # TODO: may want to validate that kwargs should be an attribute on GT
+        new_obj = copy.copy(self)
+        new_obj.__dict__.update(kwargs)
+
+        return new_obj
 
     # TODO: Refactor API methods -----
     fmt_number = fmt_number

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -25,6 +25,7 @@ from great_tables._formats import (
     fmt_integer,
     fmt_scientific,
     fmt_currency,
+    fmt_engineering,
 )
 from great_tables._heading import HeadingAPI
 from great_tables._locale import LocaleAPI
@@ -101,6 +102,8 @@ class GT(
     fmt_integer = fmt_integer
     fmt_scientific = fmt_scientific
     fmt_currency = fmt_currency
+    fmt_engineering = fmt_engineering
+
     tab_spanner = tab_spanner
     cols_move = cols_move
 

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -95,13 +95,6 @@ class GT(
         gtdata = GTData.from_data(data, locale=locale, **kwargs)
         super().__init__(**gtdata.__dict__)
 
-    def _replace(self, **kwargs) -> Self:
-        # TODO: may want to validate that kwargs should be an attribute on GT
-        new_obj = copy.copy(self)
-        new_obj.__dict__.update(kwargs)
-
-        return new_obj
-
     # TODO: Refactor API methods -----
     fmt_number = fmt_number
     fmt_percent = fmt_percent

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -31,7 +31,7 @@ from great_tables._locale import LocaleAPI
 from great_tables._options import OptionsAPI
 from great_tables._row_groups import RowGroupsAPI
 from great_tables._source_notes import SourceNotesAPI
-from great_tables._spanners import tab_spanner
+from great_tables._spanners import tab_spanner, cols_move
 from great_tables._stub import reorder_stub_df
 from great_tables._stubhead import StubheadAPI
 
@@ -102,6 +102,7 @@ class GT(
     fmt_scientific = fmt_scientific
     fmt_currency = fmt_currency
     tab_spanner = tab_spanner
+    cols_move = cols_move
 
     # -----
 

--- a/tests/test_gt.py
+++ b/tests/test_gt.py
@@ -1,6 +1,7 @@
 import pytest
 
 from great_tables import GT
+from great_tables._gt_data import RowGroups
 import pandas as pd
 
 # Generate a gt Table object for assertion testing
@@ -13,8 +14,14 @@ def gt_tbl():
     return GT(pd_data)
 
 
-def test_gt_object_prerender(gt_tbl: GT):
+def test_gt_replace(gt_tbl: GT):
+    row_groups = RowGroups(["x"])
+    new_gt_tbl = gt_tbl._replace(_row_groups=row_groups)
 
+    assert new_gt_tbl._row_groups is row_groups
+
+
+def test_gt_object_prerender(gt_tbl: GT):
     assert type(gt_tbl).__name__ == "GT"
 
     # Assert that certain private variables exist with a
@@ -32,13 +39,14 @@ def test_gt_object_prerender(gt_tbl: GT):
 
 
 def test_gt_table_render(gt_tbl: GT):
-
     # Assert that a table render process will generate a string object
     assert type(gt_tbl.render(context="html")).__name__ == "str"
 
     assert (
         type(
-            gt_tbl.tab_header(title="Title of Table", subtitle="The Subtitle").render(context="html")
+            gt_tbl.tab_header(title="Title of Table", subtitle="The Subtitle").render(
+                context="html"
+            )
         ).__name__
         == "str"
     )

--- a/tests/test_gt_data.py
+++ b/tests/test_gt_data.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from great_tables._gt_data import Stub, RowInfo
+from great_tables._gt_data import Stub, RowInfo, Boxhead, ColInfo
 from great_tables._gt_data import RowGroups
 
 
@@ -31,3 +31,9 @@ def test_row_groups_construct_manual():
 
     assert isinstance(groups[:], RowGroups)
 
+
+def test_boxhead_reorder():
+    boxh = Boxhead([ColInfo("a"), ColInfo("b"), ColInfo("c")])
+    new_boxh = boxh.reorder(["b", "a", "c"])
+
+    assert new_boxh == Boxhead([ColInfo("b"), ColInfo("a"), ColInfo("c")])

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -1,7 +1,9 @@
+import pandas as pd
 import pytest
 
-from great_tables._spanners import spanners_print_matrix, empty_spanner_matrix
+from great_tables._spanners import spanners_print_matrix, empty_spanner_matrix, tab_spanner
 from great_tables._gt_data import Spanners, SpannerInfo, Boxhead, ColInfo, ColInfoTypeEnum
+from great_tables import GT
 
 
 @pytest.fixture
@@ -67,3 +69,14 @@ def test_empty_spanner_matrix_arg_omit_columns_row():
 
     assert vars == ["a", "b"]
     assert mat == []
+
+
+def test_tab_spanners_simple():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    src_gt = GT(df)
+
+    dst_span = Spanners([SpannerInfo("a_spanner", 0, "a_spanner", vars=["b", "a"])])
+
+    new_gt = tab_spanner(src_gt, "a_spanner", columns=["b", "a"], gather=False)
+    assert len(new_gt._spanners)
+    assert new_gt._spanners == dst_span

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -1,7 +1,12 @@
 import pandas as pd
 import pytest
 
-from great_tables._spanners import spanners_print_matrix, empty_spanner_matrix, tab_spanner
+from great_tables._spanners import (
+    spanners_print_matrix,
+    empty_spanner_matrix,
+    tab_spanner,
+    cols_move,
+)
 from great_tables._gt_data import Spanners, SpannerInfo, Boxhead, ColInfo, ColInfoTypeEnum
 from great_tables import GT
 
@@ -95,3 +100,11 @@ def test_tab_spanners_with_spanner_ids():
 
     assert len(new_gt._spanners) == 2
     assert new_gt._spanners[1] == dst_span
+
+
+def test_cols_move():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    src_gt = GT(df)
+
+    new_gt = cols_move(src_gt, columns=["a"], after="b")
+    assert [col.var for col in new_gt._boxhead] == ["b", "a", "c"]

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -71,12 +71,27 @@ def test_empty_spanner_matrix_arg_omit_columns_row():
     assert mat == []
 
 
-def test_tab_spanners_simple():
+def test_tab_spanners_with_columns():
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
     src_gt = GT(df)
 
-    dst_span = Spanners([SpannerInfo("a_spanner", 0, "a_spanner", vars=["b", "a"])])
+    dst_span = SpannerInfo("a_spanner", 0, "a_spanner", vars=["b", "a"])
 
     new_gt = tab_spanner(src_gt, "a_spanner", columns=["b", "a"], gather=False)
     assert len(new_gt._spanners)
-    assert new_gt._spanners == dst_span
+    assert new_gt._spanners[0] == dst_span
+
+
+def test_tab_spanners_with_spanner_ids():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    src_gt = GT(df)
+
+    # we'll be testing for this second spanner added
+    dst_span = SpannerInfo("b_spanner", 1, "b_spanner", vars=["c", "b", "a"])
+
+    gt_with_span = tab_spanner(src_gt, "a_spanner", columns=["b", "a"], gather=False)
+
+    new_gt = tab_spanner(gt_with_span, "b_spanner", spanners="a_spanner", columns=["c"])
+
+    assert len(new_gt._spanners) == 2
+    assert new_gt._spanners[1] == dst_span

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -102,6 +102,16 @@ def test_tab_spanners_with_spanner_ids():
     assert new_gt._spanners[1] == dst_span
 
 
+def test_tab_spanners_with_gather():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    src_gt = GT(df)
+
+    new_gt = tab_spanner(src_gt, "a_spanner", columns=["a", "c"], gather=True)
+
+    assert len(new_gt._spanners) == 1
+    assert [col.var for col in new_gt._boxhead] == ["a", "c", "b"]
+
+
 def test_cols_move():
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
     src_gt = GT(df)

--- a/tests/test_tbl_data.py
+++ b/tests/test_tbl_data.py
@@ -3,21 +3,23 @@ import polars as pl
 import polars.testing
 import pytest
 
-from great_tables._tbl_data import _get_cell, _get_column_dtype, _set_cell, get_column_names, DataFrameLike, reorder
+from great_tables._tbl_data import (
+    _get_cell,
+    _get_column_dtype,
+    _set_cell,
+    get_column_names,
+    DataFrameLike,
+    reorder,
+    eval_select,
+)
 
 
-params_frames = [
-    pytest.param(pd.DataFrame, id="pandas"),
-    pytest.param(pl.DataFrame, id="polars")
-]
+params_frames = [pytest.param(pd.DataFrame, id="pandas"), pytest.param(pl.DataFrame, id="polars")]
+
 
 @pytest.fixture(params=params_frames, scope="function")
 def df(request) -> pd.DataFrame:
-    return request.param({
-        'col1': [1, 2, 3],
-        'col2': ['a', 'b', 'c'],
-        'col3': [4.0, 5.0, 6.0]
-    })
+    return request.param({"col1": [1, 2, 3], "col2": ["a", "b", "c"], "col3": [4.0, 5.0, 6.0]})
 
 
 def assert_frame_equal(src, target):
@@ -30,7 +32,7 @@ def assert_frame_equal(src, target):
 
 
 def test_get_column_names(df: DataFrameLike):
-    expected = ['col1', 'col2', 'col3']
+    expected = ["col1", "col2", "col3"]
     assert get_column_names(df) == expected
 
 
@@ -39,16 +41,12 @@ def test_get_column_dtypes(df: DataFrameLike):
 
 
 def test_get_cell(df: DataFrameLike):
-    assert _get_cell(df, 1, 'col2') == 'b'
+    assert _get_cell(df, 1, "col2") == "b"
 
 
 def test_set_cell(df: DataFrameLike):
-    expected = df.__class__({
-        'col1': [1, 2, 3],
-        'col2': ['a', 'x', 'c'],
-        'col3': [4.0, 5.0, 6.0]
-    })
-    _set_cell(df, 1, 'col2', 'x')
+    expected = df.__class__({"col1": [1, 2, 3], "col2": ["a", "x", "c"], "col3": [4.0, 5.0, 6.0]})
+    _set_cell(df, 1, "col2", "x")
     assert_frame_equal(df, expected)
 
 
@@ -60,3 +58,8 @@ def test_reorder(df: DataFrameLike):
         dst.index = pd.Index([0, 2])
 
     assert_frame_equal(res, dst)
+
+
+def test_eval_select_with_list(df: DataFrameLike):
+    sel = eval_select(df, ["col2", "col1"])
+    assert sel == [("col2", 1), ("col1", 0)]


### PR DESCRIPTION
This PR completes adding basic tab_spanner functionality (except in the rendering sense).

As part of the implementation, it fleshes out these pieces:

* cols_move
* eval_select for tidyselection on a DataFrame