### PR TITLE
fix: do not mutate sourcenotes or body

### DIFF
--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -425,12 +425,7 @@ __Sourcenotes = None
 from typing import List
 
 
-class SourceNotes:
-    source_notes: List[str] = []
-
-    def __init__(self):
-        pass
-
+SourceNotes = list[str]
 
 # Footnotes ----
 __Footnotes = None

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -64,7 +64,7 @@ class GTData:
             _spanners=Spanners([]),
             _heading=Heading(),
             _stubhead=Stubhead(),
-            _source_notes=SourceNotes(),
+            _source_notes=[],
             _footnotes=Footnotes(),
             _styles=Styles(),
             _locale=Locale(locale),

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -425,7 +425,7 @@ __Sourcenotes = None
 from typing import List
 
 
-SourceNotes = list[str]
+SourceNotes = List[str]
 
 # Footnotes ----
 __Footnotes = None

--- a/great_tables/_source_notes.py
+++ b/great_tables/_source_notes.py
@@ -1,41 +1,37 @@
 from __future__ import annotations
 
+from ._gt_data import GTData
 
-class SourceNotesAPI:
-    def tab_source_note(self, source_note: str):
-        """
-        Add a source note citation.
 
-        Add a source note to the footer part of the gt table. A source note is
-        useful for citing the data included in the table. Several can be added to the
-        footer, simply use multiple calls of `tab_source_note()` and they will be
-        inserted in the order provided. We can use Markdown formatting for the note,
-        or, if the table is intended for HTML output, we can include HTML formatting.
+def tab_source_note(data: GTData, source_note: str):
+    """
+    Add a source note citation.
 
-        Parameters
-        ----------
-        source_note (str)
-            Text to be used in the source note. We can optionally use the `md()` or
-            `html()` helper functions to style the text as Markdown or to retain HTML
-            elements in the text.
+    Add a source note to the footer part of the gt table. A source note is
+    useful for citing the data included in the table. Several can be added to the
+    footer, simply use multiple calls of `tab_source_note()` and they will be
+    inserted in the order provided. We can use Markdown formatting for the note,
+    or, if the table is intended for HTML output, we can include HTML formatting.
 
-        Returns
-        -------
-        GT
-            Result of the table operation.
+    Parameters
+    ----------
+    source_note (str)
+        Text to be used in the source note. We can optionally use the `md()` or
+        `html()` helper functions to style the text as Markdown or to retain HTML
+        elements in the text.
 
-        Examples
-        --------
-            >>> from gt import *
-            >>> x = GT([{"a": 5, "b": 10}, {"a": 15, "b": 20}])
-            >>>     .tab_source_note(source_note="Source note for the table.")
-            >>> x
-            >>> print(x)
-        """
+    Returns
+    -------
+    GT
+        Result of the table operation.
 
-        if self._source_notes.source_notes == []:
-            self._source_notes.source_notes = [source_note]
-        elif type(self._source_notes.source_notes) is list:
-            self._source_notes.source_notes.append(source_note)
+    Examples
+    --------
+        >>> from gt import *
+        >>> x = GT([{"a": 5, "b": 10}, {"a": 15, "b": 20}])
+        >>>     .tab_source_note(source_note="Source note for the table.")
+        >>> x
+        >>> print(x)
+    """
 
-        return self
+    return data._replace(_source_notes=data._source_notes + [source_note])

--- a/great_tables/data/__init__.py
+++ b/great_tables/data/__init__.py
@@ -143,8 +143,6 @@ _illness_dtype = {
     "norm_u": "float64",
 }
 
-_islands_fname = pkg_resources.resource_filename(DATA_MOD, "11-islands.csv")
-
 countrypops: pd.DataFrame = pd.read_csv(_countrypops_fname, dtype=_countrypops_dtype)  # type: ignore
 countrypops.__doc__ = """
 Yearly populations of countries from 1960 to 2022
@@ -298,8 +296,6 @@ remained stable during their illness, unfortunately, the patient's condition did
 not improve. On days 7 and 8, the patient's health declined further, with
 symptoms such as nosebleeds, gastrointestinal bleeding, and hematoma.
 """
-
-islands: pd.DataFrame = pd.read_csv(_islands_fname)  # type: ignore
 
 
 _x_locales_fname = pkg_resources.resource_filename(DATA_MOD, "x_locales.csv")

--- a/great_tables/data/__init__.py
+++ b/great_tables/data/__init__.py
@@ -143,6 +143,8 @@ _illness_dtype = {
     "norm_u": "float64",
 }
 
+_islands_fname = pkg_resources.resource_filename(DATA_MOD, "11-islands.csv")
+
 countrypops: pd.DataFrame = pd.read_csv(_countrypops_fname, dtype=_countrypops_dtype)  # type: ignore
 countrypops.__doc__ = """
 Yearly populations of countries from 1960 to 2022
@@ -296,6 +298,8 @@ remained stable during their illness, unfortunately, the patient's condition did
 not improve. On days 7 and 8, the patient's health declined further, with
 symptoms such as nosebleeds, gastrointestinal bleeding, and hematoma.
 """
+
+islands: pd.DataFrame = pd.read_csv(_islands_fname)  # type: ignore
 
 
 _x_locales_fname = pkg_resources.resource_filename(DATA_MOD, "x_locales.csv")

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -31,7 +31,7 @@ from great_tables._heading import HeadingAPI
 from great_tables._locale import LocaleAPI
 from great_tables._options import OptionsAPI
 from great_tables._row_groups import RowGroupsAPI
-from great_tables._source_notes import SourceNotesAPI
+from great_tables._source_notes import tab_source_note
 from great_tables._spanners import tab_spanner, cols_move
 from great_tables._stub import reorder_stub_df
 from great_tables._stubhead import StubheadAPI
@@ -67,7 +67,6 @@ class GT(
     RowGroupsAPI,
     HeadingAPI,
     StubheadAPI,
-    SourceNotesAPI,
     FootnotesAPI,
     LocaleAPI,
     FormatsAPI,
@@ -91,9 +90,17 @@ class GT(
     def _repr_html_(self):
         return self.render(context="html")
 
-    def __init__(self, data: Any, locale: str = "", **kwargs):
+    def __init__(
+        self,
+        data: Any,
+        locale: str = "",
+        rowname_col: str | None = None,
+        groupname_col: str | None = None,
+    ):
         # This is a bad idea ----
-        gtdata = GTData.from_data(data, locale=locale, **kwargs)
+        gtdata = GTData.from_data(
+            data, locale=locale, rowname_col=rowname_col, groupname_col=groupname_col
+        )
         super().__init__(**gtdata.__dict__)
 
     # TODO: Refactor API methods -----
@@ -105,6 +112,7 @@ class GT(
     fmt_engineering = fmt_engineering
 
     tab_spanner = tab_spanner
+    tab_source_note = tab_source_note
     cols_move = cols_move
 
     # -----
@@ -120,7 +128,7 @@ class GT(
         # Build the body of the table by generating a dictionary
         # of lists with cells initially set to nan values
         built = copy.copy(self)
-        built._body = self._body.__class__(self._tbl_data)
+        built._body = self._body.__class__(self._tbl_data.copy())
         built._render_formats(context)
         # built._body = _migrate_unformatted_to_output(body)
 
@@ -401,8 +409,9 @@ def _stub_group_names_has_column(data: GT) -> bool:
 def _row_groups_get(data: GT) -> List[str]:
     return data._row_groups._d
 
+
 def _create_source_notes_component(data: GT) -> str:
-    source_notes = data._source_notes.source_notes
+    source_notes = data._source_notes
 
     # If there are no source notes, then return an empty string
     if source_notes == []:

--- a/tests/test_gt.py
+++ b/tests/test_gt.py
@@ -32,7 +32,7 @@ def test_gt_object_prerender(gt_tbl: GT):
     assert type(gt_tbl._spanners).__name__ == "Spanners"
     assert type(gt_tbl._heading).__name__ == "Heading"
     assert type(gt_tbl._stubhead).__name__ == "Stubhead"
-    assert type(gt_tbl._source_notes).__name__ == "SourceNotes"
+    assert isinstance(gt_tbl._source_notes, list)
     assert type(gt_tbl._footnotes).__name__ == "Footnotes"
     assert type(gt_tbl._styles).__name__ == "Styles"
     assert type(gt_tbl._locale).__name__ == "Locale"


### PR DESCRIPTION
This PR fixes SourceNotes and Body code, so it does not mutate the underlying data. This was causing issues where re-running code could continuously append notes, or error due to body mutations (e.g. a numeric column becoming a string column)

Note that I removed the custom SourceNotes class, in favor of using a list of strings