### PR TITLE
ci: deploy to pypi on release

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -33,3 +33,24 @@ jobs:
       - name: pytest unit tests
         run: |
           make test
+
+
+  release-pypi:
+    name: "Release to pypi"
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.event_name == 'release'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - name: "Build Package"
+        run: |
+          python -m pip install build wheel
+          python -m build --sdist --wheel
+      - name: "Deploy to PyPI"
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This PR deploys to pypi whenever we make a github release. It only runs if the tests pass. However, note it does not require the docs to build (since they are in a different workflow, and it's a bit tricky, but not impossible to do?!). There are ways to test that don't involve full blown attempting to deploy. But given how early it is, I vote for us merging, doing a release, and then seeing what happens 😈.