### PR TITLE
Docs fix upgrade quartodoc

### DIFF
--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -80,10 +80,6 @@ class GT(
     """
     Create a gt Table object.
 
-    Methods
-    -------
-        render: Renders and returns the HTML table.
-
     Examples
     --------
         >>> from gt import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ homepage = "https://github.com/posit-dev/great_tables"
 [project.optional-dependencies]
 dev = [
     "jupyter",
-    "quartodoc>=0.7.1"; python_version >= '3.9'",
+    "quartodoc>=0.7.1; python_version >= '3.9'",
     "polars",
     "pytest>=3",
     "siuba",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ homepage = "https://github.com/posit-dev/great_tables"
 [project.optional-dependencies]
 dev = [
     "jupyter",
-    "quartodoc>=0.7.1"; python_version >= '3.9',
+    "quartodoc>=0.7.1"; python_version >= '3.9'",
     "polars",
     "pytest>=3",
     "siuba",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ homepage = "https://github.com/posit-dev/great_tables"
 [project.optional-dependencies]
 dev = [
     "jupyter",
-    "quartodoc",
+    "quartodoc>=0.7.1",
     "polars",
     "pytest>=3",
     "siuba",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ homepage = "https://github.com/posit-dev/great_tables"
 [project.optional-dependencies]
 dev = [
     "jupyter",
-    "quartodoc>=0.7.1",
+    "quartodoc>=0.7.1"; python_version >= '3.9',
     "polars",
     "pytest>=3",
     "siuba",


### PR DESCRIPTION
This PR upgrades to the latest quartodoc, which can correctly document the methods on the `GT` class.

Note that I had to remove the methods section from GT, which apparently quartodoc does not support  😓 