### PR TITLE
fix: tab_header no longer mutates GTData

### DIFF
--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -32,7 +32,7 @@ class GTData:
     _row_groups: RowGroups
     _group_rows: GroupRows
     _spanners: Spanners
-    _heading: Heading | None
+    _heading: Heading
     _stubhead: Stubhead
     _source_notes: SourceNotes
     _footnotes: Footnotes
@@ -706,6 +706,7 @@ __Heading = None
 from typing import Optional, Union, List
 
 
+@dataclass
 class Heading:
     title: Optional[str] = None
     subtitle: Optional[str] = None

--- a/great_tables/_heading.py
+++ b/great_tables/_heading.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 from typing import Optional, Union, List
-from ._gt_data import GTData
+from ._gt_data import GTData, Heading
+
+from copy import copy
 
 
 class HeadingAPI:
@@ -68,8 +70,7 @@ class HeadingAPI:
         )
         ```
         """
-        self._heading.title = title
-        self._heading.subtitle = subtitle
-        self._heading.preheader = preheader
+        result = copy(self)
+        result._heading = Heading(title=title, subtitle=subtitle, preheader=preheader)
 
-        return self
+        return result

--- a/tests/test_heading.py
+++ b/tests/test_heading.py
@@ -1,0 +1,14 @@
+import pandas as pd
+
+from great_tables import GT
+
+
+def test_heading_no_mutate():
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    gt = GT(df)
+
+    gt2 = gt.tab_header(title="First")
+
+    assert gt2 is not gt
+    assert gt._heading.title is None
+    assert gt2._heading.title == "First"


### PR DESCRIPTION
This PR changes `tab_header()`, so that it creates and returns a copy of GTData, and puts a new Heading object on it (vs mutating the existing heading).

This prevents heading mutations from creating headings in places where tab_heading isn't called.