### PR TITLE
fix: spanners_print_matrix now excludes selected cols that are in the stub

### DIFF
--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -502,7 +502,11 @@ def spanners_print_matrix(
 
     for span_ii, span in enumerate(crnt_spans):
         for var in span.vars:
-            label_matrix[span.spanner_level][var] = spanner_reprs[span_ii]
+            # This if clause skips spanned columns that are not in the
+            # boxhead vars we are planning to use (e.g. not in the visible ones
+            # or in the stub).
+            if var in label_matrix[span.spanner_level]:
+                label_matrix[span.spanner_level][var] = spanner_reprs[span_ii]
 
     # reverse order , so if you were to print it out, level 0 would appear on the bottom
     label_matrix.reverse()

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -74,6 +74,17 @@ def test_spanners_print_matrix_arg_include_hidden(spanners, boxhead):
     ]
 
 
+def test_spanners_print_matrix_exclude_stub():
+    """spanners_print_matrix omits a selected column if it's in the stub."""
+    info = SpannerInfo(spanner_id="a", spanner_level=0, vars=["x", "y"], built="A")
+    spanners = Spanners([info])
+    boxh = Boxhead([ColInfo(var="x"), ColInfo(var="y", type=ColInfoTypeEnum.stub)])
+
+    mat, vars = spanners_print_matrix(spanners, boxh, omit_columns_row=True)
+    assert vars == ["x"]
+    assert mat == [{"x": "A"}]
+
+
 def test_empty_spanner_matrix():
     mat, vars = empty_spanner_matrix(["a", "b"], omit_columns_row=False)
 


### PR DESCRIPTION
This PR ensures that `spanners_print_matrix` does not include columns selected for a spanner, if those columns are in the stub.

For example, `currency` below was bumping other columns in header over:

```python
from great_tables import GT, exibble

gt = GT(exibble, rowname_col="currency").tab_spanner("A", ["currency", "group", "row"])
```

<img width="1059" alt="image" src="https://github.com/posit-dev/great-tables/assets/2574498/dfaaf9b6-39ba-4a56-af48-567e02e41b72">

Now it doesn't!:

<img width="981" alt="image" src="https://github.com/posit-dev/great-tables/assets/2574498/25710905-c93f-42b2-9002-391602544432">

