### PR TITLE
refactor: freeze dataclasses

### DIFF
--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import pandas as pd
 from typing import Optional, Any
+from typing_extensions import Self
 from ._gt_data import GTData
 
 from ._utils import _assert_list_is_subset
 
 
 class BoxheadAPI:
-    def cols_label(self, **kwargs: Any) -> GTData:
+    def cols_label(self, **kwargs: Any) -> Self:
         """
         Relabel one or more columns.
 
@@ -92,10 +93,9 @@ class BoxheadAPI:
         # msg: "All column names provided must exist in the input `.data` table."
         _assert_list_is_subset(mod_columns, set_list=column_names)
 
-        for i in range(len(kwargs)):
-            self._boxhead._set_column_label(column=mod_columns[i], label=new_labels[i])
+        boxhead = self._boxhead._set_column_labels(kwargs)
 
-        return self
+        return self._replace(_boxhead=boxhead)
 
     def cols_align(self, align: str = "left", columns: Optional[str] = None) -> GTData:
         """

--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -1,168 +1,171 @@
 from __future__ import annotations
 
 import pandas as pd
-from typing import Optional, Any
+from typing import TYPE_CHECKING, Optional, Any
 from typing_extensions import Self
-from ._gt_data import GTData
 
 from ._utils import _assert_list_is_subset
 
+if TYPE_CHECKING:
+    from ._types import GTSelf
 
-class BoxheadAPI:
-    def cols_label(self, **kwargs: Any) -> Self:
-        """
-        Relabel one or more columns.
 
-        Column labels can be modified from their default values (the names of the columns from the
-        input table data). When you create a table object using `gt.GT()`, column names effectively
-        become the column labels. While this serves as a good first approximation, column names
-        aren't often appealing as column labels in an output table. The `cols_label()` method
-        provides the flexibility to relabel one or more columns and we even have the option to use
-        the `md()` or `html()` helpers for rendering column labels from Markdown or using HTML.
+def cols_label(self: GTSelf, **kwargs: Any) -> GTSelf:
+    """
+    Relabel one or more columns.
 
-        It's important to note that while columns can be freely relabeled, we continue to refer to
-        columns by their names for targeting purposes. Column names in the input data table must be
-        unique whereas column labels in **great_tables** have no requirement for uniqueness (which
-        is useful for labeling columns as, say, measurement units that may be repeated several
-        times---usually under different spanner labels). Thus, we can still easily distinguish
-        between columns in other method calls (e.g., in all of the `fmt*()` methods) even though we
-        may lose distinguishability in column labels once they have been relabeled.
+    Column labels can be modified from their default values (the names of the columns from the
+    input table data). When you create a table object using `gt.GT()`, column names effectively
+    become the column labels. While this serves as a good first approximation, column names
+    aren't often appealing as column labels in an output table. The `cols_label()` method
+    provides the flexibility to relabel one or more columns and we even have the option to use
+    the `md()` or `html()` helpers for rendering column labels from Markdown or using HTML.
 
-        Parameters
-        ----------
-        **kwargs : str
-            The column names and new labels. The column names are provided as keyword arguments
-            and the new labels are provided as the values for those keyword arguments. For example,
-            `cols_label(col1="Column 1", col2="Column 2")` would relabel columns `col1`
-            and `col2` with the labels `"Column 1"` and `"Column 2"`, respectively.
+    It's important to note that while columns can be freely relabeled, we continue to refer to
+    columns by their names for targeting purposes. Column names in the input data table must be
+    unique whereas column labels in **great_tables** have no requirement for uniqueness (which
+    is useful for labeling columns as, say, measurement units that may be repeated several
+    times---usually under different spanner labels). Thus, we can still easily distinguish
+    between columns in other method calls (e.g., in all of the `fmt*()` methods) even though we
+    may lose distinguishability in column labels once they have been relabeled.
 
-        Returns
-        -------
-        GT
-            The GT object is returned.
+    Parameters
+    ----------
+    **kwargs : str
+        The column names and new labels. The column names are provided as keyword arguments
+        and the new labels are provided as the values for those keyword arguments. For example,
+        `cols_label(col1="Column 1", col2="Column 2")` would relabel columns `col1`
+        and `col2` with the labels `"Column 1"` and `"Column 2"`, respectively.
 
-        Examples
-        --------
-        Let's use a portion of the `countrypops` dataset to create a table. We can relabel all the
-        table's columns with the `cols_label()` method to improve its presentation. In this simple
-        case we are supplying the name of the column as the key, and the label text as the value.
+    Returns
+    -------
+    GT
+        The GT object is returned.
 
-        ```{python}
-        import great_tables as gt
+    Examples
+    --------
+    Let's use a portion of the `countrypops` dataset to create a table. We can relabel all the
+    table's columns with the `cols_label()` method to improve its presentation. In this simple
+    case we are supplying the name of the column as the key, and the label text as the value.
 
-        countrypops_mini = gt.countrypops.loc[gt.countrypops[\"country_name\"] == \"Uganda\"][
-            [\"country_name\", \"year\", \"population\"]
-        ].tail(5)
+    ```{python}
+    import great_tables as gt
 
-        (
-            gt.GT(countrypops_mini)
-            .cols_label(
-                country_name=\"Name\",
-                year=\"Year\",
-                population=\"Population\"
-            )
+    countrypops_mini = gt.countrypops.loc[gt.countrypops[\"country_name\"] == \"Uganda\"][
+        [\"country_name\", \"year\", \"population\"]
+    ].tail(5)
+
+    (
+        gt.GT(countrypops_mini)
+        .cols_label(
+            country_name=\"Name\",
+            year=\"Year\",
+            population=\"Population\"
         )
-        ```
+    )
+    ```
 
-        We can also use Markdown formatting for the column labels. In this example, we'll use
-        `gt.md("*Population*")` to make the label italicized.
+    We can also use Markdown formatting for the column labels. In this example, we'll use
+    `gt.md("*Population*")` to make the label italicized.
 
-        ```{python}
-        (
-            gt.GT(countrypops_mini)
-            .cols_label(
-                country_name=\"Name\",
-                year=\"Year\",
-                population=gt.md(\"*Population*\")
-            )
+    ```{python}
+    (
+        gt.GT(countrypops_mini)
+        .cols_label(
+            country_name=\"Name\",
+            year=\"Year\",
+            population=gt.md(\"*Population*\")
         )
-        ```
-        """
+    )
+    ```
+    """
 
-        # If nothing is provided, return `data` unchanged
-        if len(kwargs) == 0:
-            return self
+    # If nothing is provided, return `data` unchanged
+    if len(kwargs) == 0:
+        return self
 
-        mod_columns = list(kwargs.keys())
-        new_labels = list(kwargs.values())
+    mod_columns = list(kwargs.keys())
+    new_labels = list(kwargs.values())
 
-        # Get the full list of column names for the data
-        column_names = self._boxhead._get_columns()
+    # Get the full list of column names for the data
+    column_names = self._boxhead._get_columns()
 
-        # Stop function if any of the column names specified are not in `cols_labels`
-        # msg: "All column names provided must exist in the input `.data` table."
-        _assert_list_is_subset(mod_columns, set_list=column_names)
+    # Stop function if any of the column names specified are not in `cols_labels`
+    # msg: "All column names provided must exist in the input `.data` table."
+    _assert_list_is_subset(mod_columns, set_list=column_names)
 
-        boxhead = self._boxhead._set_column_labels(kwargs)
+    boxhead = self._boxhead._set_column_labels(kwargs)
 
-        return self._replace(_boxhead=boxhead)
+    return self._replace(_boxhead=boxhead)
 
-    def cols_align(self, align: str = "left", columns: Optional[str] = None) -> Self:
-        """
-        Set the alignment of one or more columns.
 
-        The `cols_align()` method sets the alignment of one or more columns. The `align` argument
-        can be set to one of `"left"`, `"center"`, or `"right"` and the `columns` argument can be
-        used to specify which columns to apply the alignment to. If `columns` is not specified, the
-        alignment is applied to all columns.
+def cols_align(self: GTSelf, align: str = "left", columns: Optional[str] = None) -> GTSelf:
+    """
+    Set the alignment of one or more columns.
 
-        Parameters
-        ----------
-        align : str
-            The alignment to apply. Must be one of `"left"`, `"center"`, or `"right"`.
-        columns : Union[str, List[str], None]
-            The columns to target. Can either be a single column name or a series of column names
-            provided in a list. If `None`, the alignment is applied to all columns.
+    The `cols_align()` method sets the alignment of one or more columns. The `align` argument
+    can be set to one of `"left"`, `"center"`, or `"right"` and the `columns` argument can be
+    used to specify which columns to apply the alignment to. If `columns` is not specified, the
+    alignment is applied to all columns.
 
-        Returns
-        -------
-        GT
-            The GT object is returned.
+    Parameters
+    ----------
+    align : str
+        The alignment to apply. Must be one of `"left"`, `"center"`, or `"right"`.
+    columns : Union[str, List[str], None]
+        The columns to target. Can either be a single column name or a series of column names
+        provided in a list. If `None`, the alignment is applied to all columns.
 
-        Examples
-        --------
-        Let's use the `countrypops` to create a small table. We can change the alignment of the
-        `population` column with `cols_align()`. In this example, the column label and body cells of
-        `population` will be aligned to the left.
+    Returns
+    -------
+    GT
+        The GT object is returned.
 
-        ```{python}
-        import great_tables as gt
+    Examples
+    --------
+    Let's use the `countrypops` to create a small table. We can change the alignment of the
+    `population` column with `cols_align()`. In this example, the column label and body cells of
+    `population` will be aligned to the left.
 
-        countrypops_mini = gt.countrypops.loc[gt.countrypops[\"country_name\"] == \"San Marino\"][
-            [\"country_name\", \"year\", \"population\"]
-        ].tail(5)
+    ```{python}
+    import great_tables as gt
 
-        (
-            gt.GT(countrypops_mini, rowname_col=\"year\", groupname_col=\"country_name\")
-            .cols_align(align=\"left\", columns=\"population\")
+    countrypops_mini = gt.countrypops.loc[gt.countrypops[\"country_name\"] == \"San Marino\"][
+        [\"country_name\", \"year\", \"population\"]
+    ].tail(5)
+
+    (
+        gt.GT(countrypops_mini, rowname_col=\"year\", groupname_col=\"country_name\")
+        .cols_align(align=\"left\", columns=\"population\")
+    )
+    ```
+
+    """
+
+    # Throw if `align` is not one of the three allowed values
+    if align not in ["left", "center", "right"]:
+        raise ValueError("Align must be one of 'left', 'center', or 'right'.")
+
+    # Get the full list of column names for the data
+    column_names = self._boxhead._get_columns()
+
+    # Upgrade `columns` to a list if `columns` is a string and not None
+    if isinstance(columns, str):
+        columns = [columns]
+        _assert_list_is_subset(columns, set_list=column_names)
+    elif columns is None:
+        columns = column_names
+
+    # Set the alignment for each column
+    return self._replace(_boxhead=self._boxhead._set_column_aligns(columns, align=align))
+
+
+def _print_boxhead(self: GTSelf) -> pd.DataFrame:
+    boxhead_list = list(
+        zip(
+            [x.var for x in self._boxhead],
+            [x.visible for x in self._boxhead],
+            [x.column_label for x in self._boxhead],
         )
-        ```
-
-        """
-
-        # Throw if `align` is not one of the three allowed values
-        if align not in ["left", "center", "right"]:
-            raise ValueError("Align must be one of 'left', 'center', or 'right'.")
-
-        # Get the full list of column names for the data
-        column_names = self._boxhead._get_columns()
-
-        # Upgrade `columns` to a list if `columns` is a string and not None
-        if isinstance(columns, str):
-            columns = [columns]
-            _assert_list_is_subset(columns, set_list=column_names)
-        elif columns is None:
-            columns = column_names
-
-        # Set the alignment for each column
-        return self._replace(_boxhead=self._boxhead._set_column_aligns(columns, align=align))
-
-    def _print_boxhead(self) -> pd.DataFrame:
-        boxhead_list = list(
-            zip(
-                [x.var for x in self._boxhead],
-                [x.visible for x in self._boxhead],
-                [x.column_label for x in self._boxhead],
-            )
-        )
-        return pd.DataFrame(boxhead_list, columns=["var", "visible", "column_label"])
+    )
+    return pd.DataFrame(boxhead_list, columns=["var", "visible", "column_label"])

--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -97,7 +97,7 @@ class BoxheadAPI:
 
         return self._replace(_boxhead=boxhead)
 
-    def cols_align(self, align: str = "left", columns: Optional[str] = None) -> GTData:
+    def cols_align(self, align: str = "left", columns: Optional[str] = None) -> Self:
         """
         Set the alignment of one or more columns.
 
@@ -155,10 +155,7 @@ class BoxheadAPI:
             columns = column_names
 
         # Set the alignment for each column
-        for column in columns:
-            self._boxhead._set_column_align(column=column, align=align)
-
-        return self
+        return self._replace(_boxhead=self._boxhead._set_column_aligns(columns, align=align))
 
     def _print_boxhead(self) -> pd.DataFrame:
         boxhead_list = list(

--- a/great_tables/_footnotes.py
+++ b/great_tables/_footnotes.py
@@ -2,6 +2,5 @@ from __future__ import annotations
 from typing import Optional, List
 from enum import Enum, auto
 
-class FootnotesAPI:
-    pass
-    # TODO: create the `tab_footnote()` function
+
+# TODO: create the `tab_footnote()` function

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -46,60 +46,56 @@ TimeStyle: TypeAlias = Literal[
 ]
 
 
-class FormatsAPI:
-    @staticmethod
-    def fmt(
-        x: GTData,
-        fns: Union[FormatFn, FormatFns],
-        columns: Union[str, List[str], None] = None,
-        rows: Union[int, List[int], None] = None,
-    ) -> GTData:
-        """
-        Set a column format with a formatter function.
+def fmt(
+    x: GTSelf,
+    fns: Union[FormatFn, FormatFns],
+    columns: Union[str, List[str], None] = None,
+    rows: Union[int, List[int], None] = None,
+) -> GTSelf:
+    """
+    Set a column format with a formatter function.
 
-        The `fmt()` method provides a way to execute custom formatting functionality with raw data
-        values in a way that can consider all output contexts.
+    The `fmt()` method provides a way to execute custom formatting functionality with raw data
+    values in a way that can consider all output contexts.
 
-        Along with the `columns` and `rows` arguments that provide some precision in targeting data
-        cells, the `fns` argument allows you to define one or more functions for manipulating the
-        raw data.
+    Along with the `columns` and `rows` arguments that provide some precision in targeting data
+    cells, the `fns` argument allows you to define one or more functions for manipulating the
+    raw data.
 
-        Parameters
-        ----------
-        fns : Union[FormatFn, FormatFns]
-            Either a single formatting function or a named list of functions.
-        columns : Union[str, List[str], None]
-            The columns to target. Can either be a single column name or a series of column names
-            provided in a list.
-        rows : Union[int, List[int], None]
-            In conjunction with `columns`, we can specify which of their rows should undergo
-            formatting. The default is all rows, resulting in all rows in `columns` being formatted.
-            Alternatively, we can supply a list of row indices.
+    Parameters
+    ----------
+    fns : Union[FormatFn, FormatFns]
+        Either a single formatting function or a named list of functions.
+    columns : Union[str, List[str], None]
+        The columns to target. Can either be a single column name or a series of column names
+        provided in a list.
+    rows : Union[int, List[int], None]
+        In conjunction with `columns`, we can specify which of their rows should undergo
+        formatting. The default is all rows, resulting in all rows in `columns` being formatted.
+        Alternatively, we can supply a list of row indices.
 
-        Returns
-        -------
-        GT
-            The GT object is returned.
-        """
+    Returns
+    -------
+    GT
+        The GT object is returned.
+    """
 
-        # If a single function is supplied to `fns` then
-        # repackage that into a list as the `default` function
-        if isinstance(fns, Callable):
-            fns = FormatFns(default=fns)
+    # If a single function is supplied to `fns` then
+    # repackage that into a list as the `default` function
+    if isinstance(fns, Callable):
+        fns = FormatFns(default=fns)
 
-        columns = _listify(columns, list)
+    columns = _listify(columns, list)
 
-        if rows is None:
-            rows = list(range(n_rows(x._tbl_data)))
-        elif isinstance(rows, int):
-            rows = [rows]
+    if rows is None:
+        rows = list(range(n_rows(x._tbl_data)))
+    elif isinstance(rows, int):
+        rows = [rows]
 
-        formatter = FormatInfo(fns, columns, rows)
-        x._formats.append(formatter)
+    formatter = FormatInfo(fns, columns, rows)
+    x._formats.append(formatter)
 
-        return x
-
-    # TODO: transition to static methods ----
+    return x
 
 
 def fmt_number(
@@ -301,7 +297,7 @@ def fmt_number(
 
         return x_formatted
 
-    FormatsAPI.fmt(self, fns=fmt_number_fn, columns=columns, rows=rows)
+    fmt(self, fns=fmt_number_fn, columns=columns, rows=rows)
 
     return self
 
@@ -468,7 +464,7 @@ def fmt_integer(
 
         return x_formatted
 
-    FormatsAPI.fmt(self, fns=fmt_integer_fn, columns=columns, rows=rows)
+    fmt(self, fns=fmt_integer_fn, columns=columns, rows=rows)
 
     return self
 
@@ -728,7 +724,7 @@ def fmt_scientific(
 
         return x_formatted
 
-    FormatsAPI.fmt(self, fns=fmt_scientific_fn, columns=columns, rows=rows)
+    fmt(self, fns=fmt_scientific_fn, columns=columns, rows=rows)
 
     return self
 
@@ -931,7 +927,7 @@ def fmt_percent(
 
         return x_formatted
 
-    FormatsAPI.fmt(self, fns=fmt_percent_fn, columns=columns, rows=rows)
+    fmt(self, fns=fmt_percent_fn, columns=columns, rows=rows)
 
     return self
 
@@ -1167,7 +1163,7 @@ def fmt_currency(
 
         return x_formatted
 
-    FormatsAPI.fmt(self, fns=fmt_currency_fn, columns=columns, rows=rows)
+    fmt(self, fns=fmt_currency_fn, columns=columns, rows=rows)
 
     return self
 
@@ -1274,7 +1270,7 @@ def fmt_roman(
 
         return x_formatted
 
-    FormatsAPI.fmt(self, fns=fmt_roman_fn, columns=columns, rows=rows)
+    fmt(self, fns=fmt_roman_fn, columns=columns, rows=rows)
 
     return self
 
@@ -1509,7 +1505,7 @@ def fmt_bytes(
 
         return x_formatted
 
-    FormatsAPI.fmt(self, fns=fmt_bytes_fn, columns=columns, rows=rows)
+    fmt(self, fns=fmt_bytes_fn, columns=columns, rows=rows)
 
     return self
 
@@ -1654,7 +1650,7 @@ def fmt_date(
 
         return x_formatted
 
-    FormatsAPI.fmt(self, fns=fmt_date_fn, columns=columns, rows=rows)
+    fmt(self, fns=fmt_date_fn, columns=columns, rows=rows)
 
     return self
 
@@ -1790,7 +1786,7 @@ def fmt_time(
 
         return x_formatted
 
-    FormatsAPI.fmt(self, fns=fmt_time_fn, columns=columns, rows=rows)
+    fmt(self, fns=fmt_time_fn, columns=columns, rows=rows)
 
     return self
 
@@ -1839,7 +1835,7 @@ def fmt_markdown(
 
         return x_formatted
 
-    FormatsAPI.fmt(self, fns=fmt_markdown_fn, columns=columns, rows=rows)
+    fmt(self, fns=fmt_markdown_fn, columns=columns, rows=rows)
 
     return self
 

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -47,7 +47,7 @@ TimeStyle: TypeAlias = Literal[
 
 
 def fmt(
-    x: GTSelf,
+    self: GTSelf,
     fns: Union[FormatFn, FormatFns],
     columns: Union[str, List[str], None] = None,
     rows: Union[int, List[int], None] = None,
@@ -88,14 +88,12 @@ def fmt(
     columns = _listify(columns, list)
 
     if rows is None:
-        rows = list(range(n_rows(x._tbl_data)))
+        rows = list(range(n_rows(self._tbl_data)))
     elif isinstance(rows, int):
         rows = [rows]
 
     formatter = FormatInfo(fns, columns, rows)
-    x._formats.append(formatter)
-
-    return x
+    return self._replace(_formats=[*self._formats, formatter])
 
 
 def fmt_number(
@@ -297,9 +295,7 @@ def fmt_number(
 
         return x_formatted
 
-    fmt(self, fns=fmt_number_fn, columns=columns, rows=rows)
-
-    return self
+    return fmt(self, fns=fmt_number_fn, columns=columns, rows=rows)
 
 
 def fmt_integer(
@@ -464,9 +460,7 @@ def fmt_integer(
 
         return x_formatted
 
-    fmt(self, fns=fmt_integer_fn, columns=columns, rows=rows)
-
-    return self
+    return fmt(self, fns=fmt_integer_fn, columns=columns, rows=rows)
 
 
 def fmt_scientific(
@@ -724,9 +718,7 @@ def fmt_scientific(
 
         return x_formatted
 
-    fmt(self, fns=fmt_scientific_fn, columns=columns, rows=rows)
-
-    return self
+    return fmt(self, fns=fmt_scientific_fn, columns=columns, rows=rows)
 
 
 def fmt_percent(
@@ -927,9 +919,7 @@ def fmt_percent(
 
         return x_formatted
 
-    fmt(self, fns=fmt_percent_fn, columns=columns, rows=rows)
-
-    return self
+    return fmt(self, fns=fmt_percent_fn, columns=columns, rows=rows)
 
 
 def fmt_currency(
@@ -1163,9 +1153,7 @@ def fmt_currency(
 
         return x_formatted
 
-    fmt(self, fns=fmt_currency_fn, columns=columns, rows=rows)
-
-    return self
+    return fmt(self, fns=fmt_currency_fn, columns=columns, rows=rows)
 
 
 def fmt_roman(
@@ -1270,9 +1258,7 @@ def fmt_roman(
 
         return x_formatted
 
-    fmt(self, fns=fmt_roman_fn, columns=columns, rows=rows)
-
-    return self
+    return fmt(self, fns=fmt_roman_fn, columns=columns, rows=rows)
 
 
 def fmt_bytes(
@@ -1505,9 +1491,7 @@ def fmt_bytes(
 
         return x_formatted
 
-    fmt(self, fns=fmt_bytes_fn, columns=columns, rows=rows)
-
-    return self
+    return fmt(self, fns=fmt_bytes_fn, columns=columns, rows=rows)
 
 
 def fmt_date(
@@ -1650,9 +1634,7 @@ def fmt_date(
 
         return x_formatted
 
-    fmt(self, fns=fmt_date_fn, columns=columns, rows=rows)
-
-    return self
+    return fmt(self, fns=fmt_date_fn, columns=columns, rows=rows)
 
 
 def fmt_time(
@@ -1786,9 +1768,7 @@ def fmt_time(
 
         return x_formatted
 
-    fmt(self, fns=fmt_time_fn, columns=columns, rows=rows)
-
-    return self
+    return fmt(self, fns=fmt_time_fn, columns=columns, rows=rows)
 
 
 def fmt_markdown(
@@ -1835,9 +1815,7 @@ def fmt_markdown(
 
         return x_formatted
 
-    fmt(self, fns=fmt_markdown_fn, columns=columns, rows=rows)
-
-    return self
+    return fmt(self, fns=fmt_markdown_fn, columns=columns, rows=rows)
 
 
 def _value_to_decimal_notation(

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -892,7 +892,7 @@ default_fonts_list = [
 ]
 
 
-@dataclass
+@dataclass(frozen=True)
 class OptionsInfo:
     scss: bool
     category: str

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -381,12 +381,16 @@ class Boxhead(_Sequence[ColInfo]):
         return self.__class__(out_cols)
 
     # Set column alignments
-    def _set_column_align(self, column: str, align: str):
+    def _set_column_aligns(self, columns: List[str], align: str) -> Self:
+        set_cols = set(columns)
+        out_cols: List[ColInfo] = []
         for x in self._d:
-            if x.var == column:
-                x.column_align = align
+            if x.var in set_cols:
+                out_cols.append(replace(x, column_align=align))
+            else:
+                out_cols.append(x)
 
-        return self
+        return self.__class__(out_cols)
 
     # Get a list of column widths
     def _get_column_widths(self) -> List[str | None]:

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -892,226 +892,232 @@ default_fonts_list = [
 ]
 
 
+@dataclass
 class OptionsInfo:
-    parameter: str
-    scss: Optional[bool]
-    category: Optional[str]
-    type: Optional[str]
+    scss: bool
+    category: str
+    type: str
     value: Optional[Union[Any, List[str]]]
 
-    def __init__(
-        self,
-        parameter: str,
-        scss: Optional[bool] = None,
-        category: Optional[str] = None,
-        type: Optional[str] = None,
-        value: Optional[Union[Any, List[str]]] = None,
-    ):
-        self.parameter = parameter
-        self.scss = scss
-        self.category = category
-        self.type = type
-        self.value = value
 
-
-# fmt: off
+@dataclass(frozen=True)
 class Options:
-    def __init__(self):
-        self._options: dict[str, OptionsInfo] = dict(
-           (v.parameter, v) for v in [
-            #           parameter                            scss    category            type        value
-            OptionsInfo("table_id",                          False,  "table",            "value",    None),
-            OptionsInfo("table_caption",                     False,  "table",            "value",    None),
-            OptionsInfo("table_width",                        True,  "table",            "px",       "auto"),
-            OptionsInfo("table_layout",                       True,  "table",            "value",    "fixed"),
-            OptionsInfo("table_margin_left",                  True,  "table",            "px",       "auto"),
-            OptionsInfo("table_margin_right",                 True,  "table",            "px",       "auto"),
-            OptionsInfo("table_background_color",             True,  "table",            "value",    "#FFFFFF"),
-            OptionsInfo("table_additional_css",              False,  "table",            "values",   None),
-            OptionsInfo("table_font_names",                  False,  "table",            "values",   default_fonts_list),
-            OptionsInfo("table_font_size",                    True,  "table",            "px",       "16px"),
-            OptionsInfo("table_font_weight",                  True,  "table",            "value",    "normal"),
-            OptionsInfo("table_font_style",                   True,  "table",            "value",    "normal"),
-            OptionsInfo("table_font_color",                   True,  "table",            "value",    "#333333"),
-            OptionsInfo("table_font_color_light",             True,  "table",            "value",    "#FFFFFF"),
-            OptionsInfo("table_border_top_include",          False,  "table",            "boolean",  True),
-            OptionsInfo("table_border_top_style",             True,  "table",            "value",    "solid"),
-            OptionsInfo("table_border_top_width",             True,  "table",            "px",       "2px"),
-            OptionsInfo("table_border_top_color",             True,  "table",            "value",    "#A8A8A8"),
-            OptionsInfo("table_border_right_style",           True,  "table",            "value",    "none"),
-            OptionsInfo("table_border_right_width",           True,  "table",            "px",       "2px"),
-            OptionsInfo("table_border_right_color",           True,  "table",            "value",    "#D3D3D3"),
-            OptionsInfo("table_border_bottom_include",       False,  "table",            "boolean",  True),
-            OptionsInfo("table_border_bottom_style",          True,  "table",            "value",    "solid"),
-            OptionsInfo("table_border_bottom_width",          True,  "table",            "px",       "2px"),
-            OptionsInfo("table_border_bottom_color",          True,  "table",            "value",    "#A8A8A8"),
-            OptionsInfo("table_border_left_style",            True,  "table",            "value",    "none"),
-            OptionsInfo("table_border_left_width",            True,  "table",            "px",       "2px"),
-            OptionsInfo("table_border_left_color",            True,  "table",            "value",    "#D3D3D3"),
-            OptionsInfo("heading_background_color",           True,  "heading",          "value",    None),
-            OptionsInfo("heading_align",                      True,  "heading",          "value",    "center"),
-            OptionsInfo("heading_title_font_size",            True,  "heading",          "px",       "125%"),
-            OptionsInfo("heading_title_font_weight",          True,  "heading",          "value",    "initial"),
-            OptionsInfo("heading_subtitle_font_size",         True,  "heading",          "px",       "85%"),
-            OptionsInfo("heading_subtitle_font_weight",       True,  "heading",          "value",    "initial"),
-            OptionsInfo("heading_padding",                    True,  "heading",          "px",       "4px"),
-            OptionsInfo("heading_padding_horizontal",         True,  "heading",          "px",       "5px"),
-            OptionsInfo("heading_border_bottom_style",        True,  "heading",          "value",    "solid"),
-            OptionsInfo("heading_border_bottom_width",        True,  "heading",          "px",       "2px"),
-            OptionsInfo("heading_border_bottom_color",        True,  "heading",          "value",    "#D3D3D3"),
-            OptionsInfo("heading_border_lr_style",            True,  "heading",          "value",    "none"),
-            OptionsInfo("heading_border_lr_width",            True,  "heading",          "px",       "1px"),
-            OptionsInfo("heading_border_lr_color",            True,  "heading",          "value",    "#D3D3D3"),
-            OptionsInfo("column_labels_background_color",     True,  "column_labels",    "value",    None),
-            OptionsInfo("column_labels_font_size",            True,  "column_labels",    "px",       "100%"),
-            OptionsInfo("column_labels_font_weight",          True,  "column_labels",    "value",    "normal"),
-            OptionsInfo("column_labels_text_transform",       True,  "column_labels",    "value",    "inherit"),
-            OptionsInfo("column_labels_padding",              True,  "column_labels",    "px",       "5px"),
-            OptionsInfo("column_labels_padding_horizontal",   True,  "column_labels",    "px",       "5px"),
-            OptionsInfo("column_labels_vlines_style",         True,  "table_body",       "value",    "none"),
-            OptionsInfo("column_labels_vlines_width",         True,  "table_body",       "px",       "1px"),
-            OptionsInfo("column_labels_vlines_color",         True,  "table_body",       "value",    "#D3D3D3"),
-            OptionsInfo("column_labels_border_top_style",     True,  "column_labels",    "value",    "solid"),
-            OptionsInfo("column_labels_border_top_width",     True,  "column_labels",    "px",       "2px"),
-            OptionsInfo("column_labels_border_top_color",     True,  "column_labels",    "value",    "#D3D3D3"),
-            OptionsInfo("column_labels_border_bottom_style",  True,  "column_labels",    "value",    "solid"),
-            OptionsInfo("column_labels_border_bottom_width",  True,  "column_labels",    "px",       "2px"),
-            OptionsInfo("column_labels_border_bottom_color",  True,  "column_labels",    "value",    "#D3D3D3"),
-            OptionsInfo("column_labels_border_lr_style",      True,  "column_labels",    "value",    "none"),
-            OptionsInfo("column_labels_border_lr_width",      True,  "column_labels",    "px",       "1px"),
-            OptionsInfo("column_labels_border_lr_color",      True,  "column_labels",    "value",    "#D3D3D3"),
-            OptionsInfo("column_labels_hidden",              False,  "column_labels",    "boolean",  False),
-            OptionsInfo("row_group_background_color",         True,  "row_group",        "value",    None),
-            OptionsInfo("row_group_font_size",                True,  "row_group",        "px",       "100%"),
-            OptionsInfo("row_group_font_weight",              True,  "row_group",        "value",    "initial"),
-            OptionsInfo("row_group_text_transform",           True,  "row_group",        "value",    "inherit"),
-            OptionsInfo("row_group_padding",                  True,  "row_group",        "px",       "8px"),
-            OptionsInfo("row_group_padding_horizontal",       True,  "row_group",        "px",       "5px"),
-            OptionsInfo("row_group_border_top_style",         True,  "row_group",        "value",    "solid"),
-            OptionsInfo("row_group_border_top_width",         True,  "row_group",        "px",       "2px"),
-            OptionsInfo("row_group_border_top_color",         True,  "row_group",        "value",    "#D3D3D3"),
-            OptionsInfo("row_group_border_right_style",       True,  "row_group",        "value",    "none"),
-            OptionsInfo("row_group_border_right_width",       True,  "row_group",        "px",       "1px"),
-            OptionsInfo("row_group_border_right_color",       True,  "row_group",        "value",    "#D3D3D3"),
-            OptionsInfo("row_group_border_bottom_style",      True,  "row_group",        "value",    "solid"),
-            OptionsInfo("row_group_border_bottom_width",      True,  "row_group",        "px",       "2px"),
-            OptionsInfo("row_group_border_bottom_color",      True,  "row_group",        "value",    "#D3D3D3"),
-            OptionsInfo("row_group_border_left_style",        True,  "row_group",        "value",    "none"),
-            OptionsInfo("row_group_border_left_width",        True,  "row_group",        "px",       "1px"),
-            OptionsInfo("row_group_border_left_color",        True,  "row_group",        "value",    "#D3D3D3"),
-            OptionsInfo("row_group_default_label",           False,  "row_group",        "value",    None),
-            OptionsInfo("row_group_as_column",               False,  "row_group",        "boolean",  False),
-            OptionsInfo("table_body_hlines_style",            True,  "table_body",       "value",    "solid"),
-            OptionsInfo("table_body_hlines_width",            True,  "table_body",       "px",       "1px"),
-            OptionsInfo("table_body_hlines_color",            True,  "table_body",       "value",    "#D3D3D3"),
-            OptionsInfo("table_body_vlines_style",            True,  "table_body",       "value",    "none"),
-            OptionsInfo("table_body_vlines_width",            True,  "table_body",       "px",       "1px"),
-            OptionsInfo("table_body_vlines_color",            True,  "table_body",       "value",    "#D3D3D3"),
-            OptionsInfo("table_body_border_top_style",        True,  "table_body",       "value",    "solid"),
-            OptionsInfo("table_body_border_top_width",        True,  "table_body",       "px",       "2px"),
-            OptionsInfo("table_body_border_top_color",        True,  "table_body",       "value",    "#D3D3D3"),
-            OptionsInfo("table_body_border_bottom_style",     True,  "table_body",       "value",    "solid"),
-            OptionsInfo("table_body_border_bottom_width",     True,  "table_body",       "px",       "2px"),
-            OptionsInfo("table_body_border_bottom_color",     True,  "table_body",       "value",    "#D3D3D3"),
-            OptionsInfo("data_row_padding",                   True,  "data_row",         "px",       "8px"),
-            OptionsInfo("data_row_padding_horizontal",        True,  "data_row",         "px",       "5px"),
-            OptionsInfo("stub_background_color",              True,  "stub",             "value",    None),
-            OptionsInfo("stub_font_size",                     True,  "stub",             "px",       "100%"),
-            OptionsInfo("stub_font_weight",                   True,  "stub",             "value",    "initial"),
-            OptionsInfo("stub_text_transform",                True,  "stub",             "value",    "inherit"),
-            OptionsInfo("stub_border_style",                  True,  "stub",             "value",    "solid"),
-            OptionsInfo("stub_border_width",                  True,  "stub",             "px",       "2px"),
-            OptionsInfo("stub_border_color",                  True,  "stub",             "value",    "#D3D3D3"),
-            OptionsInfo("stub_row_group_background_color",    True,  "stub",             "value",    None),
-            OptionsInfo("stub_row_group_font_size",           True,  "stub",             "px",       "100%"),
-            OptionsInfo("stub_row_group_font_weight",         True,  "stub",             "value",    "initial"),
-            OptionsInfo("stub_row_group_text_transform",      True,  "stub",             "value",    "inherit"),
-            OptionsInfo("stub_row_group_border_style",        True,  "stub",             "value",    "solid"),
-            OptionsInfo("stub_row_group_border_width",        True,  "stub",             "px",       "2px"),
-            OptionsInfo("stub_row_group_border_color",        True,  "stub",             "value",    "#D3D3D3"),
-            OptionsInfo("summary_row_padding",                True,  "summary_row",      "px",       "8px"),
-            OptionsInfo("summary_row_padding_horizontal",     True,  "summary_row",      "px",       "5px"),
-            OptionsInfo("summary_row_background_color",       True,  "summary_row",      "value",    None),
-            OptionsInfo("summary_row_text_transform",         True,  "summary_row",      "value",    "inherit"),
-            OptionsInfo("summary_row_border_style",           True,  "summary_row",      "value",    "solid"),
-            OptionsInfo("summary_row_border_width",           True,  "summary_row",      "px",       "2px"),
-            OptionsInfo("summary_row_border_color",           True,  "summary_row",      "value",    "#D3D3D3"),
-            OptionsInfo("grand_summary_row_padding",          True,  "grand_summary_row", "px",      "8px"),
-            OptionsInfo("grand_summary_row_padding_horizontal",True, "grand_summary_row", "px",      "5px"),
-            OptionsInfo("grand_summary_row_background_color", True,  "grand_summary_row", "value",   None),
-            OptionsInfo("grand_summary_row_text_transform",   True,  "grand_summary_row", "value",   "inherit"),
-            OptionsInfo("grand_summary_row_border_style",     True,  "grand_summary_row", "value",   "double"),
-            OptionsInfo("grand_summary_row_border_width",     True,  "grand_summary_row", "px",      "6px"),
-            OptionsInfo("grand_summary_row_border_color",     True,  "grand_summary_row", "value",   "#D3D3D3"),
-            OptionsInfo("footnotes_font_size",                True,  "footnotes",        "px",       "90%"),
-            OptionsInfo("footnotes_padding",                  True,  "footnotes",        "px",       "4px"),
-            OptionsInfo("footnotes_padding_horizontal",       True,  "footnotes",        "px",       "5px"),
-            OptionsInfo("footnotes_background_color",         True,  "footnotes",        "value",    None),
-            OptionsInfo("footnotes_margin",                   True,  "footnotes",        "px",       "0px"),
-            OptionsInfo("footnotes_border_bottom_style",      True,  "footnotes",        "value",    "none"),
-            OptionsInfo("footnotes_border_bottom_width",      True,  "footnotes",        "px",       "2px"),
-            OptionsInfo("footnotes_border_bottom_color",      True,  "footnotes",        "value",    "#D3D3D3"),
-            OptionsInfo("footnotes_border_lr_style",          True,  "footnotes",        "value",    "none"),
-            OptionsInfo("footnotes_border_lr_width",          True,  "footnotes",        "px",       "2px"),
-            OptionsInfo("footnotes_border_lr_color",          True,  "footnotes",        "value",    "#D3D3D3"),
-            OptionsInfo("footnotes_marks" ,                  False,  "footnotes",        "values",   "numbers"),
-            OptionsInfo("footnotes_multiline",               False,  "footnotes",        "boolean",  True),
-            OptionsInfo("footnotes_sep",                     False,  "footnotes",        "value",    " "),
-            OptionsInfo("source_notes_padding",               True,  "source_notes",     "px",       "4px"),
-            OptionsInfo("source_notes_padding_horizontal",    True,  "source_notes",     "px",       "5px"),
-            OptionsInfo("source_notes_background_color",      True,  "source_notes",     "value",    None),
-            OptionsInfo("source_notes_font_size",             True,  "source_notes",     "px",       "90%"),
-            OptionsInfo("source_notes_border_bottom_style",   True,  "source_notes",     "value",    "none"),
-            OptionsInfo("source_notes_border_bottom_width",   True,  "source_notes",     "px",       "2px"),
-            OptionsInfo("source_notes_border_bottom_color",   True,  "source_notes",     "value",    "#D3D3D3"),
-            OptionsInfo("source_notes_border_lr_style",       True,  "source_notes",     "value",    "none"),
-            OptionsInfo("source_notes_border_lr_width",       True,  "source_notes",     "px",       "2px"),
-            OptionsInfo("source_notes_border_lr_color",       True,  "source_notes",     "value",    "#D3D3D3"),
-            OptionsInfo("source_notes_multiline",            False,  "source_notes",     "boolean",  True),
-            OptionsInfo("source_notes_sep",                  False,  "source_notes",     "value",    " "),
-            OptionsInfo("row_striping_background_color",      True,  "row",              "value",    "rgba(128,128,128,0.05)"),
-            OptionsInfo("row_striping_include_stub",         False,  "row",              "boolean",  False),
-            OptionsInfo("row_striping_include_table_body",   False,  "row",              "boolean",  False),
-            OptionsInfo("container_width",                   False,  "container",        "px",       "auto"),
-            OptionsInfo("container_height",                  False,  "container",        "px",       "auto"),
-            OptionsInfo("container_padding_x",               False,  "container",        "px",       "0px"),
-            OptionsInfo("container_padding_y",               False,  "container",        "px",       "10px"),
-            OptionsInfo("container_overflow_x",              False,  "container",        "overflow", "auto"),
-            OptionsInfo("container_overflow_y",              False,  "container",        "overflow", "auto"),
-            OptionsInfo("page_orientation",                  False,  "page",             "value",    "portrait"),
-            OptionsInfo("page_numbering",                    False,  "page",             "boolean",  False),
-            OptionsInfo("page_header_use_tbl_headings",      False,  "page",             "boolean",  False),
-            OptionsInfo("page_footer_use_tbl_notes",         False,  "page",             "boolean",  False),
-            OptionsInfo("page_width",                        False,  "page",             "value",    "8.5in"),
-            OptionsInfo("page_height",                       False,  "page",             "value",    "11.0in"),
-            OptionsInfo("page_margin_left",                  False,  "page",             "value",    "1.0in"),
-            OptionsInfo("page_margin_right",                 False,  "page",             "value",    "1.0in"),
-            OptionsInfo("page_margin_top",                   False,  "page",             "value",    "1.0in"),
-            OptionsInfo("page_margin_bottom",                False,  "page",             "value",    "1.0in"),
-            OptionsInfo("page_header_height",                False,  "page",             "value",    "0.5in"),
-            OptionsInfo("page_footer_height",                False,  "page",             "value",    "0.5in"),
-            OptionsInfo("quarto_disable_processing",         False,  "quarto",           "logical",  False),
-            OptionsInfo("quarto_use_bootstrap",              False,  "quarto",           "logical",  False),
-        ])
-# fmt: on
+    table_id: OptionsInfo = OptionsInfo(False, "table", "value", None)
+    table_caption: OptionsInfo = OptionsInfo(False, "table", "value", None)
+    table_width: OptionsInfo = OptionsInfo(True, "table", "px", "auto")
+    table_layout: OptionsInfo = OptionsInfo(True, "table", "value", "fixed")
+    table_margin_left: OptionsInfo = OptionsInfo(True, "table", "px", "auto")
+    table_margin_right: OptionsInfo = OptionsInfo(True, "table", "px", "auto")
+    table_background_color: OptionsInfo = OptionsInfo(True, "table", "value", "#FFFFFF")
+    table_additional_css: OptionsInfo = OptionsInfo(False, "table", "values", None)
+    table_font_names: OptionsInfo = OptionsInfo(False, "table", "values", default_fonts_list)
+    table_font_size: OptionsInfo = OptionsInfo(True, "table", "px", "16px")
+    table_font_weight: OptionsInfo = OptionsInfo(True, "table", "value", "normal")
+    table_font_style: OptionsInfo = OptionsInfo(True, "table", "value", "normal")
+    table_font_color: OptionsInfo = OptionsInfo(True, "table", "value", "#333333")
+    table_font_color_light: OptionsInfo = OptionsInfo(True, "table", "value", "#FFFFFF")
+    table_border_top_include: OptionsInfo = OptionsInfo(False, "table", "boolean", True)
+    table_border_top_style: OptionsInfo = OptionsInfo(True, "table", "value", "solid")
+    table_border_top_width: OptionsInfo = OptionsInfo(True, "table", "px", "2px")
+    table_border_top_color: OptionsInfo = OptionsInfo(True, "table", "value", "#A8A8A8")
+    table_border_right_style: OptionsInfo = OptionsInfo(True, "table", "value", "none")
+    table_border_right_width: OptionsInfo = OptionsInfo(True, "table", "px", "2px")
+    table_border_right_color: OptionsInfo = OptionsInfo(True, "table", "value", "#D3D3D3")
+    table_border_bottom_include: OptionsInfo = OptionsInfo(False, "table", "boolean", True)
+    table_border_bottom_style: OptionsInfo = OptionsInfo(True, "table", "value", "solid")
+    table_border_bottom_width: OptionsInfo = OptionsInfo(True, "table", "px", "2px")
+    table_border_bottom_color: OptionsInfo = OptionsInfo(True, "table", "value", "#A8A8A8")
+    table_border_left_style: OptionsInfo = OptionsInfo(True, "table", "value", "none")
+    table_border_left_width: OptionsInfo = OptionsInfo(True, "table", "px", "2px")
+    table_border_left_color: OptionsInfo = OptionsInfo(True, "table", "value", "#D3D3D3")
+    heading_background_color: OptionsInfo = OptionsInfo(True, "heading", "value", None)
+    heading_align: OptionsInfo = OptionsInfo(True, "heading", "value", "center")
+    heading_title_font_size: OptionsInfo = OptionsInfo(True, "heading", "px", "125%")
+    heading_title_font_weight: OptionsInfo = OptionsInfo(True, "heading", "value", "initial")
+    heading_subtitle_font_size: OptionsInfo = OptionsInfo(True, "heading", "px", "85%")
+    heading_subtitle_font_weight: OptionsInfo = OptionsInfo(True, "heading", "value", "initial")
+    heading_padding: OptionsInfo = OptionsInfo(True, "heading", "px", "4px")
+    heading_padding_horizontal: OptionsInfo = OptionsInfo(True, "heading", "px", "5px")
+    heading_border_bottom_style: OptionsInfo = OptionsInfo(True, "heading", "value", "solid")
+    heading_border_bottom_width: OptionsInfo = OptionsInfo(True, "heading", "px", "2px")
+    heading_border_bottom_color: OptionsInfo = OptionsInfo(True, "heading", "value", "#D3D3D3")
+    heading_border_lr_style: OptionsInfo = OptionsInfo(True, "heading", "value", "none")
+    heading_border_lr_width: OptionsInfo = OptionsInfo(True, "heading", "px", "1px")
+    heading_border_lr_color: OptionsInfo = OptionsInfo(True, "heading", "value", "#D3D3D3")
+    column_labels_background_color: OptionsInfo = OptionsInfo(True, "column_labels", "value", None)
+    column_labels_font_size: OptionsInfo = OptionsInfo(True, "column_labels", "px", "100%")
+    column_labels_font_weight: OptionsInfo = OptionsInfo(True, "column_labels", "value", "normal")
+    column_labels_text_transform: OptionsInfo = OptionsInfo(
+        True, "column_labels", "value", "inherit"
+    )
+    column_labels_padding: OptionsInfo = OptionsInfo(True, "column_labels", "px", "5px")
+    column_labels_padding_horizontal: OptionsInfo = OptionsInfo(True, "column_labels", "px", "5px")
+    column_labels_vlines_style: OptionsInfo = OptionsInfo(True, "table_body", "value", "none")
+    column_labels_vlines_width: OptionsInfo = OptionsInfo(True, "table_body", "px", "1px")
+    column_labels_vlines_color: OptionsInfo = OptionsInfo(True, "table_body", "value", "#D3D3D3")
+    column_labels_border_top_style: OptionsInfo = OptionsInfo(
+        True, "column_labels", "value", "solid"
+    )
+    column_labels_border_top_width: OptionsInfo = OptionsInfo(True, "column_labels", "px", "2px")
+    column_labels_border_top_color: OptionsInfo = OptionsInfo(
+        True, "column_labels", "value", "#D3D3D3"
+    )
+    column_labels_border_bottom_style: OptionsInfo = OptionsInfo(
+        True, "column_labels", "value", "solid"
+    )
+    column_labels_border_bottom_width: OptionsInfo = OptionsInfo(True, "column_labels", "px", "2px")
+    column_labels_border_bottom_color: OptionsInfo = OptionsInfo(
+        True, "column_labels", "value", "#D3D3D3"
+    )
+    column_labels_border_lr_style: OptionsInfo = OptionsInfo(True, "column_labels", "value", "none")
+    column_labels_border_lr_width: OptionsInfo = OptionsInfo(True, "column_labels", "px", "1px")
+    column_labels_border_lr_color: OptionsInfo = OptionsInfo(
+        True, "column_labels", "value", "#D3D3D3"
+    )
+    column_labels_hidden: OptionsInfo = OptionsInfo(False, "column_labels", "boolean", False)
+    row_group_background_color: OptionsInfo = OptionsInfo(True, "row_group", "value", None)
+    row_group_font_size: OptionsInfo = OptionsInfo(True, "row_group", "px", "100%")
+    row_group_font_weight: OptionsInfo = OptionsInfo(True, "row_group", "value", "initial")
+    row_group_text_transform: OptionsInfo = OptionsInfo(True, "row_group", "value", "inherit")
+    row_group_padding: OptionsInfo = OptionsInfo(True, "row_group", "px", "8px")
+    row_group_padding_horizontal: OptionsInfo = OptionsInfo(True, "row_group", "px", "5px")
+    row_group_border_top_style: OptionsInfo = OptionsInfo(True, "row_group", "value", "solid")
+    row_group_border_top_width: OptionsInfo = OptionsInfo(True, "row_group", "px", "2px")
+    row_group_border_top_color: OptionsInfo = OptionsInfo(True, "row_group", "value", "#D3D3D3")
+    row_group_border_right_style: OptionsInfo = OptionsInfo(True, "row_group", "value", "none")
+    row_group_border_right_width: OptionsInfo = OptionsInfo(True, "row_group", "px", "1px")
+    row_group_border_right_color: OptionsInfo = OptionsInfo(True, "row_group", "value", "#D3D3D3")
+    row_group_border_bottom_style: OptionsInfo = OptionsInfo(True, "row_group", "value", "solid")
+    row_group_border_bottom_width: OptionsInfo = OptionsInfo(True, "row_group", "px", "2px")
+    row_group_border_bottom_color: OptionsInfo = OptionsInfo(True, "row_group", "value", "#D3D3D3")
+    row_group_border_left_style: OptionsInfo = OptionsInfo(True, "row_group", "value", "none")
+    row_group_border_left_width: OptionsInfo = OptionsInfo(True, "row_group", "px", "1px")
+    row_group_border_left_color: OptionsInfo = OptionsInfo(True, "row_group", "value", "#D3D3D3")
+    row_group_default_label: OptionsInfo = OptionsInfo(False, "row_group", "value", None)
+    row_group_as_column: OptionsInfo = OptionsInfo(False, "row_group", "boolean", False)
+    table_body_hlines_style: OptionsInfo = OptionsInfo(True, "table_body", "value", "solid")
+    table_body_hlines_width: OptionsInfo = OptionsInfo(True, "table_body", "px", "1px")
+    table_body_hlines_color: OptionsInfo = OptionsInfo(True, "table_body", "value", "#D3D3D3")
+    table_body_vlines_style: OptionsInfo = OptionsInfo(True, "table_body", "value", "none")
+    table_body_vlines_width: OptionsInfo = OptionsInfo(True, "table_body", "px", "1px")
+    table_body_vlines_color: OptionsInfo = OptionsInfo(True, "table_body", "value", "#D3D3D3")
+    table_body_border_top_style: OptionsInfo = OptionsInfo(True, "table_body", "value", "solid")
+    table_body_border_top_width: OptionsInfo = OptionsInfo(True, "table_body", "px", "2px")
+    table_body_border_top_color: OptionsInfo = OptionsInfo(True, "table_body", "value", "#D3D3D3")
+    table_body_border_bottom_style: OptionsInfo = OptionsInfo(True, "table_body", "value", "solid")
+    table_body_border_bottom_width: OptionsInfo = OptionsInfo(True, "table_body", "px", "2px")
+    table_body_border_bottom_color: OptionsInfo = OptionsInfo(
+        True, "table_body", "value", "#D3D3D3"
+    )
+    data_row_padding: OptionsInfo = OptionsInfo(True, "data_row", "px", "8px")
+    data_row_padding_horizontal: OptionsInfo = OptionsInfo(True, "data_row", "px", "5px")
+    stub_background_color: OptionsInfo = OptionsInfo(True, "stub", "value", None)
+    stub_font_size: OptionsInfo = OptionsInfo(True, "stub", "px", "100%")
+    stub_font_weight: OptionsInfo = OptionsInfo(True, "stub", "value", "initial")
+    stub_text_transform: OptionsInfo = OptionsInfo(True, "stub", "value", "inherit")
+    stub_border_style: OptionsInfo = OptionsInfo(True, "stub", "value", "solid")
+    stub_border_width: OptionsInfo = OptionsInfo(True, "stub", "px", "2px")
+    stub_border_color: OptionsInfo = OptionsInfo(True, "stub", "value", "#D3D3D3")
+    stub_row_group_background_color: OptionsInfo = OptionsInfo(True, "stub", "value", None)
+    stub_row_group_font_size: OptionsInfo = OptionsInfo(True, "stub", "px", "100%")
+    stub_row_group_font_weight: OptionsInfo = OptionsInfo(True, "stub", "value", "initial")
+    stub_row_group_text_transform: OptionsInfo = OptionsInfo(True, "stub", "value", "inherit")
+    stub_row_group_border_style: OptionsInfo = OptionsInfo(True, "stub", "value", "solid")
+    stub_row_group_border_width: OptionsInfo = OptionsInfo(True, "stub", "px", "2px")
+    stub_row_group_border_color: OptionsInfo = OptionsInfo(True, "stub", "value", "#D3D3D3")
+    summary_row_padding: OptionsInfo = OptionsInfo(True, "summary_row", "px", "8px")
+    summary_row_padding_horizontal: OptionsInfo = OptionsInfo(True, "summary_row", "px", "5px")
+    summary_row_background_color: OptionsInfo = OptionsInfo(True, "summary_row", "value", None)
+    summary_row_text_transform: OptionsInfo = OptionsInfo(True, "summary_row", "value", "inherit")
+    summary_row_border_style: OptionsInfo = OptionsInfo(True, "summary_row", "value", "solid")
+    summary_row_border_width: OptionsInfo = OptionsInfo(True, "summary_row", "px", "2px")
+    summary_row_border_color: OptionsInfo = OptionsInfo(True, "summary_row", "value", "#D3D3D3")
+    grand_summary_row_padding: OptionsInfo = OptionsInfo(True, "grand_summary_row", "px", "8px")
+    grand_summary_row_padding_horizontal: OptionsInfo = OptionsInfo(
+        True, "grand_summary_row", "px", "5px"
+    )
+    grand_summary_row_background_color: OptionsInfo = OptionsInfo(
+        True, "grand_summary_row", "value", None
+    )
+    grand_summary_row_text_transform: OptionsInfo = OptionsInfo(
+        True, "grand_summary_row", "value", "inherit"
+    )
+    grand_summary_row_border_style: OptionsInfo = OptionsInfo(
+        True, "grand_summary_row", "value", "double"
+    )
+    grand_summary_row_border_width: OptionsInfo = OptionsInfo(
+        True, "grand_summary_row", "px", "6px"
+    )
+    grand_summary_row_border_color: OptionsInfo = OptionsInfo(
+        True, "grand_summary_row", "value", "#D3D3D3"
+    )
+    footnotes_font_size: OptionsInfo = OptionsInfo(True, "footnotes", "px", "90%")
+    footnotes_padding: OptionsInfo = OptionsInfo(True, "footnotes", "px", "4px")
+    footnotes_padding_horizontal: OptionsInfo = OptionsInfo(True, "footnotes", "px", "5px")
+    footnotes_background_color: OptionsInfo = OptionsInfo(True, "footnotes", "value", None)
+    footnotes_margin: OptionsInfo = OptionsInfo(True, "footnotes", "px", "0px")
+    footnotes_border_bottom_style: OptionsInfo = OptionsInfo(True, "footnotes", "value", "none")
+    footnotes_border_bottom_width: OptionsInfo = OptionsInfo(True, "footnotes", "px", "2px")
+    footnotes_border_bottom_color: OptionsInfo = OptionsInfo(True, "footnotes", "value", "#D3D3D3")
+    footnotes_border_lr_style: OptionsInfo = OptionsInfo(True, "footnotes", "value", "none")
+    footnotes_border_lr_width: OptionsInfo = OptionsInfo(True, "footnotes", "px", "2px")
+    footnotes_border_lr_color: OptionsInfo = OptionsInfo(True, "footnotes", "value", "#D3D3D3")
+    footnotes_marks: OptionsInfo = OptionsInfo(False, "footnotes", "values", "numbers")
+    footnotes_multiline: OptionsInfo = OptionsInfo(False, "footnotes", "boolean", True)
+    footnotes_sep: OptionsInfo = OptionsInfo(False, "footnotes", "value", " ")
+    source_notes_padding: OptionsInfo = OptionsInfo(True, "source_notes", "px", "4px")
+    source_notes_padding_horizontal: OptionsInfo = OptionsInfo(True, "source_notes", "px", "5px")
+    source_notes_background_color: OptionsInfo = OptionsInfo(True, "source_notes", "value", None)
+    source_notes_font_size: OptionsInfo = OptionsInfo(True, "source_notes", "px", "90%")
+    source_notes_border_bottom_style: OptionsInfo = OptionsInfo(
+        True, "source_notes", "value", "none"
+    )
+    source_notes_border_bottom_width: OptionsInfo = OptionsInfo(True, "source_notes", "px", "2px")
+    source_notes_border_bottom_color: OptionsInfo = OptionsInfo(
+        True, "source_notes", "value", "#D3D3D3"
+    )
+    source_notes_border_lr_style: OptionsInfo = OptionsInfo(True, "source_notes", "value", "none")
+    source_notes_border_lr_width: OptionsInfo = OptionsInfo(True, "source_notes", "px", "2px")
+    source_notes_border_lr_color: OptionsInfo = OptionsInfo(
+        True, "source_notes", "value", "#D3D3D3"
+    )
+    source_notes_multiline: OptionsInfo = OptionsInfo(False, "source_notes", "boolean", True)
+    source_notes_sep: OptionsInfo = OptionsInfo(False, "source_notes", "value", " ")
+    row_striping_background_color: OptionsInfo = OptionsInfo(
+        True, "row", "value", "rgba(128,128,128,0.05)"
+    )
+    row_striping_include_stub: OptionsInfo = OptionsInfo(False, "row", "boolean", False)
+    row_striping_include_table_body: OptionsInfo = OptionsInfo(False, "row", "boolean", False)
+    container_width: OptionsInfo = OptionsInfo(False, "container", "px", "auto")
+    container_height: OptionsInfo = OptionsInfo(False, "container", "px", "auto")
+    container_padding_x: OptionsInfo = OptionsInfo(False, "container", "px", "0px")
+    container_padding_y: OptionsInfo = OptionsInfo(False, "container", "px", "10px")
+    container_overflow_x: OptionsInfo = OptionsInfo(False, "container", "overflow", "auto")
+    container_overflow_y: OptionsInfo = OptionsInfo(False, "container", "overflow", "auto")
+    page_orientation: OptionsInfo = OptionsInfo(False, "page", "value", "portrait")
+    page_numbering: OptionsInfo = OptionsInfo(False, "page", "boolean", False)
+    page_header_use_tbl_headings: OptionsInfo = OptionsInfo(False, "page", "boolean", False)
+    page_footer_use_tbl_notes: OptionsInfo = OptionsInfo(False, "page", "boolean", False)
+    page_width: OptionsInfo = OptionsInfo(False, "page", "value", "8.5in")
+    page_height: OptionsInfo = OptionsInfo(False, "page", "value", "11.0in")
+    page_margin_left: OptionsInfo = OptionsInfo(False, "page", "value", "1.0in")
+    page_margin_right: OptionsInfo = OptionsInfo(False, "page", "value", "1.0in")
+    page_margin_top: OptionsInfo = OptionsInfo(False, "page", "value", "1.0in")
+    page_margin_bottom: OptionsInfo = OptionsInfo(False, "page", "value", "1.0in")
+    page_header_height: OptionsInfo = OptionsInfo(False, "page", "value", "0.5in")
+    page_footer_height: OptionsInfo = OptionsInfo(False, "page", "value", "0.5in")
+    quarto_disable_processing: OptionsInfo = OptionsInfo(False, "quarto", "logical", False)
+    quarto_use_bootstrap: OptionsInfo = OptionsInfo(False, "quarto", "logical", False)
 
     def _get_all_options_keys(self) -> List[Union[str, None]]:
         return [x.parameter for x in self._options.values()]
 
-    def __getattr__(self, __name: str) -> OptionsInfo:
-        return self._options[__name]
-        # use this like
-        #
-        # options = Options()
-        # options.foo.value = "bar"
-        # print(options.foo.type)
-
-    #def _get_option_type(self, option: str) -> Union[Any, List[str]]:
+    # def _get_option_type(self, option: str) -> Union[Any, List[str]]:
     #    return self._options[option].type
 
     def _get_option_value(self, option: str) -> Union[Any, List[str]]:
         return self._options[option].value
 
     def _set_option_value(self, option: str, value: Any):
-       self._options[option].value = value
-       return self
+        self._options[option].value = value
+        return self

--- a/great_tables/_heading.py
+++ b/great_tables/_heading.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Union, List
+from typing import TYPE_CHECKING, Optional, Union, List
 from typing_extensions import Self
 
 from ._gt_data import Heading
@@ -7,69 +7,72 @@ from ._gt_data import Heading
 from copy import copy
 
 
-class HeadingAPI:
-    def tab_header(
-        self,
-        title: str,
-        subtitle: Optional[str] = None,
-        preheader: Optional[Union[str, List[str]]] = None,
-    ) -> Self:
-        """
-        Add a table header.
+if TYPE_CHECKING:
+    from ._types import GTSelf
 
-        We can add a table header to the **gt** table with a title and even a subtitle using the
-        `tab_header()` method. A table header is an optional table component that is positioned
-        above above the column labels. We have the flexibility to use Markdown or HTML formatting
-        for the header's title and subtitle with the `md()` and `html()` helper functions.
 
-        Parameters
-        ----------
-        title : str
-            Text to be used in the table title. We can elect to use the `md()` and `html()` helper
-            functions to style the text as Markdown or to retain HTML elements in the text.
-        subtitle : str
-            Text to be used in the table subtitle. We can elect to use the `md()` and `html()`
-            helper functions to style the text as Markdown or to retain HTML elements in the text.
-        preheader (str)
-            Optional preheader content that is rendered above the table. Can be supplied as a list
-            of strings.
+def tab_header(
+    self: GTSelf,
+    title: str,
+    subtitle: Optional[str] = None,
+    preheader: Optional[Union[str, List[str]]] = None,
+) -> GTSelf:
+    """
+    Add a table header.
 
-        Returns
-        -------
-        GT
-            The GT object is returned.
+    We can add a table header to the **gt** table with a title and even a subtitle using the
+    `tab_header()` method. A table header is an optional table component that is positioned
+    above above the column labels. We have the flexibility to use Markdown or HTML formatting
+    for the header's title and subtitle with the `md()` and `html()` helper functions.
 
-        Examples
-        --------
-        Let's use a small portion of the `gtcars` dataset to create a table. A header part can be
-        added to the table with the `tab_header()` method. We'll add a title and the optional
-        subtitle as well. With the `md()` helper function, we can make sure the Markdown formatting
-        is interpreted and transformed.
+    Parameters
+    ----------
+    title : str
+        Text to be used in the table title. We can elect to use the `md()` and `html()` helper
+        functions to style the text as Markdown or to retain HTML elements in the text.
+    subtitle : str
+        Text to be used in the table subtitle. We can elect to use the `md()` and `html()`
+        helper functions to style the text as Markdown or to retain HTML elements in the text.
+    preheader (str)
+        Optional preheader content that is rendered above the table. Can be supplied as a list
+        of strings.
 
-        ```{python}
-        import great_tables as gt
+    Returns
+    -------
+    GT
+        The GT object is returned.
 
-        gtcars_mini = gt.gtcars[[\"mfr\", \"model\", \"msrp\"]].head(5)
+    Examples
+    --------
+    Let's use a small portion of the `gtcars` dataset to create a table. A header part can be
+    added to the table with the `tab_header()` method. We'll add a title and the optional
+    subtitle as well. With the `md()` helper function, we can make sure the Markdown formatting
+    is interpreted and transformed.
 
-        (
-            gt.GT(gtcars_mini)
-            .tab_header(
-                title=gt.md(\"Data listing from **gtcars**\"),
-                subtitle=gt.md(\"`gtcars` is an R dataset\")
-            )
+    ```{python}
+    import great_tables as gt
+
+    gtcars_mini = gt.gtcars[[\"mfr\", \"model\", \"msrp\"]].head(5)
+
+    (
+        gt.GT(gtcars_mini)
+        .tab_header(
+            title=gt.md(\"Data listing from **gtcars**\"),
+            subtitle=gt.md(\"`gtcars` is an R dataset\")
         )
-        ```
+    )
+    ```
 
-        We can alternatively use the `html()` helper function to retain HTML elements in the text.
+    We can alternatively use the `html()` helper function to retain HTML elements in the text.
 
-        ```{python}
-        (
-            gt.GT(gtcars_mini)
-            .tab_header(
-                title=gt.md("Data listing <strong>gtcars</strong>"),
-                subtitle=gt.html("From <span style='color:red;'>gtcars</span>")
-            )
+    ```{python}
+    (
+        gt.GT(gtcars_mini)
+        .tab_header(
+            title=gt.md("Data listing <strong>gtcars</strong>"),
+            subtitle=gt.html("From <span style='color:red;'>gtcars</span>")
         )
-        ```
-        """
-        return self._replace(_heading=Heading(title=title, subtitle=subtitle, preheader=preheader))
+    )
+    ```
+    """
+    return self._replace(_heading=Heading(title=title, subtitle=subtitle, preheader=preheader))

--- a/great_tables/_heading.py
+++ b/great_tables/_heading.py
@@ -72,7 +72,4 @@ class HeadingAPI:
         )
         ```
         """
-        result = copy(self)
-        result._heading = Heading(title=title, subtitle=subtitle, preheader=preheader)
-
-        return result
+        return self._replace(_heading=Heading(title=title, subtitle=subtitle, preheader=preheader))

--- a/great_tables/_locale.py
+++ b/great_tables/_locale.py
@@ -13,10 +13,6 @@ class Locale:
         self._locale = locale
 
 
-class LocaleAPI:
-    pass
-
-
 def _get_locales_data() -> pd.DataFrame:
     _x_locales_fname = pkg_resources.resource_filename("great_tables.data", "x_locales.csv")
     _x_locales_dtype = {

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from dataclasses import replace
 from typing import TYPE_CHECKING, Optional, Union, List, cast
 from great_tables import _utils
 
@@ -355,13 +356,12 @@ def tab_options(
     del saved_args["self"]
 
     modified_args = {k: v for k, v in saved_args.items() if v is not None}
+    new_options_info = {
+        k: replace(getattr(self._options, k), value=v) for k, v in modified_args.items()
+    }
+    new_options = replace(self._options, **new_options_info)
 
-    for i in range(len(modified_args)):
-        self._options._set_option_value(
-            option=list(modified_args.keys())[i], value=list(modified_args.values())[i]
-        )
-
-    return self
+    return self._replace(_options=new_options)
 
 
 def opt_footnote_marks(self: GTSelf, marks: Union[str, List[str]] = "numbers") -> GTSelf:

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1,533 +1,542 @@
 from __future__ import annotations
-from typing import Optional, Union, List, cast
+from typing import TYPE_CHECKING, Optional, Union, List, cast
 from great_tables import _utils
 
 
-class OptionsAPI:
-    def tab_options(
-        self,
-        container_width: Optional[str] = None,
-        container_height: Optional[str] = None,
-        container_overflow_x: Optional[str] = None,
-        container_overflow_y: Optional[str] = None,
-        table_width: Optional[str] = None,
-        table_layout: Optional[str] = None,
-        table_align: Optional[str] = None,
-        table_margin_left: Optional[str] = None,
-        table_margin_right: Optional[str] = None,
-        table_background_color: Optional[str] = None,
-        table_additional_css: Optional[str] = None,
-        table_font_names: Optional[str] = None,
-        table_font_size: Optional[str] = None,
-        table_font_weight: Optional[str] = None,
-        table_font_style: Optional[str] = None,
-        table_font_color: Optional[str] = None,
-        table_font_color_light: Optional[str] = None,
-        table_border_top_style: Optional[str] = None,
-        table_border_top_width: Optional[str] = None,
-        table_border_top_color: Optional[str] = None,
-        table_border_right_style: Optional[str] = None,
-        table_border_right_width: Optional[str] = None,
-        table_border_right_color: Optional[str] = None,
-        table_border_bottom_style: Optional[str] = None,
-        table_border_bottom_width: Optional[str] = None,
-        table_border_bottom_color: Optional[str] = None,
-        table_border_left_style: Optional[str] = None,
-        table_border_left_width: Optional[str] = None,
-        table_border_left_color: Optional[str] = None,
-        heading_background_color: Optional[str] = None,
-        heading_align: Optional[str] = None,
-        heading_title_font_size: Optional[str] = None,
-        heading_title_font_weight: Optional[str] = None,
-        heading_subtitle_font_size: Optional[str] = None,
-        heading_subtitle_font_weight: Optional[str] = None,
-        heading_padding: Optional[str] = None,
-        heading_padding_horizontal: Optional[str] = None,
-        heading_border_bottom_style: Optional[str] = None,
-        heading_border_bottom_width: Optional[str] = None,
-        heading_border_bottom_color: Optional[str] = None,
-        heading_border_lr_style: Optional[str] = None,
-        heading_border_lr_width: Optional[str] = None,
-        heading_border_lr_color: Optional[str] = None,
-        column_labels_background_color: Optional[str] = None,
-        column_labels_font_size: Optional[str] = None,
-        column_labels_font_weight: Optional[str] = None,
-        column_labels_text_transform: Optional[str] = None,
-        column_labels_padding: Optional[str] = None,
-        column_labels_padding_horizontal: Optional[str] = None,
-        column_labels_vlines_style: Optional[str] = None,
-        column_labels_vlines_width: Optional[str] = None,
-        column_labels_vlines_color: Optional[str] = None,
-        column_labels_border_top_style: Optional[str] = None,
-        column_labels_border_top_width: Optional[str] = None,
-        column_labels_border_top_color: Optional[str] = None,
-        column_labels_border_bottom_style: Optional[str] = None,
-        column_labels_border_bottom_width: Optional[str] = None,
-        column_labels_border_bottom_color: Optional[str] = None,
-        column_labels_border_lr_style: Optional[str] = None,
-        column_labels_border_lr_width: Optional[str] = None,
-        column_labels_border_lr_color: Optional[str] = None,
-        column_labels_hidden: Optional[bool] = None,
-        row_group_background_color: Optional[str] = None,
-        row_group_font_size: Optional[str] = None,
-        row_group_font_weight: Optional[str] = None,
-        row_group_text_transform: Optional[str] = None,
-        row_group_padding: Optional[str] = None,
-        row_group_padding_horizontal: Optional[str] = None,
-        row_group_border_top_style: Optional[str] = None,
-        row_group_border_top_width: Optional[str] = None,
-        row_group_border_top_color: Optional[str] = None,
-        row_group_border_bottom_style: Optional[str] = None,
-        row_group_border_bottom_width: Optional[str] = None,
-        row_group_border_bottom_color: Optional[str] = None,
-        row_group_border_left_style: Optional[str] = None,
-        row_group_border_left_width: Optional[str] = None,
-        row_group_border_left_color: Optional[str] = None,
-        row_group_border_right_style: Optional[str] = None,
-        row_group_border_right_width: Optional[str] = None,
-        row_group_border_right_color: Optional[str] = None,
-        row_group_default_label: Optional[str] = None,
-        row_group_as_column: Optional[bool] = None,
-        table_body_hlines_style: Optional[str] = None,
-        table_body_hlines_width: Optional[str] = None,
-        table_body_hlines_color: Optional[str] = None,
-        table_body_vlines_style: Optional[str] = None,
-        table_body_vlines_width: Optional[str] = None,
-        table_body_vlines_color: Optional[str] = None,
-        table_body_border_top_style: Optional[str] = None,
-        table_body_border_top_width: Optional[str] = None,
-        table_body_border_top_color: Optional[str] = None,
-        table_body_border_bottom_style: Optional[str] = None,
-        table_body_border_bottom_width: Optional[str] = None,
-        table_body_border_bottom_color: Optional[str] = None,
-        stub_background_color: Optional[str] = None,
-        stub_font_size: Optional[str] = None,
-        stub_font_weight: Optional[str] = None,
-        stub_text_transform: Optional[str] = None,
-        stub_border_style: Optional[str] = None,
-        stub_border_width: Optional[str] = None,
-        stub_border_color: Optional[str] = None,
-        stub_row_group_font_size: Optional[str] = None,
-        stub_row_group_font_weight: Optional[str] = None,
-        stub_row_group_text_transform: Optional[str] = None,
-        stub_row_group_border_style: Optional[str] = None,
-        stub_row_group_border_width: Optional[str] = None,
-        stub_row_group_border_color: Optional[str] = None,
-        data_row_padding: Optional[str] = None,
-        data_row_padding_horizontal: Optional[str] = None,
-        summary_row_background_color: Optional[str] = None,
-        summary_row_text_transform: Optional[str] = None,
-        summary_row_padding: Optional[str] = None,
-        summary_row_padding_horizontal: Optional[str] = None,
-        summary_row_border_style: Optional[str] = None,
-        summary_row_border_width: Optional[str] = None,
-        summary_row_border_color: Optional[str] = None,
-        grand_summary_row_background_color: Optional[str] = None,
-        grand_summary_row_text_transform: Optional[str] = None,
-        grand_summary_row_padding: Optional[str] = None,
-        grand_summary_row_padding_horizontal: Optional[str] = None,
-        grand_summary_row_border_style: Optional[str] = None,
-        grand_summary_row_border_width: Optional[str] = None,
-        grand_summary_row_border_color: Optional[str] = None,
-        footnotes_background_color: Optional[str] = None,
-        footnotes_font_size: Optional[str] = None,
-        footnotes_padding: Optional[str] = None,
-        footnotes_padding_horizontal: Optional[str] = None,
-        footnotes_border_bottom_style: Optional[str] = None,
-        footnotes_border_bottom_width: Optional[str] = None,
-        footnotes_border_bottom_color: Optional[str] = None,
-        footnotes_border_lr_style: Optional[str] = None,
-        footnotes_border_lr_width: Optional[str] = None,
-        footnotes_border_lr_color: Optional[str] = None,
-        footnotes_marks: Optional[Union[str, List[str]]] = None,
-        footnotes_multiline: Optional[bool] = None,
-        footnotes_sep: Optional[str] = None,
-        source_notes_background_color: Optional[str] = None,
-        source_notes_font_size: Optional[str] = None,
-        source_notes_padding: Optional[str] = None,
-        source_notes_padding_horizontal: Optional[str] = None,
-        source_notes_border_bottom_style: Optional[str] = None,
-        source_notes_border_bottom_width: Optional[str] = None,
-        source_notes_border_bottom_color: Optional[str] = None,
-        source_notes_border_lr_style: Optional[str] = None,
-        source_notes_border_lr_width: Optional[str] = None,
-        source_notes_border_lr_color: Optional[str] = None,
-        source_notes_multiline: Optional[bool] = None,
-        source_notes_sep: Optional[str] = None,
-        row_striping_background_color: Optional[str] = None,
-        row_striping_include_stub: Optional[bool] = None,
-        row_striping_include_table_body: Optional[bool] = None,
-    ):
-        """
-        Modify the table output options.
+if TYPE_CHECKING:
+    from ._types import GTSelf
 
-        Modify the options available in a table. These options are named by the components, the
-        subcomponents, and the element that can adjusted.
 
-        Parameters
-        ----------
-        container_width, container_height : str
-            The width and height of the table's container. Can be specified as a single-length
-            character with units of pixels or as a percentage. If provided as a scalar numeric
-            value, it is assumed that the value is given in units of pixels. The `px()` and `pct()`
-            helpers can also be used to pass in numeric values and obtain values as pixel or percent
-            units.
-        container_overflow_x, container_overflow_y : bool
-            Options to enable scrolling in the horizontal and vertical directions when the table
-            content overflows the container dimensions. Using `True` (the default for both) means
-            that horizontal or vertical scrolling is enabled to view the entire table in those
-            directions. With `False`, the table may be clipped if the table width or height exceeds
-            the `container_width` or `container_height`.
-        table_width
-            The width of the table. Can be specified as a string with units of pixels or as a
-            percentage. If provided as a numeric value, it is assumed that the value is given in
-            units of pixels. The `px()` and `pct()` helpers can also be used to pass in numeric
-            values and obtain values as pixel or percent units.
-        table_layout
-            The value for the `table-layout` CSS style in the HTML output context. By default, this
-            is `"fixed"` but another valid option is `"auto"`.
-        table_align
-            The horizontal alignment of the table in its container. By default, this is `"center"`.
-            Other options are `"left"` and `"right"`. This will automatically set
-            `table_margin_left` and `table_margin_right` to the appropriate values.
-        table_margin_left,table_margin_right
-            The size of the margins on the left and right of the table within the container. Can be
-            specified as a single-length character with units of pixels or as a percentage. If
-            provided as a numeric value, it is assumed that the value is given in units of pixels.
-            The `px()` and `pct()` helpers can also be used to pass in numeric values and obtain
-            values as pixel or percent units. Using `table_margin_left` or `table_margin_right` will
-            overwrite any values set by `table_align`.
-        table_background_color,heading_background_color,column_labels_background_color,row_group_background_color,stub_background_color,summary_row_background_color,grand_summary_row_background_color,footnotes_background_color,source_notes_background_color
-            Background colors for the parent element `table` and the following child elements:
-            `heading`, `column_labels`, `row_group`, `stub`, `summary_row`, `grand_summary_row`,
-            `footnotes`, and `source_notes`. A color name or a hexadecimal color code should be
-            provided.
-        table_additional_css
-            This option can be used to supply an additional block of CSS rules to be applied after
-            the automatically generated table CSS.
-        table_font_names
-            The names of the fonts used for the table. This should be provided as a list of font
-            names. If the first font isn't available, then the next font is tried (and so on).
-        table_font_style
-            The font style for the table. Can be one of either `"normal"`, `"italic"`, or `"oblique"`.
-        table_font_color,table_font_color_light
-            The text color used throughout the table. There are two variants: `table_font_color` is
-            for text overlaid on lighter background colors, and `table_font_color_light` is
-            automatically used when text needs to be overlaid on darker background colors. A color
-            name or a hexadecimal color code should be provided.
-        table_font_size,heading_title_font_size,heading_subtitle_font_size,column_labels_font_size,row_group_font_size,stub_font_size,footnotes_font_size,source_notes_font_size
-            The font sizes for the parent text element `table` and the following child elements:
-            `heading_title`, `heading_subtitle`, `column_labels`, `row_group`, `footnotes`, and
-            `source_notes`. Can be specified as a string with units of pixels (e.g., `"12px"`) or as
-            a percentage (e.g., `"80%"`). If provided as a scalar numeric value, it is assumed that
-            the value is given in units of pixels. The `px()` and `pct()` helpers can also be used
-            to pass in numeric values and obtain values as pixel or percentage units.
-        heading_align
-            Controls the horizontal alignment of the heading title and subtitle. We can either use
-            `"center"`, `"left"`, or `"right"`.
-        table_font_weight,heading_title_font_weight,heading_subtitle_font_weight,column_labels_font_weight,row_group_font_weight,stub_font_weight
-            The font weights of the table, `heading_title`, `heading_subtitle`, `column_labels`,
-            `row_group`, and `stub` text elements. Can be a text-based keyword such as `"normal"`,
-            `"bold"`, `"lighter"`, `"bolder"`, or, a numeric value between `1` and `1000`,
-            inclusive. Note that only variable fonts may support the numeric mapping of weight.
-        column_labels_text_transform,row_group_text_transform,stub_text_transform,summary_row_text_transform,grand_summary_row_text_transform
-            Options to apply text transformations to the `column_labels`, `row_group`, `stub`,
-            `summary_row`, and `grand_summary_row` text elements. Either of the `"uppercase"`,
-            `"lowercase"`, or `"capitalize"` keywords can be used.
-        heading_padding,column_labels_padding,data_row_padding,row_group_padding,summary_row_padding,grand_summary_row_padding,footnotes_padding,source_notes_padding
-            The amount of vertical padding to incorporate in the `heading` (title and subtitle), the
-            `column_labels` (this includes the column spanners), the row group labels
-            (`row_group_padding`), in the body/stub rows (`data_row_padding`), in summary rows
-            (`summary_row_padding` or `grand_summary_row_padding`), or in the footnotes and source
-            notes (`footnotes_padding` and `source_notes_padding`).
-        heading_padding_horizontal,column_labels_padding_horizontal,data_row_padding_horizontal,row_group_padding_horizontal,summary_row_padding_horizontal,grand_summary_row_padding_horizontal,footnotes_padding_horizontal,source_notes_padding_horizontal
-            The amount of horizontal padding to incorporate in the `heading` (title and subtitle),
-            the `column_labels` (this includes the column spanners), the row group labels
-            (`row_group_padding_horizontal`), in the body/stub rows (`data_row_padding`), in summary
-            rows (`summary_row_padding_horizontal` or `grand_summary_row_padding_horizontal`), or in
-            the footnotes and source notes (`footnotes_padding_horizontal` and
-            `source_notes_padding_horizontal`).
-        table_border_top_style,table_border_top_width,table_border_top_color,table_border_right_style,table_border_right_width,table_border_right_color,table_border_bottom_style,table_border_bottom_width,table_border_bottom_color,table_border_left_style,table_border_left_width,table_border_left_color
-            The style, width, and color properties of the table's absolute top and absolute bottom
-            borders.
-        heading_border_bottom_style,heading_border_bottom_width,heading_border_bottom_color
-            The style, width, and color properties of the header's bottom border. This border shares
-            space with that of the `column_labels` location. If the `width` of this border is
-            larger, then it will be the visible border.
-        heading_border_lr_style,heading_border_lr_width,heading_border_lr_color
-            The style, width, and color properties for the left and right borders of the `heading`
-            location.
-        column_labels_vlines_style,column_labels_vlines_width,column_labels_vlines_color
-            The style, width, and color properties for all vertical lines ('vlines') of the the
-            `column_labels`.
-        column_labels_border_top_style,column_labels_border_top_width,column_labels_border_top_color
-            The style, width, and color properties for the top border of the `column_labels`
-            location. This border shares space with that of the `heading` location. If the `width`
-            of this border is larger, then it will be the visible border.
-        column_labels_border_bottom_style,column_labels_border_bottom_width,column_labels_border_bottom_color
-            The style, width, and color properties for the bottom border of the `column_labels`
-            location.
-        column_labels_border_lr_style,column_labels_border_lr_width,column_labels_border_lr_color
-            The style, width, and color properties for the left and right borders of the
-            `column_labels` location.
-        column_labels_hidden
-            An option to hide the column labels. If providing `TRUE` then the entire `column_labels`
-            location won't be seen and the table header (if present) will collapse downward.
-        row_group_border_top_style,row_group_border_top_width,row_group_border_top_color,row_group_border_bottom_style,row_group_border_bottom_width,row_group_border_bottom_color,row_group_border_left_style,row_group_border_left_width,row_group_border_left_color,row_group_border_right_style,row_group_border_right_width,row_group_border_right_color
-            The style, width, and color properties for all top, bottom, left, and right borders of
-            the `row_group` location.
-        table_body_hlines_style,table_body_hlines_width,table_body_hlines_color,table_body_vlines_style,table_body_vlines_width,table_body_vlines_color
-            The style, width, and color properties for all horizontal lines ('hlines') and vertical
-            lines ('vlines') in the `table_body`.
-        table_body_border_top_style,table_body_border_top_width,table_body_border_top_color,table_body_border_bottom_style,table_body_border_bottom_width,table_body_border_bottom_color
-            The style, width, and color properties for all top and bottom borders of the
-            `table_body` location.
-        stub_border_style,stub_border_width,stub_border_color
-            The style, width, and color properties for the vertical border of the table stub.
-        stub_row_group_font_size,stub_row_group_font_weight,stub_row_group_text_transform,stub_row_group_border_style,stub_row_group_border_width,stub_row_group_border_color
-            Options for the row group column in the stub (made possible when using
-            `row_group_as_column=True`). The defaults for these options mirror that of the `stub.*`
-            variants (except for `stub_row_group_border_width`, which is `"1px"` instead of
-            `"2px"`).
-        row_group_default_label
-            An option to set a default row group label for any rows not formally placed in a row
-            group named by `group` in any call of `tab_row_group()`. If this is set as `None` and
-            there are rows that haven't been placed into a row group (where one or more row groups
-            already exist), those rows will be automatically placed into a row group without a label.
-        row_group_as_column
-            How should row groups be structured? By default, they are separate rows that lie above
-            the each of the groups. Setting this to `True` will structure row group labels are
-            columns to the far left of the table.
-        summary_row_border_style,summary_row_border_width,summary_row_border_color
-            The style, width, and color properties for all horizontal borders of the `summary_row`
-            location.
-        grand_summary_row_border_style,grand_summary_row_border_width,grand_summary_row_border_color
-            The style, width, and color properties for the top borders of the `grand_summary_row`
-            location.
-        footnotes_border_bottom_style,footnotes_border_bottom_width,footnotes_border_bottom_color
-            The style, width, and color properties for the bottom border of the `footnotes`
-            location.
-        footnotes_border_lr_style,footnotes_border_lr_width,footnotes_border_lr_color
-            The style, width, and color properties for the left and right borders of the
-            `footnotes` location.
-        footnotes_marks
-            The set of sequential marks used to reference and identify each of the footnotes (same
-            input as the [opt_footnote_marks()] function. We can supply a list that represents the
-            series of footnote marks. This list is recycled when its usage goes beyond the length of
-            the set. At each cycle, the marks are simply combined (e.g., `*` -> `**` -> `***`). The
-            option exists for providing keywords for certain types of footnote marks. The keyword
-            `"numbers"` (the default, indicating that we want to use numeric marks). We can use
-            lowercase `"letters"` or uppercase `"LETTERS"`. There is the option for using a
-            traditional symbol set where `"standard"` provides four symbols, and, `"extended"` adds
-            two more symbols, making six.
-        footnotes_multiline,source_notes_multiline
-            An option to either put footnotes and source notes in separate lines (the default, or
-            `True`) or render them as a continuous line of text with `footnotes_sep` providing the
-            separator (by default `" "`) between notes.
-        footnotes_sep,source_notes_sep
-            The separating characters between adjacent footnotes and source notes in their
-            respective footer sections when rendered as a continuous line of text (when
-            `footnotes_multiline is False`). The default value is a single space character (`" "`).
-        source_notes_border_bottom_style,source_notes_border_bottom_width,source_notes_border_bottom_color
-            The style, width, and color properties for the bottom border of the `source_notes`
-            location.
-        source_notes_border_lr_style,source_notes_border_lr_width,source_notes_border_lr_color
-            The style, width, and color properties for the left and right borders of the
-            `source_notes` location.
-        row_striping_background_color
-            The background color for striped table body rows. A color name or a hexadecimal color
-            code should be provided.
-        row_striping_include_stub
-            An option for whether to include the stub when striping rows.
-        row_striping_include_table_body
-            An option for whether to include the table body when striping rows.
+def tab_options(
+    self: GTSelf,
+    container_width: Optional[str] = None,
+    container_height: Optional[str] = None,
+    container_overflow_x: Optional[str] = None,
+    container_overflow_y: Optional[str] = None,
+    table_width: Optional[str] = None,
+    table_layout: Optional[str] = None,
+    table_align: Optional[str] = None,
+    table_margin_left: Optional[str] = None,
+    table_margin_right: Optional[str] = None,
+    table_background_color: Optional[str] = None,
+    table_additional_css: Optional[str] = None,
+    table_font_names: Optional[str] = None,
+    table_font_size: Optional[str] = None,
+    table_font_weight: Optional[str] = None,
+    table_font_style: Optional[str] = None,
+    table_font_color: Optional[str] = None,
+    table_font_color_light: Optional[str] = None,
+    table_border_top_style: Optional[str] = None,
+    table_border_top_width: Optional[str] = None,
+    table_border_top_color: Optional[str] = None,
+    table_border_right_style: Optional[str] = None,
+    table_border_right_width: Optional[str] = None,
+    table_border_right_color: Optional[str] = None,
+    table_border_bottom_style: Optional[str] = None,
+    table_border_bottom_width: Optional[str] = None,
+    table_border_bottom_color: Optional[str] = None,
+    table_border_left_style: Optional[str] = None,
+    table_border_left_width: Optional[str] = None,
+    table_border_left_color: Optional[str] = None,
+    heading_background_color: Optional[str] = None,
+    heading_align: Optional[str] = None,
+    heading_title_font_size: Optional[str] = None,
+    heading_title_font_weight: Optional[str] = None,
+    heading_subtitle_font_size: Optional[str] = None,
+    heading_subtitle_font_weight: Optional[str] = None,
+    heading_padding: Optional[str] = None,
+    heading_padding_horizontal: Optional[str] = None,
+    heading_border_bottom_style: Optional[str] = None,
+    heading_border_bottom_width: Optional[str] = None,
+    heading_border_bottom_color: Optional[str] = None,
+    heading_border_lr_style: Optional[str] = None,
+    heading_border_lr_width: Optional[str] = None,
+    heading_border_lr_color: Optional[str] = None,
+    column_labels_background_color: Optional[str] = None,
+    column_labels_font_size: Optional[str] = None,
+    column_labels_font_weight: Optional[str] = None,
+    column_labels_text_transform: Optional[str] = None,
+    column_labels_padding: Optional[str] = None,
+    column_labels_padding_horizontal: Optional[str] = None,
+    column_labels_vlines_style: Optional[str] = None,
+    column_labels_vlines_width: Optional[str] = None,
+    column_labels_vlines_color: Optional[str] = None,
+    column_labels_border_top_style: Optional[str] = None,
+    column_labels_border_top_width: Optional[str] = None,
+    column_labels_border_top_color: Optional[str] = None,
+    column_labels_border_bottom_style: Optional[str] = None,
+    column_labels_border_bottom_width: Optional[str] = None,
+    column_labels_border_bottom_color: Optional[str] = None,
+    column_labels_border_lr_style: Optional[str] = None,
+    column_labels_border_lr_width: Optional[str] = None,
+    column_labels_border_lr_color: Optional[str] = None,
+    column_labels_hidden: Optional[bool] = None,
+    row_group_background_color: Optional[str] = None,
+    row_group_font_size: Optional[str] = None,
+    row_group_font_weight: Optional[str] = None,
+    row_group_text_transform: Optional[str] = None,
+    row_group_padding: Optional[str] = None,
+    row_group_padding_horizontal: Optional[str] = None,
+    row_group_border_top_style: Optional[str] = None,
+    row_group_border_top_width: Optional[str] = None,
+    row_group_border_top_color: Optional[str] = None,
+    row_group_border_bottom_style: Optional[str] = None,
+    row_group_border_bottom_width: Optional[str] = None,
+    row_group_border_bottom_color: Optional[str] = None,
+    row_group_border_left_style: Optional[str] = None,
+    row_group_border_left_width: Optional[str] = None,
+    row_group_border_left_color: Optional[str] = None,
+    row_group_border_right_style: Optional[str] = None,
+    row_group_border_right_width: Optional[str] = None,
+    row_group_border_right_color: Optional[str] = None,
+    row_group_default_label: Optional[str] = None,
+    row_group_as_column: Optional[bool] = None,
+    table_body_hlines_style: Optional[str] = None,
+    table_body_hlines_width: Optional[str] = None,
+    table_body_hlines_color: Optional[str] = None,
+    table_body_vlines_style: Optional[str] = None,
+    table_body_vlines_width: Optional[str] = None,
+    table_body_vlines_color: Optional[str] = None,
+    table_body_border_top_style: Optional[str] = None,
+    table_body_border_top_width: Optional[str] = None,
+    table_body_border_top_color: Optional[str] = None,
+    table_body_border_bottom_style: Optional[str] = None,
+    table_body_border_bottom_width: Optional[str] = None,
+    table_body_border_bottom_color: Optional[str] = None,
+    stub_background_color: Optional[str] = None,
+    stub_font_size: Optional[str] = None,
+    stub_font_weight: Optional[str] = None,
+    stub_text_transform: Optional[str] = None,
+    stub_border_style: Optional[str] = None,
+    stub_border_width: Optional[str] = None,
+    stub_border_color: Optional[str] = None,
+    stub_row_group_font_size: Optional[str] = None,
+    stub_row_group_font_weight: Optional[str] = None,
+    stub_row_group_text_transform: Optional[str] = None,
+    stub_row_group_border_style: Optional[str] = None,
+    stub_row_group_border_width: Optional[str] = None,
+    stub_row_group_border_color: Optional[str] = None,
+    data_row_padding: Optional[str] = None,
+    data_row_padding_horizontal: Optional[str] = None,
+    summary_row_background_color: Optional[str] = None,
+    summary_row_text_transform: Optional[str] = None,
+    summary_row_padding: Optional[str] = None,
+    summary_row_padding_horizontal: Optional[str] = None,
+    summary_row_border_style: Optional[str] = None,
+    summary_row_border_width: Optional[str] = None,
+    summary_row_border_color: Optional[str] = None,
+    grand_summary_row_background_color: Optional[str] = None,
+    grand_summary_row_text_transform: Optional[str] = None,
+    grand_summary_row_padding: Optional[str] = None,
+    grand_summary_row_padding_horizontal: Optional[str] = None,
+    grand_summary_row_border_style: Optional[str] = None,
+    grand_summary_row_border_width: Optional[str] = None,
+    grand_summary_row_border_color: Optional[str] = None,
+    footnotes_background_color: Optional[str] = None,
+    footnotes_font_size: Optional[str] = None,
+    footnotes_padding: Optional[str] = None,
+    footnotes_padding_horizontal: Optional[str] = None,
+    footnotes_border_bottom_style: Optional[str] = None,
+    footnotes_border_bottom_width: Optional[str] = None,
+    footnotes_border_bottom_color: Optional[str] = None,
+    footnotes_border_lr_style: Optional[str] = None,
+    footnotes_border_lr_width: Optional[str] = None,
+    footnotes_border_lr_color: Optional[str] = None,
+    footnotes_marks: Optional[Union[str, List[str]]] = None,
+    footnotes_multiline: Optional[bool] = None,
+    footnotes_sep: Optional[str] = None,
+    source_notes_background_color: Optional[str] = None,
+    source_notes_font_size: Optional[str] = None,
+    source_notes_padding: Optional[str] = None,
+    source_notes_padding_horizontal: Optional[str] = None,
+    source_notes_border_bottom_style: Optional[str] = None,
+    source_notes_border_bottom_width: Optional[str] = None,
+    source_notes_border_bottom_color: Optional[str] = None,
+    source_notes_border_lr_style: Optional[str] = None,
+    source_notes_border_lr_width: Optional[str] = None,
+    source_notes_border_lr_color: Optional[str] = None,
+    source_notes_multiline: Optional[bool] = None,
+    source_notes_sep: Optional[str] = None,
+    row_striping_background_color: Optional[str] = None,
+    row_striping_include_stub: Optional[bool] = None,
+    row_striping_include_table_body: Optional[bool] = None,
+) -> GTSelf:
+    """
+    Modify the table output options.
 
-        Returns
-        -------
-        GT
-            The GT object is returned.
-        """
-        saved_args = locals()
+    Modify the options available in a table. These options are named by the components, the
+    subcomponents, and the element that can adjusted.
 
-        del saved_args["self"]
+    Parameters
+    ----------
+    container_width, container_height : str
+        The width and height of the table's container. Can be specified as a single-length
+        character with units of pixels or as a percentage. If provided as a scalar numeric
+        value, it is assumed that the value is given in units of pixels. The `px()` and `pct()`
+        helpers can also be used to pass in numeric values and obtain values as pixel or percent
+        units.
+    container_overflow_x, container_overflow_y : bool
+        Options to enable scrolling in the horizontal and vertical directions when the table
+        content overflows the container dimensions. Using `True` (the default for both) means
+        that horizontal or vertical scrolling is enabled to view the entire table in those
+        directions. With `False`, the table may be clipped if the table width or height exceeds
+        the `container_width` or `container_height`.
+    table_width
+        The width of the table. Can be specified as a string with units of pixels or as a
+        percentage. If provided as a numeric value, it is assumed that the value is given in
+        units of pixels. The `px()` and `pct()` helpers can also be used to pass in numeric
+        values and obtain values as pixel or percent units.
+    table_layout
+        The value for the `table-layout` CSS style in the HTML output context. By default, this
+        is `"fixed"` but another valid option is `"auto"`.
+    table_align
+        The horizontal alignment of the table in its container. By default, this is `"center"`.
+        Other options are `"left"` and `"right"`. This will automatically set
+        `table_margin_left` and `table_margin_right` to the appropriate values.
+    table_margin_left,table_margin_right
+        The size of the margins on the left and right of the table within the container. Can be
+        specified as a single-length character with units of pixels or as a percentage. If
+        provided as a numeric value, it is assumed that the value is given in units of pixels.
+        The `px()` and `pct()` helpers can also be used to pass in numeric values and obtain
+        values as pixel or percent units. Using `table_margin_left` or `table_margin_right` will
+        overwrite any values set by `table_align`.
+    table_background_color,heading_background_color,column_labels_background_color,row_group_background_color,stub_background_color,summary_row_background_color,grand_summary_row_background_color,footnotes_background_color,source_notes_background_color
+        Background colors for the parent element `table` and the following child elements:
+        `heading`, `column_labels`, `row_group`, `stub`, `summary_row`, `grand_summary_row`,
+        `footnotes`, and `source_notes`. A color name or a hexadecimal color code should be
+        provided.
+    table_additional_css
+        This option can be used to supply an additional block of CSS rules to be applied after
+        the automatically generated table CSS.
+    table_font_names
+        The names of the fonts used for the table. This should be provided as a list of font
+        names. If the first font isn't available, then the next font is tried (and so on).
+    table_font_style
+        The font style for the table. Can be one of either `"normal"`, `"italic"`, or `"oblique"`.
+    table_font_color,table_font_color_light
+        The text color used throughout the table. There are two variants: `table_font_color` is
+        for text overlaid on lighter background colors, and `table_font_color_light` is
+        automatically used when text needs to be overlaid on darker background colors. A color
+        name or a hexadecimal color code should be provided.
+    table_font_size,heading_title_font_size,heading_subtitle_font_size,column_labels_font_size,row_group_font_size,stub_font_size,footnotes_font_size,source_notes_font_size
+        The font sizes for the parent text element `table` and the following child elements:
+        `heading_title`, `heading_subtitle`, `column_labels`, `row_group`, `footnotes`, and
+        `source_notes`. Can be specified as a string with units of pixels (e.g., `"12px"`) or as
+        a percentage (e.g., `"80%"`). If provided as a scalar numeric value, it is assumed that
+        the value is given in units of pixels. The `px()` and `pct()` helpers can also be used
+        to pass in numeric values and obtain values as pixel or percentage units.
+    heading_align
+        Controls the horizontal alignment of the heading title and subtitle. We can either use
+        `"center"`, `"left"`, or `"right"`.
+    table_font_weight,heading_title_font_weight,heading_subtitle_font_weight,column_labels_font_weight,row_group_font_weight,stub_font_weight
+        The font weights of the table, `heading_title`, `heading_subtitle`, `column_labels`,
+        `row_group`, and `stub` text elements. Can be a text-based keyword such as `"normal"`,
+        `"bold"`, `"lighter"`, `"bolder"`, or, a numeric value between `1` and `1000`,
+        inclusive. Note that only variable fonts may support the numeric mapping of weight.
+    column_labels_text_transform,row_group_text_transform,stub_text_transform,summary_row_text_transform,grand_summary_row_text_transform
+        Options to apply text transformations to the `column_labels`, `row_group`, `stub`,
+        `summary_row`, and `grand_summary_row` text elements. Either of the `"uppercase"`,
+        `"lowercase"`, or `"capitalize"` keywords can be used.
+    heading_padding,column_labels_padding,data_row_padding,row_group_padding,summary_row_padding,grand_summary_row_padding,footnotes_padding,source_notes_padding
+        The amount of vertical padding to incorporate in the `heading` (title and subtitle), the
+        `column_labels` (this includes the column spanners), the row group labels
+        (`row_group_padding`), in the body/stub rows (`data_row_padding`), in summary rows
+        (`summary_row_padding` or `grand_summary_row_padding`), or in the footnotes and source
+        notes (`footnotes_padding` and `source_notes_padding`).
+    heading_padding_horizontal,column_labels_padding_horizontal,data_row_padding_horizontal,row_group_padding_horizontal,summary_row_padding_horizontal,grand_summary_row_padding_horizontal,footnotes_padding_horizontal,source_notes_padding_horizontal
+        The amount of horizontal padding to incorporate in the `heading` (title and subtitle),
+        the `column_labels` (this includes the column spanners), the row group labels
+        (`row_group_padding_horizontal`), in the body/stub rows (`data_row_padding`), in summary
+        rows (`summary_row_padding_horizontal` or `grand_summary_row_padding_horizontal`), or in
+        the footnotes and source notes (`footnotes_padding_horizontal` and
+        `source_notes_padding_horizontal`).
+    table_border_top_style,table_border_top_width,table_border_top_color,table_border_right_style,table_border_right_width,table_border_right_color,table_border_bottom_style,table_border_bottom_width,table_border_bottom_color,table_border_left_style,table_border_left_width,table_border_left_color
+        The style, width, and color properties of the table's absolute top and absolute bottom
+        borders.
+    heading_border_bottom_style,heading_border_bottom_width,heading_border_bottom_color
+        The style, width, and color properties of the header's bottom border. This border shares
+        space with that of the `column_labels` location. If the `width` of this border is
+        larger, then it will be the visible border.
+    heading_border_lr_style,heading_border_lr_width,heading_border_lr_color
+        The style, width, and color properties for the left and right borders of the `heading`
+        location.
+    column_labels_vlines_style,column_labels_vlines_width,column_labels_vlines_color
+        The style, width, and color properties for all vertical lines ('vlines') of the the
+        `column_labels`.
+    column_labels_border_top_style,column_labels_border_top_width,column_labels_border_top_color
+        The style, width, and color properties for the top border of the `column_labels`
+        location. This border shares space with that of the `heading` location. If the `width`
+        of this border is larger, then it will be the visible border.
+    column_labels_border_bottom_style,column_labels_border_bottom_width,column_labels_border_bottom_color
+        The style, width, and color properties for the bottom border of the `column_labels`
+        location.
+    column_labels_border_lr_style,column_labels_border_lr_width,column_labels_border_lr_color
+        The style, width, and color properties for the left and right borders of the
+        `column_labels` location.
+    column_labels_hidden
+        An option to hide the column labels. If providing `TRUE` then the entire `column_labels`
+        location won't be seen and the table header (if present) will collapse downward.
+    row_group_border_top_style,row_group_border_top_width,row_group_border_top_color,row_group_border_bottom_style,row_group_border_bottom_width,row_group_border_bottom_color,row_group_border_left_style,row_group_border_left_width,row_group_border_left_color,row_group_border_right_style,row_group_border_right_width,row_group_border_right_color
+        The style, width, and color properties for all top, bottom, left, and right borders of
+        the `row_group` location.
+    table_body_hlines_style,table_body_hlines_width,table_body_hlines_color,table_body_vlines_style,table_body_vlines_width,table_body_vlines_color
+        The style, width, and color properties for all horizontal lines ('hlines') and vertical
+        lines ('vlines') in the `table_body`.
+    table_body_border_top_style,table_body_border_top_width,table_body_border_top_color,table_body_border_bottom_style,table_body_border_bottom_width,table_body_border_bottom_color
+        The style, width, and color properties for all top and bottom borders of the
+        `table_body` location.
+    stub_border_style,stub_border_width,stub_border_color
+        The style, width, and color properties for the vertical border of the table stub.
+    stub_row_group_font_size,stub_row_group_font_weight,stub_row_group_text_transform,stub_row_group_border_style,stub_row_group_border_width,stub_row_group_border_color
+        Options for the row group column in the stub (made possible when using
+        `row_group_as_column=True`). The defaults for these options mirror that of the `stub.*`
+        variants (except for `stub_row_group_border_width`, which is `"1px"` instead of
+        `"2px"`).
+    row_group_default_label
+        An option to set a default row group label for any rows not formally placed in a row
+        group named by `group` in any call of `tab_row_group()`. If this is set as `None` and
+        there are rows that haven't been placed into a row group (where one or more row groups
+        already exist), those rows will be automatically placed into a row group without a label.
+    row_group_as_column
+        How should row groups be structured? By default, they are separate rows that lie above
+        the each of the groups. Setting this to `True` will structure row group labels are
+        columns to the far left of the table.
+    summary_row_border_style,summary_row_border_width,summary_row_border_color
+        The style, width, and color properties for all horizontal borders of the `summary_row`
+        location.
+    grand_summary_row_border_style,grand_summary_row_border_width,grand_summary_row_border_color
+        The style, width, and color properties for the top borders of the `grand_summary_row`
+        location.
+    footnotes_border_bottom_style,footnotes_border_bottom_width,footnotes_border_bottom_color
+        The style, width, and color properties for the bottom border of the `footnotes`
+        location.
+    footnotes_border_lr_style,footnotes_border_lr_width,footnotes_border_lr_color
+        The style, width, and color properties for the left and right borders of the
+        `footnotes` location.
+    footnotes_marks
+        The set of sequential marks used to reference and identify each of the footnotes (same
+        input as the [opt_footnote_marks()] function. We can supply a list that represents the
+        series of footnote marks. This list is recycled when its usage goes beyond the length of
+        the set. At each cycle, the marks are simply combined (e.g., `*` -> `**` -> `***`). The
+        option exists for providing keywords for certain types of footnote marks. The keyword
+        `"numbers"` (the default, indicating that we want to use numeric marks). We can use
+        lowercase `"letters"` or uppercase `"LETTERS"`. There is the option for using a
+        traditional symbol set where `"standard"` provides four symbols, and, `"extended"` adds
+        two more symbols, making six.
+    footnotes_multiline,source_notes_multiline
+        An option to either put footnotes and source notes in separate lines (the default, or
+        `True`) or render them as a continuous line of text with `footnotes_sep` providing the
+        separator (by default `" "`) between notes.
+    footnotes_sep,source_notes_sep
+        The separating characters between adjacent footnotes and source notes in their
+        respective footer sections when rendered as a continuous line of text (when
+        `footnotes_multiline is False`). The default value is a single space character (`" "`).
+    source_notes_border_bottom_style,source_notes_border_bottom_width,source_notes_border_bottom_color
+        The style, width, and color properties for the bottom border of the `source_notes`
+        location.
+    source_notes_border_lr_style,source_notes_border_lr_width,source_notes_border_lr_color
+        The style, width, and color properties for the left and right borders of the
+        `source_notes` location.
+    row_striping_background_color
+        The background color for striped table body rows. A color name or a hexadecimal color
+        code should be provided.
+    row_striping_include_stub
+        An option for whether to include the stub when striping rows.
+    row_striping_include_table_body
+        An option for whether to include the table body when striping rows.
 
-        modified_args = {k: v for k, v in saved_args.items() if v is not None}
+    Returns
+    -------
+    GT
+        The GT object is returned.
+    """
+    saved_args = locals()
 
-        for i in range(len(modified_args)):
-            self._options._set_option_value(
-                option=list(modified_args.keys())[i], value=list(modified_args.values())[i]
-            )
+    del saved_args["self"]
 
-        return self
+    modified_args = {k: v for k, v in saved_args.items() if v is not None}
 
-    def opt_footnote_marks(self, marks: Union[str, List[str]] = "numbers"):
-        """
-        Option to modify the set of footnote marks
-        Alter the footnote marks for any footnotes that may be present in the table. Either a list
-        of marks can be provided (including Unicode characters), or, a specific keyword could be
-        used to signify a preset sequence. This method serves as a shortcut for using
-        `tab_options(footnotes_marks=<marks>)`
+    for i in range(len(modified_args)):
+        self._options._set_option_value(
+            option=list(modified_args.keys())[i], value=list(modified_args.values())[i]
+        )
 
-        We can supply a list of strings will represent the series of marks. The series of footnote
-        marks is recycled when its usage goes beyond the length of the set. At each cycle, the marks
-        are simply doubled, tripled, and so on (e.g., `*` -> `**` -> `***`). The option exists for
-        providing keywords for certain types of footnote marks. The keywords are
+    return self
 
-        - `"numbers"`: numeric marks, they begin from 1 and these marks are not subject to recycling
-        behavior
-        - `"letters"`: lowercase alphabetic marks. Same as using the `gt.letters()` function which
-        produces a list of 26 lowercase letters from the Roman alphabet
-        - `"LETTERS"`: uppercase alphabetic marks. Same as using the `gt.LETTERS()` function which
-        produces a list of 26 uppercase letters from the Roman alphabet
-        - `"standard"`: symbolic marks, four symbols in total
-        - `"extended"`: symbolic marks, extends the standard set by adding two more symbols, making
-        six
 
-        Parameters
-        ----------
+def opt_footnote_marks(self: GTSelf, marks: Union[str, List[str]] = "numbers") -> GTSelf:
+    """
+    Option to modify the set of footnote marks
+    Alter the footnote marks for any footnotes that may be present in the table. Either a list
+    of marks can be provided (including Unicode characters), or, a specific keyword could be
+    used to signify a preset sequence. This method serves as a shortcut for using
+    `tab_options(footnotes_marks=<marks>)`
 
-        marks : Union[str, List[str]]
-            Either a list of strings that will represent the series of marks or a keyword string
-            that represents a preset sequence of marks. The valid keywords are: `"numbers"` (for
-            numeric marks), `"letters"` and `"LETTERS"` (for lowercase and uppercase alphabetic
-            marks), `"standard"` (for a traditional set of four symbol marks), and `"extended"`
-            (which adds two more symbols to the standard set).
+    We can supply a list of strings will represent the series of marks. The series of footnote
+    marks is recycled when its usage goes beyond the length of the set. At each cycle, the marks
+    are simply doubled, tripled, and so on (e.g., `*` -> `**` -> `***`). The option exists for
+    providing keywords for certain types of footnote marks. The keywords are
 
-        Returns
-        -------
-        GT
-            The GT object is returned.
-        """
-        # Validate the marks keyword passed in as a string
-        if marks is str:
-            marks = _utils._match_arg(
-                x=cast(str, marks),
-                lst=["numbers", "letters", "LETTERS", "standard", "extended"],
-            )
+    - `"numbers"`: numeric marks, they begin from 1 and these marks are not subject to recycling
+    behavior
+    - `"letters"`: lowercase alphabetic marks. Same as using the `gt.letters()` function which
+    produces a list of 26 lowercase letters from the Roman alphabet
+    - `"LETTERS"`: uppercase alphabetic marks. Same as using the `gt.LETTERS()` function which
+    produces a list of 26 uppercase letters from the Roman alphabet
+    - `"standard"`: symbolic marks, four symbols in total
+    - `"extended"`: symbolic marks, extends the standard set by adding two more symbols, making
+    six
 
-        self.tab_options(footnotes_marks=marks)
-        return self
+    Parameters
+    ----------
 
-    def opt_row_striping(self, row_striping: bool = True):
-        """
-        Option to add or remove row striping.
+    marks : Union[str, List[str]]
+        Either a list of strings that will represent the series of marks or a keyword string
+        that represents a preset sequence of marks. The valid keywords are: `"numbers"` (for
+        numeric marks), `"letters"` and `"LETTERS"` (for lowercase and uppercase alphabetic
+        marks), `"standard"` (for a traditional set of four symbol marks), and `"extended"`
+        (which adds two more symbols to the standard set).
 
-        By default, a gt*table does not have row striping enabled. However, this method allows us to
-        easily enable or disable striped rows in the table body. It's a convenient shortcut for
-        `gt.tab_options(row_striping_include_table_body=<True|False>)`.
+    Returns
+    -------
+    GT
+        The GT object is returned.
+    """
+    # Validate the marks keyword passed in as a string
+    if marks is str:
+        marks = _utils._match_arg(
+            x=cast(str, marks),
+            lst=["numbers", "letters", "LETTERS", "standard", "extended"],
+        )
 
-        Parameters
-        ----------
-        row_striping : bool
-            A boolean that indicates whether row striping should be added or removed. Defaults to
-            `True`.
+    return tab_options(self, footnotes_marks=marks)
 
-        Returns
-        -------
-        GT
-            The GT object is returned.
-        """
-        self.tab_options(row_striping_include_table_body=row_striping)
-        return self
 
-    def opt_align_table_header(self, align: str = "center"):
-        """
-        Option to align the table header.
+def opt_row_striping(self: GTSelf, row_striping: bool = True) -> GTSelf:
+    """
+    Option to add or remove row striping.
 
-        By default, a table header added to a gt table has center alignment for both the title and
-        the subtitle elements. This function allows us to easily set the horizontal alignment of the
-        title and subtitle to the left or right by using the `"align"` argument. This function
-        serves as a convenient shortcut for `gt.tab_options(heading.align=<align>)`.
+    By default, a gt*table does not have row striping enabled. However, this method allows us to
+    easily enable or disable striped rows in the table body. It's a convenient shortcut for
+    `gt.tab_options(row_striping_include_table_body=<True|False>)`.
 
-        Parameters
-        ----------
-        align : str
-            The alignment of the title and subtitle elements in the table header. Options are
-            `"center"` (the default), `"left"`, or `"right"`.
+    Parameters
+    ----------
+    row_striping : bool
+        A boolean that indicates whether row striping should be added or removed. Defaults to
+        `True`.
 
-        Returns
-        -------
-        GT
-            The GT object is returned.
-        """
+    Returns
+    -------
+    GT
+        The GT object is returned.
+    """
+    return tab_options(self, row_striping_include_table_body=row_striping)
 
-        align = _utils._match_arg(x=align, lst=["left", "center", "right"])
 
-        self.tab_options(heading_align=align)
-        return self
+def opt_align_table_header(self: GTSelf, align: str = "center") -> GTSelf:
+    """
+    Option to align the table header.
 
-    # TODO: create the `opt_vertical_padding()` method
+    By default, a table header added to a gt table has center alignment for both the title and
+    the subtitle elements. This function allows us to easily set the horizontal alignment of the
+    title and subtitle to the left or right by using the `"align"` argument. This function
+    serves as a convenient shortcut for `gt.tab_options(heading.align=<align>)`.
 
-    # TODO: create the `opt_horizontal_padding()` method
+    Parameters
+    ----------
+    align : str
+        The alignment of the title and subtitle elements in the table header. Options are
+        `"center"` (the default), `"left"`, or `"right"`.
 
-    def opt_all_caps(
-        self,
-        all_caps: bool = True,
-        locations: Union[str, List[str]] = ["column_labels", "stub", "row_group"],
-    ):
-        """
-        Option to use all caps in select table locations.
+    Returns
+    -------
+    GT
+        The GT object is returned.
+    """
 
-        Sometimes an all-capitalized look is suitable for a table. By using `opt_all_caps()`, we can
-        transform characters in the column labels, the stub, and in all row groups in this way (and
-        there's control over which of these locations are transformed). This function serves as a
-        convenient shortcut for `tab_options(<location>.text_transform="uppercase",
-        <location>.font.size=gt.pct(80), <location>.font.weight="bolder")` (for all `locations`
-        selected).
+    align = _utils._match_arg(x=align, lst=["left", "center", "right"])
 
-        Parameters
-        ----------
-        all_caps : bool
-            Indicates whether the text transformation to all caps should be performed (`True`, the
-            default) or reset to default values (`False`) for the `locations` targeted.
+    return tab_options(self, heading_align=align)
 
-        locations : Union[str, List[str]]
-            Which locations should undergo this text transformation? By default it includes all of
-            the `"column_labels"`, the `"stub"`, and the `"row_group"` locations. However, we could
-            just choose one or two of those.
 
-        Returns
-        -------
-        GT
-            The GT object is returned.
-        """
+# TODO: create the `opt_vertical_padding()` method
 
-        # If providing a scalar string value, normalize it to be in a list
-        if type(locations).__name__ != "list":
-            locations = _utils._str_scalar_to_list(cast(str, locations))
+# TODO: create the `opt_horizontal_padding()` method
 
-        # Ensure that the `locations` value is a list of strings
-        _utils._assert_str_list(locations)
 
-        # TODO: Ensure that all values within `locations` are valid
+def opt_all_caps(
+    self: GTSelf,
+    all_caps: bool = True,
+    locations: Union[str, List[str]] = ["column_labels", "stub", "row_group"],
+) -> GTSelf:
+    """
+    Option to use all caps in select table locations.
 
-        # Set new options for `locations` selected, or, reset to default options
-        # if `all_caps` is False
-        if all_caps is True:
-            if "column_labels" in locations:
-                self.tab_options(column_labels_font_size="80%")
-                self.tab_options(column_labels_font_weight="bolder")
-                self.tab_options(column_labels_text_transform="uppercase")
+    Sometimes an all-capitalized look is suitable for a table. By using `opt_all_caps()`, we can
+    transform characters in the column labels, the stub, and in all row groups in this way (and
+    there's control over which of these locations are transformed). This function serves as a
+    convenient shortcut for `tab_options(<location>.text_transform="uppercase",
+    <location>.font.size=gt.pct(80), <location>.font.weight="bolder")` (for all `locations`
+    selected).
 
-            if "stub" in locations:
-                self.tab_options(stub_font_size="80%")
-                self.tab_options(stub_font_weight="bolder")
-                self.tab_options(stub_text_transform="uppercase")
+    Parameters
+    ----------
+    all_caps : bool
+        Indicates whether the text transformation to all caps should be performed (`True`, the
+        default) or reset to default values (`False`) for the `locations` targeted.
 
-            if "row_group" in locations:
-                self.tab_options(row_group_font_size="80%")
-                self.tab_options(row_group_font_weight="bolder")
-                self.tab_options(row_group_text_transform="uppercase")
+    locations : Union[str, List[str]]
+        Which locations should undergo this text transformation? By default it includes all of
+        the `"column_labels"`, the `"stub"`, and the `"row_group"` locations. However, we could
+        just choose one or two of those.
 
-        else:
-            self.tab_options(column_labels_font_size="100%")
-            self.tab_options(column_labels_font_weight="normal")
-            self.tab_options(column_labels_text_transform="inherit")
-            self.tab_options(stub_font_size="100%")
-            self.tab_options(stub_font_weight="initial")
-            self.tab_options(stub_text_transform="inherit")
-            self.tab_options(row_group_font_size="100%")
-            self.tab_options(row_group_font_weight="initial")
-            self.tab_options(row_group_text_transform="inherit")
+    Returns
+    -------
+    GT
+        The GT object is returned.
+    """
 
-        return self
+    # If providing a scalar string value, normalize it to be in a list
+    if type(locations).__name__ != "list":
+        locations = _utils._str_scalar_to_list(cast(str, locations))
+
+    # Ensure that the `locations` value is a list of strings
+    _utils._assert_str_list(locations)
+
+    # TODO: Ensure that all values within `locations` are valid
+
+    # Set new options for `locations` selected, or, reset to default options
+    # if `all_caps` is False
+    # TODO: the code constantly reassigns res, in order to prepare for a
+    # world where options are not mutating the GT options object.
+    # TODO: is there a way to set multiple options at once?
+    res = self
+    if all_caps is True:
+        if "column_labels" in locations:
+            res = tab_options(res, column_labels_font_size="80%")
+            res = tab_options(res, column_labels_font_weight="bolder")
+            res = tab_options(res, column_labels_text_transform="uppercase")
+
+        if "stub" in locations:
+            res = tab_options(res, stub_font_size="80%")
+            res = tab_options(res, stub_font_weight="bolder")
+            res = tab_options(res, stub_text_transform="uppercase")
+
+        if "row_group" in locations:
+            res = tab_options(res, row_group_font_size="80%")
+            res = tab_options(res, row_group_font_weight="bolder")
+            res = tab_options(res, row_group_text_transform="uppercase")
+
+    else:
+        res = tab_options(res, column_labels_font_size="100%")
+        res = tab_options(res, column_labels_font_weight="normal")
+        res = tab_options(res, column_labels_text_transform="inherit")
+        res = tab_options(res, stub_font_size="100%")
+        res = tab_options(res, stub_font_weight="initial")
+        res = tab_options(res, stub_text_transform="inherit")
+        res = tab_options(res, row_group_font_size="100%")
+        res = tab_options(res, row_group_font_weight="initial")
+        res = tab_options(res, row_group_text_transform="inherit")
+
+    return res

--- a/great_tables/_row_groups.py
+++ b/great_tables/_row_groups.py
@@ -1,5 +1,1 @@
 from __future__ import annotations
-
-
-class RowGroupsAPI:
-    pass

--- a/great_tables/_stubhead.py
+++ b/great_tables/_stubhead.py
@@ -51,8 +51,4 @@ class StubheadAPI:
         ```
         """
 
-        result = copy(self)
-
-        result._stubhead = label
-
-        return result
+        return self._replace(_stubhead=label)

--- a/great_tables/_stubhead.py
+++ b/great_tables/_stubhead.py
@@ -1,54 +1,57 @@
 from __future__ import annotations
-from typing import Union
+from typing import TYPE_CHECKING, Union
 from typing_extensions import Self
 from copy import copy
 from ._text import Text
 
 
-class StubheadAPI:
-    def tab_stubhead(self, label: Union[str, Text]) -> Self:
-        """
-        Add label text to the stubhead.
+if TYPE_CHECKING:
+    from ._types import GTSelf
 
-        Add a label to the stubhead of a table. The stubhead is the lone element that is positioned
-        left of the column labels, and above the stub. If a stub does not exist, then there is no
-        stubhead (so no change will be made when using this method in that case). We have the
-        flexibility to use Markdown formatting for the stubhead label (through use of the `md()`
-        helper function). Furthermore, we can use HTML for the stubhead label so long as we also use
-        the `html()` helper function.
 
-        Parameters
-        ----------
-        label : str
-            The text to be used as the stubhead label. We can optionally use the `md()` and `html()`
-            functions to style the text as Markdown or to retain HTML elements in the text.
+def tab_stubhead(self: GTSelf, label: Union[str, Text]) -> GTSelf:
+    """
+    Add label text to the stubhead.
 
-        Returns
-        -------
-        GT
-            The GT object is returned.
+    Add a label to the stubhead of a table. The stubhead is the lone element that is positioned
+    left of the column labels, and above the stub. If a stub does not exist, then there is no
+    stubhead (so no change will be made when using this method in that case). We have the
+    flexibility to use Markdown formatting for the stubhead label (through use of the `md()`
+    helper function). Furthermore, we can use HTML for the stubhead label so long as we also use
+    the `html()` helper function.
 
-        Examples
-        --------
-        Using a small subset of the `gtcars` dataset, we can create a table with row labels. Since
-        we have row labels in the stub (via use of `rowname_col="model"` in the `GT()` call) we have
-        a stubhead, so, let's add a stubhead label (`"car"`) with the `tab_stubhead()` method to
-        describe what's in the stub.
+    Parameters
+    ----------
+    label : str
+        The text to be used as the stubhead label. We can optionally use the `md()` and `html()`
+        functions to style the text as Markdown or to retain HTML elements in the text.
 
-        ```{python}
-        import great_tables as gt
+    Returns
+    -------
+    GT
+        The GT object is returned.
 
-        gtcars_mini = gt.gtcars[[\"model\", \"year\", \"hp\", \"trq\"]].head(5)
+    Examples
+    --------
+    Using a small subset of the `gtcars` dataset, we can create a table with row labels. Since
+    we have row labels in the stub (via use of `rowname_col="model"` in the `GT()` call) we have
+    a stubhead, so, let's add a stubhead label (`"car"`) with the `tab_stubhead()` method to
+    describe what's in the stub.
 
-        gt.GT(gtcars_mini, rowname_col=\"model\").tab_stubhead(label=\"car\")
-        ```
+    ```{python}
+    import great_tables as gt
 
-        We can also use Markdown formatting for the stubhead label. In this example, we'll use
-        `md("*Car*")` to make the label italicized.
+    gtcars_mini = gt.gtcars[[\"model\", \"year\", \"hp\", \"trq\"]].head(5)
 
-        ```{python}
-        gt.GT(gtcars_mini, rowname_col="model").tab_stubhead(label=gt.md("*Car*"))
-        ```
-        """
+    gt.GT(gtcars_mini, rowname_col=\"model\").tab_stubhead(label=\"car\")
+    ```
 
-        return self._replace(_stubhead=label)
+    We can also use Markdown formatting for the stubhead label. In this example, we'll use
+    `md("*Car*")` to make the label italicized.
+
+    ```{python}
+    gt.GT(gtcars_mini, rowname_col="model").tab_stubhead(label=gt.md("*Car*"))
+    ```
+    """
+
+    return self._replace(_stubhead=label)

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -50,7 +50,7 @@ def create_columns_component_h(data: GTData) -> str:
     """
 
     # Should the column labels be hidden?
-    column_labels_hidden: bool = data._options._get_option_value(option="column_labels_hidden")
+    column_labels_hidden: bool = data._options.column_labels_hidden.value
 
     if column_labels_hidden:
         return ""
@@ -615,7 +615,7 @@ def _get_spanners_matrix_height(
 # Get the attributes needed for the <table> tag
 def _get_table_defs(data: GTData):
     # Get the `table-layout` value, which is set in `_options`
-    table_layout = data._options._get_option_value(option="table_layout")
+    table_layout = data._options.table_layout.value
     table_style = f"table-layout: {table_layout};"
 
     # Get the number of columns that have a width set
@@ -627,7 +627,7 @@ def _get_table_defs(data: GTData):
         return dict(table_style=None, table_colgroups=None)
 
     # Get the table's width (which or may not have been set)
-    table_width = data._options._get_option_value(option="table_width")
+    table_width = data._options.table_width.value
 
     # Get all the widths for the columns as a list where None values mean
     # that the width is not set for that column

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -32,7 +32,13 @@ from great_tables._formats import (
 )
 from great_tables._heading import HeadingAPI
 from great_tables._locale import LocaleAPI
-from great_tables._options import OptionsAPI
+from great_tables._options import (
+    tab_options,
+    opt_align_table_header,
+    opt_all_caps,
+    opt_footnote_marks,
+    opt_row_striping,
+)
 from great_tables._row_groups import RowGroupsAPI
 from great_tables._source_notes import tab_source_note
 from great_tables._spanners import (
@@ -85,7 +91,6 @@ class GT(
     FootnotesAPI,
     LocaleAPI,
     FormatsAPI,
-    OptionsAPI,
 ):
     """
     Create a **great_tables** object.
@@ -226,6 +231,12 @@ class GT(
     fmt_date = fmt_date
     fmt_time = fmt_time
     fmt_markdown = fmt_markdown
+
+    tab_options = tab_options
+    opt_align_table_header = opt_align_table_header
+    opt_all_caps = opt_all_caps
+    opt_footnote_marks = opt_footnote_marks
+    opt_row_striping = opt_row_striping
 
     tab_spanner = tab_spanner
     tab_source_note = tab_source_note

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -30,7 +30,6 @@ from great_tables._formats import (
     fmt_markdown,
 )
 from great_tables._heading import tab_header
-from great_tables._locale import LocaleAPI
 from great_tables._options import (
     tab_options,
     opt_align_table_header,
@@ -47,7 +46,7 @@ from great_tables._spanners import (
     cols_hide,
 )
 from great_tables._stub import reorder_stub_df
-from great_tables._stubhead import StubheadAPI
+from great_tables._stubhead import tab_stubhead
 from great_tables._utils_render_html import (
     create_heading_component_h,
     create_columns_component_h,
@@ -83,8 +82,6 @@ __all__ = ["GT"]
 # =============================================================================
 class GT(
     GTData,
-    StubheadAPI,
-    LocaleAPI,
     FormatsAPI,
 ):
     """
@@ -241,6 +238,8 @@ class GT(
     cols_move_to_start = cols_move_to_start
     cols_move_to_end = cols_move_to_end
     cols_hide = cols_hide
+
+    tab_stubhead = tab_stubhead
 
     # -----
 

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -15,7 +15,7 @@ from great_tables import _utils
 
 # Rewrite main gt imports to use relative imports of APIs ----
 from great_tables._body import body_reassemble
-from great_tables._boxhead import BoxheadAPI
+from great_tables._boxhead import cols_align, cols_label
 from great_tables._footnotes import FootnotesAPI
 from great_tables._formats import (
     FormatsAPI,
@@ -79,7 +79,6 @@ __all__ = ["GT"]
 # =============================================================================
 class GT(
     GTData,
-    BoxheadAPI,
     RowGroupsAPI,
     HeadingAPI,
     StubheadAPI,
@@ -215,6 +214,8 @@ class GT(
         super().__init__(**gtdata.__dict__)
 
     # TODO: Refactor API methods -----
+    cols_align = cols_align
+    cols_label = cols_label
     fmt_number = fmt_number
     fmt_integer = fmt_integer
     fmt_percent = fmt_percent

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -16,7 +16,6 @@ from great_tables import _utils
 # Rewrite main gt imports to use relative imports of APIs ----
 from great_tables._body import body_reassemble
 from great_tables._boxhead import cols_align, cols_label
-from great_tables._footnotes import FootnotesAPI
 from great_tables._formats import (
     FormatsAPI,
     fmt_number,
@@ -88,7 +87,6 @@ class GT(
     RowGroupsAPI,
     HeadingAPI,
     StubheadAPI,
-    FootnotesAPI,
     LocaleAPI,
     FormatsAPI,
 ):

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -38,7 +38,6 @@ from great_tables._options import (
     opt_footnote_marks,
     opt_row_striping,
 )
-from great_tables._row_groups import RowGroupsAPI
 from great_tables._source_notes import tab_source_note
 from great_tables._spanners import (
     tab_spanner,
@@ -84,7 +83,6 @@ __all__ = ["GT"]
 # =============================================================================
 class GT(
     GTData,
-    RowGroupsAPI,
     StubheadAPI,
     LocaleAPI,
     FormatsAPI,

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -17,7 +17,7 @@ from great_tables import _utils
 from great_tables._body import body_reassemble
 from great_tables._boxhead import cols_align, cols_label
 from great_tables._formats import (
-    FormatsAPI,
+    fmt,
     fmt_number,
     fmt_percent,
     fmt_integer,
@@ -82,7 +82,6 @@ __all__ = ["GT"]
 # =============================================================================
 class GT(
     GTData,
-    FormatsAPI,
 ):
     """
     Create a **great_tables** object.
@@ -213,6 +212,7 @@ class GT(
     # TODO: Refactor API methods -----
     cols_align = cols_align
     cols_label = cols_label
+    fmt = fmt
     fmt_number = fmt_number
     fmt_integer = fmt_integer
     fmt_percent = fmt_percent

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, List, Optional
 from typing_extensions import Self
-from dataclasses import asdict, fields, astuple
+from dataclasses import fields
 
 import pkg_resources
 
@@ -13,9 +13,6 @@ import copy
 from great_tables._gt_data import GTData
 
 # Main gt imports ----
-from great_tables import _utils
-
-# Rewrite main gt imports to use relative imports of APIs ----
 from great_tables._body import body_reassemble
 from great_tables._boxhead import cols_align, cols_label
 from great_tables._formats import (
@@ -50,7 +47,7 @@ from great_tables._spanners import (
 )
 from great_tables._stub import reorder_stub_df
 from great_tables._stubhead import tab_stubhead
-from great_tables._tbl_data import n_rows, _get_cell, copy_frame
+from great_tables._tbl_data import n_rows, _get_cell
 from great_tables._utils import _as_css_font_family_attr, _unique_set
 from great_tables._utils_render_html import (
     create_heading_component_h,

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -29,7 +29,7 @@ from great_tables._formats import (
     fmt_time,
     fmt_markdown,
 )
-from great_tables._heading import HeadingAPI
+from great_tables._heading import tab_header
 from great_tables._locale import LocaleAPI
 from great_tables._options import (
     tab_options,
@@ -85,7 +85,6 @@ __all__ = ["GT"]
 class GT(
     GTData,
     RowGroupsAPI,
-    HeadingAPI,
     StubheadAPI,
     LocaleAPI,
     FormatsAPI,
@@ -235,6 +234,8 @@ class GT(
     opt_all_caps = opt_all_caps
     opt_footnote_marks = opt_footnote_marks
     opt_row_striping = opt_row_striping
+
+    tab_header = tab_header
 
     tab_spanner = tab_spanner
     tab_source_note = tab_source_note

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -8,7 +8,7 @@ from great_tables._utils_render_html import create_body_component_h
 from great_tables._formats import (
     _format_number_fixed_decimals,
     _expand_exponential_to_full_string,
-    FormatsAPI,
+    fmt,
 )
 
 
@@ -22,7 +22,7 @@ def assert_rendered_body(snapshot, gt):
 def test_format_fns():
     df = pd.DataFrame({"x": [1, 2]})
     gt = GT(df)
-    FormatsAPI.fmt(gt, fns=lambda x: str(x + 1), columns=["x"])
+    fmt(gt, fns=lambda x: str(x + 1), columns=["x"])
 
     formats_fn = gt._formats[0]
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -22,9 +22,9 @@ def assert_rendered_body(snapshot, gt):
 def test_format_fns():
     df = pd.DataFrame({"x": [1, 2]})
     gt = GT(df)
-    fmt(gt, fns=lambda x: str(x + 1), columns=["x"])
+    new_gt = fmt(gt, fns=lambda x: str(x + 1), columns=["x"])
 
-    formats_fn = gt._formats[0]
+    formats_fn = new_gt._formats[0]
 
     res = list(map(formats_fn.func.default, df["x"]))
     assert res == ["2", "3"]


### PR DESCRIPTION
This PR freezes our dataclasses so we couldn't mutate them if we wanted to†. The `GTData._replace()` method can be used to return a copy of GTData, with specific attributes replaced.

I'm going to take out the API classes, so we can type their methods a bit better (currently, the type system doesn't know they can access a `._replace` method)

†: except by using `super().__setattr__("<attribute_name>", <value>)`, which should be used sparingly!

TODO:

* code paths it'd be helpful to tour Michael through:
  - locales
  - options