### PR TITLE
refactor!: remove datasets from top-level module (except exibble)

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -114,16 +114,16 @@ quartodoc:
         If you have single values (or lists of them) in need of formatting, we have a set of
         `val_fmt_*()` functions that have been adapted from the corresponding `fmt_*()` methods.
       contents:
-        - val_fmt_number
-        - val_fmt_integer
-        - val_fmt_scientific
-        - val_fmt_percent
-        - val_fmt_currency
-        - val_fmt_roman
-        - val_fmt_bytes
-        - val_fmt_date
-        - val_fmt_time
-        - val_fmt_markdown
+        - vals.fmt_number
+        - vals.fmt_integer
+        - vals.fmt_scientific
+        - vals.fmt_percent
+        - vals.fmt_currency
+        - vals.fmt_roman
+        - vals.fmt_bytes
+        - vals.fmt_date
+        - vals.fmt_time
+        - vals.fmt_markdown
     - title: Built in datasets
       desc: >
         The **great_tables** package is equipped with ten datasets that come in all shapes and

--- a/docs/examples-qmd/GT.qmd
+++ b/docs/examples-qmd/GT.qmd
@@ -7,7 +7,7 @@ html-table-processing: none
 
 ```{python}
 import great_tables as gt
-from great_tables import exibble
+from great_tables.data import exibble
 
 ```
 

--- a/docs/examples-qmd/fmt-number.qmd
+++ b/docs/examples-qmd/fmt-number.qmd
@@ -7,7 +7,7 @@ html-table-processing: none
 
 ```{python}
 import great_tables as gt
-from great_tables import exibble, countrypops
+from great_tables.data import exibble, countrypops
 ```
 
 Use the exibble dataset to create a gt table. With the `fmt_number()` method, we'll format the num column to have three decimal places (with `decimals=3`) and omit the use of digit separators (with `use_seps=False`).

--- a/docs/examples-qmd/table-manipulation.qmd
+++ b/docs/examples-qmd/table-manipulation.qmd
@@ -6,7 +6,7 @@ jupyter: python3
 
 ```{python}
 import great_tables as gt
-from great_tables import exibble, countrypops, gtcars  # , md, html
+from great_tables.data import exibble, countrypops, gtcars  # , md, html
 
 from siuba import *
 

--- a/docs/examples/index.qmd
+++ b/docs/examples/index.qmd
@@ -39,6 +39,7 @@ islands_mini = islands.head(10)
 :::{.g-col-6}
 
 ```{python}
+from great_tables import GT, md, html
 from great_tables.data import airquality
 
 airquality_m = airquality.head(10).assign(Year = 1973)
@@ -74,7 +75,8 @@ gt_airquality
 :::{.g-col-6}
 
 ```{python}
-from great_tables import GT, countrypops
+from great_tables import GT
+from great_tables.data import countrypops
 
 import polars as pl
 import polars.selectors as cs

--- a/docs/get-started/basic-formatting.qmd
+++ b/docs/get-started/basic-formatting.qmd
@@ -7,7 +7,8 @@ html-table-processing: none
 The values within the table body, specifically those within the body cells, can be formatted with a large selection of `fmt_*()` methods like `fmt_number()`, `fmt_scientific()`, and more. Let's use a portion of the `exibble` dataset and introduce some formatting to the cell values. First, we'll generate the basic GT object and take a look at the table without any cell formatting applied.
 
 ```{python}
-from great_tables import GT, exibble
+from great_tables import GT
+from great_tables.data import exibble
 from great_tables import vals
 
 gt_ex = GT(exibble[["num", "date", "time", "currency"]].head(5))

--- a/docs/get-started/column-selection.qmd
+++ b/docs/get-started/column-selection.qmd
@@ -16,7 +16,8 @@ However, we can specify columns using any of the following:
 * A function that takes a string and returns True or False.
 
 ```{python}
-from great_tables import GT, exibble
+from great_tables import GT
+from great_tables.data import exibble
 
 gt_ex = GT(exibble)
 

--- a/great_tables/__init__.py
+++ b/great_tables/__init__.py
@@ -8,39 +8,34 @@ del _v
 # Main gt imports ----
 
 from .gt import GT
-from great_tables.data import *
-
-# from ._base_api import *
-# from ._body import *
-# from ._boxhead import *
-# from ._footnotes import *
-# from ._formats import *
-# from ._heading import *
+from . import data
+from . import vals
 from ._helpers import letters, LETTERS, px, pct, md, html, random_id
-from ._formats_vals import (
-    val_fmt_number,
-    val_fmt_integer,
-    val_fmt_scientific,
-    val_fmt_percent,
-    val_fmt_currency,
-    val_fmt_roman,
-    val_fmt_bytes,
-    val_fmt_date,
-    val_fmt_time,
-    val_fmt_markdown,
+from .data import exibble
+
+
+__all__ = (
+    "GT",
+    "exibble",
+    "letters",
+    "LETTERS",
+    "px",
+    "pct",
+    "md",
+    "html",
+    "random_id",
 )
 
-# from ._locale import *
-# from ._options import *
-# from ._row_groups import *
-# from ._source_notes import *
-# from ._spanners import *
-# from ._stub import *
-# from ._stubhead import *
-# from ._styles import *
-# from ._table import *
-# from ._tbl_data import *
-# from ._text import *
-# from ._utils import *
 
-#
+def __getattr__(k: str):
+    # datasets are no longer exposed in this module.
+    # this function ensures that we raise a friendly error when people try to import them.
+
+    dataset_names = [entry for entry in dir(data) if not entry.startswith("_")]
+    if k in dataset_names:
+        raise ImportError(
+            "Cannot import dataset from top-level of package. Please import from data submodule:"
+            f"\n\nfrom great_tables.data import {k}"
+        )
+    else:
+        raise ImportError(f"cannot import name {k} from great_tables ({__file__})")

--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -50,8 +50,9 @@ def cols_label(self: GTSelf, **kwargs: Any) -> GTSelf:
 
     ```{python}
     import great_tables as gt
+    from great_tables.data import countrypops
 
-    countrypops_mini = gt.countrypops.loc[gt.countrypops[\"country_name\"] == \"Uganda\"][
+    countrypops_mini = countrypops.loc[countrypops[\"country_name\"] == \"Uganda\"][
         [\"country_name\", \"year\", \"population\"]
     ].tail(5)
 
@@ -129,8 +130,9 @@ def cols_align(self: GTSelf, align: str = "left", columns: Optional[str] = None)
 
     ```{python}
     import great_tables as gt
+    from great_tables.data import countrypops
 
-    countrypops_mini = gt.countrypops.loc[gt.countrypops[\"country_name\"] == \"San Marino\"][
+    countrypops_mini = countrypops.loc[countrypops[\"country_name\"] == \"San Marino\"][
         [\"country_name\", \"year\", \"population\"]
     ].tail(5)
 

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -218,7 +218,7 @@ def fmt_number(
     ```{python}
     import great_tables as gt
 
-    gt.GT(gt.exibble).fmt_number(columns=\"num\", decimals=3, use_seps=False)
+    gt.GT(gt.data.exibble).fmt_number(columns=\"num\", decimals=3, use_seps=False)
     ```
 
     See Also
@@ -390,7 +390,7 @@ def fmt_integer(
     ```{python}
     import great_tables as gt
 
-    gt.GT(gt.exibble).fmt_integer(columns=\"num\", use_seps=False)
+    gt.GT(gt.data.exibble).fmt_integer(columns=\"num\", use_seps=False)
     ```
 
     See Also
@@ -590,7 +590,7 @@ def fmt_scientific(
     ```{python}
     import great_tables as gt
 
-    gt.GT(gt.exibble).fmt_scientific(columns=\"num\")
+    gt.GT(gt.data.exibble).fmt_scientific(columns=\"num\")
     ```
 
     See Also
@@ -1047,7 +1047,7 @@ def fmt_currency(
     ```{python}
     import great_tables as gt
 
-    gt.GT(gt.exibble).fmt_currency(columns=\"currency\", decimals=3, use_seps=False)
+    gt.GT(gt.data.exibble).fmt_currency(columns=\"currency\", decimals=3, use_seps=False)
     ```
 
     See Also
@@ -1378,7 +1378,7 @@ def fmt_bytes(
     ```{python}
     import great_tables as gt
 
-    gt.GT(gt.exibble[[\"num\"]]).fmt_bytes(columns=\"num\", standard=\"decimal\")
+    gt.GT(gt.data.exibble[[\"num\"]]).fmt_bytes(columns=\"num\", standard=\"decimal\")
     ```
 
     See Also
@@ -1580,7 +1580,7 @@ def fmt_date(
     ```{python}
     import great_tables as gt
 
-    exibble_mini = gt.exibble[[\"date\", \"time\"]]
+    exibble_mini = gt.data.exibble[[\"date\", \"time\"]]
 
     gt.GT(exibble_mini).fmt_date(columns=\"date\", date_style=\"month_day_year\")
     ```
@@ -1711,7 +1711,7 @@ def fmt_time(
     ```{python}
     import great_tables as gt
 
-    exibble_mini = gt.exibble[[\"date\", \"time\"]]
+    exibble_mini = gt.data.exibble[[\"date\", \"time\"]]
 
     gt.GT(exibble_mini).fmt_time(columns=\"time\", time_style=\"h_m_s_p\")
     ```

--- a/great_tables/_heading.py
+++ b/great_tables/_heading.py
@@ -52,7 +52,7 @@ def tab_header(
     ```{python}
     import great_tables as gt
 
-    gtcars_mini = gt.gtcars[[\"mfr\", \"model\", \"msrp\"]].head(5)
+    gtcars_mini = gt.data.gtcars[[\"mfr\", \"model\", \"msrp\"]].head(5)
 
     (
         gt.GT(gtcars_mini)

--- a/great_tables/_source_notes.py
+++ b/great_tables/_source_notes.py
@@ -38,7 +38,7 @@ def tab_source_note(data: GTSelf, source_note: str) -> GTSelf:
     ```{python}
     import great_tables as gt
 
-    gtcars_mini = gt.gtcars[[\"mfr\", \"model\", \"msrp\"]].head(5)
+    gtcars_mini = gt.data.gtcars[[\"mfr\", \"model\", \"msrp\"]].head(5)
 
     (
         gt.GT(gtcars_mini, rowname_col=\"model\")

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -89,7 +89,8 @@ def tab_spanner(
     ```{python}
     import great_tables as gt
 
-    gtcars_mini = gt.gtcars[[\"model\", \"hp\", \"hp_rpm\", \"trq\", \"trq_rpm\", \"mpg_c\", \"mpg_h\"]].head(10)
+    colnames = [\"model\", \"hp\", \"hp_rpm\", \"trq\", \"trq_rpm\", \"mpg_c\", \"mpg_h\"]
+    gtcars_mini = gt.data.gtcars[colnames].head(10)
 
     (
         gt.GT(gtcars_mini)
@@ -224,8 +225,9 @@ def cols_move(data: GTData, columns: SelectExpr, after: str) -> GTData:
 
     ```{python}
     import great_tables as gt
+    from great_tables.data import countrypops
 
-    countrypops_mini = gt.countrypops.loc[gt.countrypops[\"country_name\"] == \"Japan\"][
+    countrypops_mini = countrypops.loc[countrypops[\"country_name\"] == \"Japan\"][
         [\"country_name\", \"year\", \"population\"]
     ].tail(5)
 
@@ -304,8 +306,9 @@ def cols_move_to_start(data: GTSelf, columns: SelectExpr) -> GTSelf:
 
     ```{python}
     import great_tables as gt
+    from great_tables.data import countrypops
 
-    countrypops_mini = gt.countrypops.loc[gt.countrypops[\"country_name\"] == \"Fiji\"][
+    countrypops_mini = countrypops.loc[countrypops[\"country_name\"] == \"Fiji\"][
         [\"country_name\", \"year\", \"population\"]
     ].tail(5)
 
@@ -370,8 +373,9 @@ def cols_move_to_end(data: GTSelf, columns: SelectExpr) -> GTSelf:
 
     ```{python}
     import great_tables as gt
+    from great_tables.data import countrypops
 
-    countrypops_mini = gt.countrypops.loc[gt.countrypops[\"country_name\"] == \"Benin\"][
+    countrypops_mini = countrypops.loc[countrypops[\"country_name\"] == \"Benin\"][
         [\"country_name\", \"year\", \"population\"]
     ].tail(5)
 

--- a/great_tables/_stubhead.py
+++ b/great_tables/_stubhead.py
@@ -41,7 +41,7 @@ def tab_stubhead(self: GTSelf, label: Union[str, Text]) -> GTSelf:
     ```{python}
     import great_tables as gt
 
-    gtcars_mini = gt.gtcars[[\"model\", \"year\", \"hp\", \"trq\"]].head(5)
+    gtcars_mini = gt.data.gtcars[[\"model\", \"year\", \"hp\", \"trq\"]].head(5)
 
     gt.GT(gtcars_mini, rowname_col=\"model\").tab_stubhead(label=\"car\")
     ```

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -2,7 +2,8 @@ from typing import Union
 import pandas as pd
 import pytest
 
-from great_tables import GT, exibble
+from great_tables import GT
+from great_tables.data import exibble
 from great_tables.gt import _get_column_of_values
 from great_tables._utils_render_html import create_body_component_h
 from great_tables._formats import (


### PR DESCRIPTION
This PR removes all datasets except exibble from the top-level module.

When users attempt to import a dataset that previously worked, they're given a friendly message:

```python
from great_tables import airquality
```

```
ImportError: Cannot import dataset from top-level of package. Please import from data submodule:

from great_tables.data import airquality
```