### PR TITLE
feat: shiny output and renderer for GT

### DIFF
--- a/great_tables/shiny.py
+++ b/great_tables/shiny.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+__all__ = (
+    "output_gt",
+    "render_gt",
+)
+
+from great_tables import GT
+from shiny.render.transformer import (
+    output_transformer,
+    TransformerMetadata,
+    ValueFn,
+    resolve_value_fn,
+)
+from shiny.session._utils import RenderedDeps
+from shiny._namespaces import resolve_id
+
+from htmltools import Tag, div, HTML
+
+
+def output_gt(id: str, placeholder: bool = False) -> Tag:
+    """Output UI for a great_tables table."""
+    return div({"class": "shiny-html-output"}, id=resolve_id(id))
+
+
+@output_transformer(default_ui=output_gt)
+async def GtTransformer(_meta: TransformerMetadata, _fn: ValueFn[GT | None]) -> RenderedDeps | None:
+    value = await resolve_value_fn(_fn)
+    if value is None:
+        return None
+    elif isinstance(value, GT):
+        return _meta.session._process_ui(HTML(value._repr_html_()))
+
+    raise TypeError(f"Expected a great_tables.GT object, got {type(value)}")
+
+
+def render_gt(
+    _fn: GtTransformer.ValueFn | None = None,
+) -> GtTransformer.OutputRenderer | GtTransformer.OutputRendererDecorator:
+    """Render a great_tables table."""
+
+    return GtTransformer(_fn)


### PR DESCRIPTION
This PR adds a `great_tables.shiny` module, with functions for rendering (`render_gt`) and ui output (`output_gt`).

This doesn't necessarily need to go into great_tables. It could also live in shiny. **Let's figure out the shiny's team preference, since it is early days on this type of extending in shiny.**

Here is a demo shiny app:

```python
from shiny import App, ui

from great_tables import GT, exibble
import great_tables.shiny as gts


app_ui = ui.page_fluid(gts.output_gt("table"))


def server(input, output, session):
    @output
    @gts.render_gt
    def table():
        return GT(exibble)


app = App(app_ui, server)
```

Alternatively, it seems like shiny should have a mechanism to let classes like `GT` hook into output_ui? Something similar to the `._repr_html_()` method? Or maybe that exact method itself (this is exactly what we call in the shiny Transformer anyway)?