### PR TITLE
Implement the `tab_style()` method

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -98,6 +98,12 @@ quartodoc:
         - GT.cols_move
         - GT.cols_move_to_start
         - GT.cols_move_to_end
+    - title: Selection and Styling Classes
+      contents:
+        - loc.body
+        - style.fill
+        - style.text
+        - style.borders
     - title: Helper functions
       desc: >
         An assortment of helper functions is available in the **great_tables** package. The `md()`

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -98,7 +98,12 @@ quartodoc:
         - GT.cols_move
         - GT.cols_move_to_start
         - GT.cols_move_to_end
-    - title: Selection and Styling Classes
+    - title: Location Targeting and Styling Classes
+      desc: >
+        Location targeting is a powerful feature of **great_tables**. It allows for the precise
+        selection of table locations for styling (using the `tab_style()` method). The styling
+        classes allow for the specification of the styling properties to be applied to the targeted
+        locations.
       contents:
         - loc.body
         - style.fill

--- a/great_tables/__init__.py
+++ b/great_tables/__init__.py
@@ -26,6 +26,9 @@ __all__ = (
     "md",
     "html",
     "random_id",
+    "vals",
+    "loc",
+    "style",
 )
 
 

--- a/great_tables/__init__.py
+++ b/great_tables/__init__.py
@@ -10,6 +10,8 @@ del _v
 from .gt import GT
 from . import data
 from . import vals
+from . import loc
+from . import style
 from ._helpers import letters, LETTERS, px, pct, md, html, random_id
 from .data import exibble
 

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -787,7 +787,7 @@ class StyleInfo:
     colname: Optional[str] = None
     rownum: Optional[int] = None
     colnum: Optional[int] = None
-    styles: Optional[List[CellStyle]] = field(default_factory=list)
+    styles: Optional[Dict[str, str]] = field(default_factory=dict)
 
 
 Styles: TypeAlias = List[StyleInfo]

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -787,7 +787,7 @@ class StyleInfo:
     colname: Optional[str] = None
     rownum: Optional[int] = None
     colnum: Optional[int] = None
-    styles: Optional[Dict[str, str]] = field(default_factory=dict)
+    styles: List[CellStyle] = field(default_factory=list)
 
 
 Styles: TypeAlias = List[StyleInfo]

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -11,7 +11,7 @@ from typing_extensions import TypeAlias
 # resolve generic, but we need to import at runtime, due to singledispatch looking
 # up annotations
 from ._gt_data import GTData, FootnoteInfo, Spanners, ColInfoTypeEnum, StyleInfo, FootnotePlacement
-from ._tbl_data import eval_select
+from ._tbl_data import eval_select, PlExpr
 from ._styles import CellStyle
 
 
@@ -258,6 +258,11 @@ def resolve_rows_i(
             if (name in target_names or ii in target_pos)
         ]
         return selected
+    elif isinstance(expr, PlExpr):
+        # TODO: decide later on the name supplied to `name`
+        result = data._tbl_data.with_row_count(name="__row_number__").filter(expr)
+        print([(row_names[ii], ii) for ii in result["__row_number__"]])
+        return [(row_names[ii], ii) for ii in result["__row_number__"]]
 
     # TODO: identify filter-like selectors using some backend check
     # e.g. if it's a siuba expression vs tidyselect expression, etc..

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -85,8 +85,8 @@ class LocStub(Loc):
 @dataclass
 class LocBody(Loc):
     # TODO: these can be tidyselectors
-    columns: list[str]
-    rows: list[str]
+    columns: SelectExpr
+    rows: list[str] | str
 
 
 @dataclass

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -94,3 +94,11 @@ class CellStyleBorders(CellStyle):
     style: str
     # TODO: this can include objects like px(1)
     weight: str
+
+    def _to_html_style(self) -> str:
+        border_css_list = []
+        for side in self.sides:
+            border_css_list.append(f"border-{side}: {self.weight} {self.style} {self.color};")
+
+        border_css = "".join(border_css_list)
+        return border_css

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -20,14 +20,14 @@ class CellStyle:
 class CellStyleText:
     """A style specification for text."""
 
-    color: str
-    font: str
-    size: str
-    align: Literal["center", "left", "right", "justify"]
+    color: str | None = None
+    font: str | None = None
+    size: str | None = None
+    align: Literal["center", "left", "right", "justify"] | None = None
     # TODO: this can also be a gt_column object?
-    v_align: Literal["middle", "top", "bottom"]
-    style: Literal["normal", "italic", "oblique"]
-    weight: Literal["normal", "bold", "bolder", "lighter"]
+    v_align: Literal["middle", "top", "bottom"] | None = None
+    style: Literal["normal", "italic", "oblique"] | None = None
+    weight: Literal["normal", "bold", "bolder", "lighter"] | None = None
     stretch: Literal[
         "normal",
         "condensed",

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -17,7 +17,7 @@ class CellStyle:
 
 
 @dataclass
-class CellText:
+class CellStyleText:
     """A style specification for text."""
 
     color: str

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import singledispatch
 from typing import Optional, Literal, List
 
 

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import singledispatch
-from typing import Optional, Literal
+from typing import Optional, Literal, List
 
 
 # Cell Styles ==========================================================================
@@ -96,7 +96,7 @@ class CellStyleBorders(CellStyle):
     weight: str
 
     def _to_html_style(self) -> str:
-        border_css_list = []
+        border_css_list: List[str] = []
         for side in self.sides:
             border_css_list.append(f"border-{side}: {self.weight} {self.style} {self.color};")
 

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -11,13 +11,15 @@ from typing import Optional, Literal
 
 
 # TODO: what goes into CellStyle?
-@dataclass
 class CellStyle:
     """A style specification."""
 
+    def _to_html_style(self) -> str:
+        raise NotImplementedError
+
 
 @dataclass
-class CellStyleText:
+class CellStyleText(CellStyle):
     """A style specification for text."""
 
     color: str | None = None
@@ -45,7 +47,7 @@ class CellStyleText:
         "normal", "nowrap", "pre", "pre-wrap", "pre-line", "break-spaces"
     ] | None = None
 
-    def _render_to_html_style(self):
+    def _to_html_style(self) -> str:
         rendered = f""
 
         if self.color:
@@ -65,7 +67,7 @@ class CellStyleFill(CellStyle):
     fill: str
     alpha: Optional[float] = None
 
-    def _render_to_html_style(self):
+    def _to_html_style(self) -> str:
         return f"background-color: {self.fill};"
 
 

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -62,13 +62,13 @@ class CellStyleText(CellStyle):
 
 @dataclass
 class CellStyleFill(CellStyle):
-    """A style specification for fill."""
+    """A style specification for the background fill of targeted cells."""
 
-    fill: str
+    color: str
     alpha: Optional[float] = None
 
     def _to_html_style(self) -> str:
-        return f"background-color: {self.fill};"
+        return f"background-color: {self.color};"
 
 
 @dataclass

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -45,6 +45,18 @@ class CellStyleText:
         "normal", "nowrap", "pre", "pre-wrap", "pre-line", "break-spaces"
     ] | None = None
 
+    def _render_to_html_style(self):
+        rendered = f""
+
+        if self.color:
+            rendered = rendered.join(f"color: {self.color};")
+        if self.font:
+            rendered = rendered.join(f"font-family: {self.font};")
+        if self.size:
+            rendered = rendered.join(f"font-size: {self.size};")
+
+        return rendered
+
 
 @dataclass
 class CellStyleFill(CellStyle):
@@ -52,6 +64,9 @@ class CellStyleFill(CellStyle):
 
     fill: str
     alpha: Optional[float] = None
+
+    def _render_to_html_style(self):
+        return f"background-color: {self.fill};"
 
 
 @dataclass

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -38,10 +38,12 @@ class CellStyleText:
         "expanded",
         "extra-expanded",
         "ultra-expanded",
-    ]
-    decorate: Literal["overline", "line-through", "underline", "underline overline"]
-    transform: Literal["uppercase", "lowercase", "capitalize"]
-    whitespace: Literal["normal", "nowrap", "pre", "pre-wrap", "pre-line", "break-spaces"]
+    ] | None = None
+    decorate: Literal["overline", "line-through", "underline", "underline overline"] | None = None
+    transform: Literal["uppercase", "lowercase", "capitalize"] | None = None
+    whitespace: Literal[
+        "normal", "nowrap", "pre", "pre-wrap", "pre-line", "break-spaces"
+    ] | None = None
 
 
 @dataclass

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -56,6 +56,22 @@ class CellStyleText(CellStyle):
             rendered = rendered.join(f"font-family: {self.font};")
         if self.size:
             rendered = rendered.join(f"font-size: {self.size};")
+        if self.align:
+            rendered = rendered.join(f"text-align: {self.align};")
+        if self.v_align:
+            rendered = rendered.join(f"vertical-align: {self.v_align};")
+        if self.style:
+            rendered = rendered.join(f"font-style: {self.style};")
+        if self.weight:
+            rendered = rendered.join(f"font-weight: {self.weight};")
+        if self.stretch:
+            rendered = rendered.join(f"font-stretch: {self.stretch};")
+        if self.decorate:
+            rendered = rendered.join(f"text-decoration: {self.decorate};")
+        if self.transform:
+            rendered = rendered.join(f"text-transform: {self.transform};")
+        if self.whitespace:
+            rendered = rendered.join(f"white-space: {self.whitespace};")
 
         return rendered
 

--- a/great_tables/_tab_create_modify.py
+++ b/great_tables/_tab_create_modify.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from ._gt_data import GTData
 from ._locations import Loc, PlacementOptions, set_footnote, set_style
 from ._styles import CellStyle
 

--- a/great_tables/_tab_create_modify.py
+++ b/great_tables/_tab_create_modify.py
@@ -27,7 +27,7 @@ def tab_style(
     - the text style (`style.text()`'s `style`), enabling the use of italics or oblique text.
     - the text weight (`style.text()`'s `weight`), allowing the use of thin to bold text (the degree
     of choice is greater with variable fonts)
-    - the alignment and indentation of text (`style.text()`'s `align` and `indent`)
+    - the alignment of text (`style.text()`'s `align`)
     - cell borders with the `style.borders()` class
 
     Parameters

--- a/great_tables/_tab_create_modify.py
+++ b/great_tables/_tab_create_modify.py
@@ -40,6 +40,34 @@ def tab_style(
         The cell or set of cells to be associated with the style. The `loc.body()` class can be used
         here to easily target body cell locations.
 
+    Examples
+    --------
+    Let's use a small subset of the `exibble` dataset to demonstrate how to use `tab_style()` to
+    target specific cells and apply styles to them. We'll start by creating the `exibble_sm` table
+    (a subset of the `exibble` table) and then use `tab_style()` to apply a light cyan background
+    color to the cells in the `num` column for the first two rows of the table. We'll then apply a
+    larger font size to the cells in the `fctr` column for the last four rows of the table.
+
+    ```{python}
+    import great_tables as gt
+    from great_tables import style, loc
+    from great_tables import exibble
+
+    exibble_sm = exibble[["num", "fctr", "row", "group"]]
+
+    (
+        gt.GT(exibble_sm, rowname_col="row", groupname_col="group")
+        .tab_style(
+            style=style.fill(color="lightcyan"),
+            locations=loc.body(columns="num", rows=["row_1", "row_2"]),
+        )
+        .tab_style(
+            style=style.text(size="22px"),
+            locations=loc.body(columns=["fctr"], rows=[4, 5, 6, 7]),
+        )
+    )
+    ```
+
     Returns
     -------
     GT

--- a/great_tables/_tab_create_modify.py
+++ b/great_tables/_tab_create_modify.py
@@ -15,12 +15,35 @@ def tab_style(
 ) -> GTSelf:
     """Add custom style to one or more cells
 
+    With the `tab_style()` method we can target specific cells and apply styles to them. We do this
+    with the combination of the `style` and `location` arguments. The `style` argument requires use
+    of styling classes (e.g., `style.fill(color="red")`) and the `location` argument needs to be an
+    expression of the cells we want to target using location targeting classes (e.g.,
+    `loc.body(columns=<column_name>)`). With the available suite of styling classes, here are some
+    of the styles we can apply:
+
+    - the background color of the cell (`style.fill()`'s `color`)
+    - the cell's text color, font, and size (`style.text()`'s `color`, `font`, and `size`)
+    - the text style (`style.text()`'s `style`), enabling the use of italics or oblique text.
+    - the text weight (`style.text()`'s `weight`), allowing the use of thin to bold text (the degree
+    of choice is greater with variable fonts)
+    - the alignment and indentation of text (`style.text()`'s `align` and `indent`)
+    - cell borders with the `style.borders()` class
+
     Parameters
     ----------
-    style:
-        A style specification.
-    location:
-        A location on the table.
+    style : CellStyle | list[CellStyle]
+        The styles to use for the cells at the targeted `locations`. The `style.text()`,
+        `style.fill()`, and `style.borders()` classes can be used here to more easily generate valid
+        styles.
+    location : Loc | list[Loc]
+        The cell or set of cells to be associated with the style. The `loc.body()` class can be used
+        here to easily target body cell locations.
+
+    Returns
+    -------
+    GT
+        The GT object is returned.
     """
 
     if not isinstance(style, list):

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -248,6 +248,9 @@ def eval_select(data: DataFrameLike, expr: Any, strict: bool = True) -> _NamePos
 def _(
     data: PdDataFrame, expr: Union[List[Union[str, int]], Callable[[str], bool]], strict=True
 ) -> _NamePos:
+    if isinstance(expr, str):
+        expr = [expr]
+
     if isinstance(expr, list):
         return _eval_select_from_list(list(data.columns), expr)
     elif callable(expr):
@@ -265,6 +268,9 @@ def _(data: PlDataFrame, expr: Union[List[str], _selector_proxy_], strict=True) 
     # Seems to be polars.selectors._selector_proxy_.
     from polars import Expr
     from polars import selectors
+
+    if isinstance(expr, str):
+        expr = [expr]
 
     col_pos = {k: ii for ii, k in enumerate(data.columns)}
 

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     PdDataFrame = pd.DataFrame
     PlDataFrame = pl.DataFrame
     PlSelectExpr = _selector_proxy_
+    PlExpr = pl.Expr
 
     PdSeries = pd.Series
     PlSeries = pl.Series
@@ -46,6 +47,9 @@ else:
 
     class PlSelectExpr(AbstractBackend):
         _backends = [("polars.selectors", "_selector_proxy_")]
+
+    class PlExpr(AbstractBackend):
+        _backends = [("polars", "Expr")]
 
     class PdSeries(AbstractBackend):
         _backends = [("pandas", "Series")]

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -480,12 +480,12 @@ def create_body_component_h(data: GTData) -> str:
             # Develop the `style` attribute for the current cell
             if len(styles_i) > 0:
                 style_entries = [x.styles for x in styles_i]
-                cell_styles = []
+                cell_styles_list: List[str] = []
                 for style in style_entries:
                     style_element = style[0]
-                    rendered_style = style_element._render_to_html_style()
-                    cell_styles.append(rendered_style)
-                cell_styles = f'style="{" ".join(cell_styles)}"' + " "
+                    rendered_style = style_element._to_html_style()
+                    cell_styles_list.append(rendered_style)
+                cell_styles = f'style="{" ".join(cell_styles_list)}"' + " "
             else:
                 cell_styles = ""
 

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -485,7 +485,7 @@ def create_body_component_h(data: GTData) -> str:
                     style_element = style[0]
                     rendered_style = style_element._render_to_html_style()
                     cell_styles.append(rendered_style)
-                cell_styles = f'style="{" ".join(cell_styles)}"'
+                cell_styles = f'style="{" ".join(cell_styles)}"' + " "
             else:
                 cell_styles = ""
 
@@ -493,7 +493,7 @@ def create_body_component_h(data: GTData) -> str:
                 body_cells.append(f'  <th class="gt_row gt_left gt_stub">' + cell_str + "</th>")
             else:
                 body_cells.append(
-                    f'  <td {cell_styles} class="gt_row gt_{cell_alignment}">' + cell_str + "</td>"
+                    f'  <td {cell_styles}class="gt_row gt_{cell_alignment}">' + cell_str + "</td>"
                 )
 
         body_rows.append("<tr>\n" + "\n".join(body_cells) + "\n</tr>")

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -50,12 +50,10 @@ from great_tables._utils_render_html import (
     create_source_notes_component_h,
     create_footnotes_component_h,
 )
-from great_tables._styles import CellStyle, CellStyleFill, CellStyleBorders
-from great_tables._locations import LocBody
 from great_tables._tab_create_modify import tab_style
 
 
-__all__ = ["GT", "CellStyle", "CellStyleFill", "CellStyleBorders", "LocBody"]
+__all__ = ["GT"]
 
 
 # =============================================================================

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -50,9 +50,12 @@ from great_tables._utils_render_html import (
     create_source_notes_component_h,
     create_footnotes_component_h,
 )
+from great_tables._styles import CellStyle, CellStyleFill, CellStyleBorders
+from great_tables._locations import LocBody
+from great_tables._tab_create_modify import tab_style
 
 
-__all__ = ["GT"]
+__all__ = ["GT", "CellStyle", "CellStyleFill", "CellStyleBorders", "LocBody"]
 
 
 # =============================================================================
@@ -219,6 +222,8 @@ class GT(
     cols_hide = cols_hide
 
     tab_stubhead = tab_stubhead
+
+    tab_style = tab_style
 
     # -----
 

--- a/great_tables/loc.py
+++ b/great_tables/loc.py
@@ -1,0 +1,5 @@
+from ._locations import (
+    LocBody as body,
+    LocStub as stub,
+    LocColumnLabels as column_labels,
+)

--- a/great_tables/loc.py
+++ b/great_tables/loc.py
@@ -3,3 +3,5 @@ from ._locations import (
     LocStub as stub,
     LocColumnLabels as column_labels,
 )
+
+__all__ = ("body", "stub", "column_labels")

--- a/great_tables/style.py
+++ b/great_tables/style.py
@@ -1,0 +1,5 @@
+from ._styles import (
+    CellStyleText as text,
+    CellStyleFill as fill,
+    CellStyleBorders as borders,
+)

--- a/great_tables/style.py
+++ b/great_tables/style.py
@@ -3,3 +3,5 @@ from ._styles import (
     CellStyleFill as fill,
     CellStyleBorders as borders,
 )
+
+__all__ = ("text", "fill", "borders")

--- a/tests/test_tab_create_modify.py
+++ b/tests/test_tab_create_modify.py
@@ -13,7 +13,7 @@ def gt():
 
 
 def test_tab_style(gt: GT):
-    style = CellStyleFill(fill="blue")
+    style = CellStyleFill(color="blue")
     new_gt = tab_style(gt, style, LocBody(["x"], [0]))
 
     assert len(gt._styles) == 0
@@ -24,7 +24,7 @@ def test_tab_style(gt: GT):
 
 
 def test_tab_style_multiple_columns(gt: GT):
-    style = CellStyleFill(fill="blue")
+    style = CellStyleFill(color="blue")
     new_gt = tab_style(gt, style, LocBody(["x", "y"], [0]))
 
     assert len(new_gt._styles) == 2


### PR DESCRIPTION
This adds the `tab_style()` method. The method requires `locations` and `style` values which are provided by new classes in the `loc` and `style` submodules.

You could do this:

```
import great_tables as gt
from great_tables import style, loc
from great_tables import exibble

(
    gt.GT(exibble)
    .tab_style(
        style=style.text(color="blue"),
        locations=loc.body(columns="num", rows=[0, 1, 2, 3]),
    )
    .tab_style(
        style=style.text(size="25px"),
        locations=loc.body(columns=["fctr"], rows=[0, 1, 2, 3]),
    )
    .tab_style(
        style=style.text(color="red"),
        locations=loc.body(columns=["fctr"], rows=[1, 2, 3, 4]),
    )
    .tab_style(
        style=style.text(size="10px"),
        locations=loc.body(columns=["fctr"], rows=[0, 1, 2, 3]),
    )
)
```

Fixes: https://github.com/posit-dev/great-tables/issues/63