### PR TITLE
fix: handle addition in scss template

### DIFF
--- a/great_tables/_scss.py
+++ b/great_tables/_scss.py
@@ -55,6 +55,17 @@ def font_color(color: str, table_font_color: str, table_font_color_light: str):
     return table_font_color_light
 
 
+def css_add(value: str | int, amount: int):
+    if isinstance(value, int):
+        return value + amount
+    elif value.endswith("px"):
+        return f"{int(value[:-2]) + amount}px"
+    elif value.endswith("%"):
+        return f"{int(value[:-1]) + amount}%"
+    else:
+        raise NotImplementedError(f"Unable to add to CSS value: {value}")
+
+
 def compile_scss(data: GTData, id: Optional[str]) -> str:
     """Return CSS for styling a table, based on options set."""
 
@@ -76,7 +87,12 @@ def compile_scss(data: GTData, id: Optional[str]) -> str:
 
     font_params = {f"font_color_{k}": p_font_color(scss_params[k]) for k in FONT_COLOR_VARS}
 
-    final_params = {**scss_params, **font_params}
+    final_params = {
+        **scss_params,
+        **font_params,
+        "heading_subtitle_padding_top": css_add(scss_params["heading_padding"], -1),
+        "heading_subtitle_padding_bottom": css_add(scss_params["heading_padding"], 1),
+    }
 
     # Handle table id ----
     # Determine whether the table has an ID

--- a/great_tables/_scss.py
+++ b/great_tables/_scss.py
@@ -66,7 +66,7 @@ def css_add(value: str | int, amount: int):
         raise NotImplementedError(f"Unable to add to CSS value: {value}")
 
 
-def compile_scss(data: GTData, id: Optional[str]) -> str:
+def compile_scss(data: GTData, id: Optional[str], compress: bool = True) -> str:
     """Return CSS for styling a table, based on options set."""
 
     # Obtain the SCSS options dictionary
@@ -127,8 +127,10 @@ def compile_scss(data: GTData, id: Optional[str]) -> str:
     )
 
     gt_styles_default = gt_styles_default_file.read()
-    gt_styles_default = re.sub(r"\s+", " ", gt_styles_default, 0, re.MULTILINE)
-    gt_styles_default = re.sub(r"}", "}\n", gt_styles_default, 0, re.MULTILINE)
+
+    if compress:
+        gt_styles_default = re.sub(r"\s+", " ", gt_styles_default, 0, re.MULTILINE)
+        gt_styles_default = re.sub(r"}", "}\n", gt_styles_default, 0, re.MULTILINE)
 
     compiled_css = Template(gt_styles_default).substitute(final_params)
 

--- a/great_tables/css/gt_styles_default.scss
+++ b/great_tables/css/gt_styles_default.scss
@@ -55,8 +55,8 @@ p {
   color: $font_color_heading_background_color;
   font-size: $heading_subtitle_font_size;
   font-weight: $heading_subtitle_font_weight;
-  padding-top: $heading_padding - 1;
-  padding-bottom: $heading_padding + 1;
+  padding-top: $heading_subtitle_padding_top;
+  padding-bottom: $heading_subtitle_padding_bottom;
   padding-left: $heading_padding_horizontal;
   padding-right: $heading_padding_horizontal;
   border-top-color: $table_background_color;

--- a/tests/__snapshots__/test_scss.ambr
+++ b/tests/__snapshots__/test_scss.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_scss_generated
+# name: test_scss_default_generated
   '''
   #abc table {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;

--- a/tests/__snapshots__/test_scss.ambr
+++ b/tests/__snapshots__/test_scss.ambr
@@ -1,0 +1,423 @@
+# serializer version: 1
+# name: test_scss_generated
+  '''
+  #abc table {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+          }
+  
+  
+  #abc thead, tbody, tfoot, tr, td, th {
+    border-style: none;
+  }
+  
+  #abc p {
+    margin: 0;
+    padding: 0;
+  }
+  
+  #abc .gt_table {
+    display: table;
+    border-collapse: collapse;
+    line-height: normal;
+    margin-left: auto;
+    margin-right: auto;
+    color: #333333;
+    font-size: 16px;
+    font-weight: normal;
+    font-style: normal;
+    background-color: #FFFFFF;
+    width: auto;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #A8A8A8;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #A8A8A8;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+  }
+  
+  #abc .gt_caption {
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+  
+  #abc .gt_title {
+    color: #333333;
+    font-size: 125%;
+    font-weight: initial;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-bottom-color: #FFFFFF;
+    border-bottom-width: 0;
+  }
+  
+  #abc .gt_subtitle {
+    color: #333333;
+    font-size: 85%;
+    font-weight: initial;
+    padding-top: 3px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-top-color: #FFFFFF;
+    border-top-width: 0;
+  }
+  
+  #abc .gt_heading {
+    background-color: #FFFFFF;
+    text-align: center;
+    border-bottom-color: #FFFFFF;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_bottom_border {
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+  }
+  
+  #abc .gt_col_headings {
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_col_heading {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: normal;
+    text-transform: inherit;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+    vertical-align: bottom;
+    padding-top: 5px;
+    padding-bottom: 5px + 1;
+    padding-left: 5px;
+    padding-right: 5px;
+    overflow-x: hidden;
+  }
+  
+  #abc .gt_column_spanner_outer {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: normal;
+    text-transform: inherit;
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: 4px;
+    padding-right: 4px;
+  }
+  #abc .gt_column_spanner_outer:first-child {
+    padding-left: 0;
+  }
+  #abc .gt_column_spanner_outer:last-child {
+    padding-right: 0;
+  }
+  
+  #abc .gt_column_spanner {
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    vertical-align: bottom;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    overflow-x: hidden;
+    display: inline-block;
+    width: 100%;
+  }
+  
+  #abc .gt_spanner_row {
+    border-bottom-style: hidden;
+  }
+  
+  #abc .gt_group_heading {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+    vertical-align: middle;
+    text-align: left;
+  }
+  
+  #abc .gt_empty_group_heading {
+    padding: 0.5px;
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    vertical-align: middle;
+  }
+  
+  #abc .gt_from_md > :first-child {
+    margin-top: 0;
+  }
+  
+  #abc .gt_from_md > :last-child {
+    margin-bottom: 0;
+  }
+  
+  #abc .gt_row {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    margin: 10px;
+    border-top-style: solid;
+    border-top-width: 1px;
+    border-top-color: #D3D3D3;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+    vertical-align: middle;
+    overflow-x: hidden;
+  }
+  
+  #abc .gt_stub {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-right-style: solid;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+  
+  #abc .gt_stub_row_group {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-right-style: solid;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    padding-left: 5px;
+    padding-right: 5px;
+    vertical-align: top;
+  }
+  
+  #abc .gt_row_group_first td {
+    border-top-width: 2px;
+  }
+  
+  #abc .gt_row_group_first th {
+    border-top-width: 2px;
+  }
+  
+  #abc .gt_summary_row {
+    color: #333333;
+    background-color: #FFFFFF;
+    text-transform: inherit;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+  
+  #abc .gt_first_summary_row {
+    border-top-style: solid;
+    border-top-color: #D3D3D3;
+  }
+  
+  #abc .gt_first_summary_row.thick {
+    border-top-width: 2px;
+  }
+  
+  #abc .gt_last_summary_row {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+  }
+  
+  #abc .gt_grand_summary_row {
+    color: #333333;
+    background-color: #FFFFFF;
+    text-transform: inherit;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+  
+  #abc .gt_first_grand_summary_row {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-top-style: double;
+    border-top-width: 6px;
+    border-top-color: #D3D3D3;
+  }
+  
+  #abc .gt_last_grand_summary_row_top {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-bottom-style: double;
+    border-bottom-width: 6px;
+    border-bottom-color: #D3D3D3;
+  }
+  
+  #abc .gt_striped {
+     background-color: rgba(128,128,128,0.05);
+  }
+  
+  #abc .gt_table_body {
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+  }
+  
+  #abc .gt_footnotes {
+    color: #333333;
+    background-color: #FFFFFF;
+    border-bottom-style: none;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_footnote {
+    margin: 0px;
+    font-size: 90%;
+    padding-left: 4px;
+    padding-right: 4px;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+  
+  #abc .gt_sourcenotes {
+    color: #333333;
+    background-color: #FFFFFF;
+    border-bottom-style: none;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_sourcenote {
+    font-size: 90%;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+  
+  #abc .gt_left {
+    text-align: left;
+  }
+  
+  #abc .gt_center {
+    text-align: center;
+  }
+  
+  #abc .gt_right {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  
+  #abc .gt_font_normal {
+    font-weight: normal;
+  }
+  
+  #abc .gt_font_bold {
+    font-weight: bold;
+  }
+  
+  #abc .gt_font_italic {
+    font-style: italic;
+  }
+  
+  #abc .gt_super {
+    font-size: 65%;
+  }
+  
+  #abc .gt_footnote_marks {
+    font-size: 75%;
+    vertical-align: 0.4em;
+    position: initial;
+  }
+  
+  #abc .gt_asterisk {
+    font-size: 100%;
+    vertical-align: 0;
+  }
+  
+  '''
+# ---

--- a/tests/test_scss.py
+++ b/tests/test_scss.py
@@ -1,6 +1,7 @@
 import pytest
 
-from great_tables._scss import font_color
+from great_tables._scss import font_color, css_add
+from typing import Any
 
 
 @pytest.mark.parametrize(
@@ -13,4 +14,17 @@ from great_tables._scss import font_color
 )
 def test_font_color(src, dst):
     res = font_color(src, "dark", "light")
+    assert res == dst
+
+
+@pytest.mark.parametrize(
+    "src,dst",
+    [
+        ("1px", "2px"),
+        ("1%", "2%"),
+        (1, 2),
+    ],
+)
+def test_css_add(src: "str | int", dst: "str | int"):
+    res = css_add(src, 1)
     assert res == dst

--- a/tests/test_scss.py
+++ b/tests/test_scss.py
@@ -1,7 +1,8 @@
 import pytest
+import pandas as pd
 
-from great_tables._scss import font_color, css_add
-from typing import Any
+from great_tables import GT
+from great_tables._scss import font_color, css_add, compile_scss
 
 
 @pytest.mark.parametrize(
@@ -28,3 +29,10 @@ def test_font_color(src, dst):
 def test_css_add(src: "str | int", dst: "str | int"):
     res = css_add(src, 1)
     assert res == dst
+
+
+def test_scss_default_generated(snapshot):
+    # we're using this just to generate the css
+    gt = GT(pd.DataFrame({"x": [1, 2, 3]}))
+
+    assert snapshot == compile_scss(gt, id="abc", compress=False)


### PR DESCRIPTION
This PR addresses an issue with addition not being supported in our rendering the scss file (https://github.com/posit-dev/great-tables/issues/60#issuecomment-1846329398).

It adds the following:

* a function `css_add`, and new variables in the scss for the results of calling it on other variables.
* a compress argument to compile_scss, to toggle whether or not we strip spaces from the generated css
* generates a test snapshot of css generated from default GT options