### PR TITLE
Ensure that `tab_source_note()` works when using `md()` or `html()`

### DIFF
--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -528,10 +528,12 @@ def create_source_notes_component_h(data: GTData) -> str:
         source_notes_tr: List[str] = []
 
         for note in source_notes:
+            note_str = _process_text(note)
+
             source_notes_tr.append(
                 f"""
   <tr>
-    <td class="gt_sourcenote" colspan="{n_cols_total}">{note}</td>
+    <td class="gt_sourcenote" colspan="{n_cols_total}">{note_str}</td>
   </tr>
 """
             )
@@ -550,7 +552,12 @@ def create_source_notes_component_h(data: GTData) -> str:
     # Create the source notes component as a single `<tr><td>` inside
     # of a `<tfoot>`
 
-    source_notes_str_joined = separator.join(source_notes)
+    source_note_list: List[str] = []
+    for note in source_notes:
+        note_str = _process_text(note)
+        source_note_list.append(note_str)
+
+    source_notes_str_joined = separator.join(source_note_list)
 
     source_notes_component = f"""<tfoot>
   <tr class="gt_sourcenotes">


### PR DESCRIPTION
This fixes an issue where using `md()` or `html()` on source note text (within `tab_source_note()`) would fail to produce the note. The solution is to apply `_process_text()` to incoming label text, handling the md- and html-classed text appropriately. After this fix is applied, the following example works as expected:

```
import great_tables as gt
from great_tables import md, html
from great_tables import exibble

(
    gt.GT(exibble)
    .tab_source_note(md("An **important** note."))
    .tab_source_note(md("Another *important* note."))
    .tab_source_note("A plain note.")
    .tab_source_note(html("An <strong>HTML heavy</strong> note."))
)
```

Fixes: #73 