### PR TITLE
Make invocation `loc.body()` default to all columns and rows

### DIFF
--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -308,7 +308,6 @@ def resolve_rows_i(
 
     Unlike tidyselect::eval_select, this function returns names in
     the order they appear in the data (rather than ordered by selectors).
-
     """
 
     if isinstance(data, GTData):

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -210,6 +210,7 @@ def resolve_cols_i(
 
     if isinstance(data, GTData):
         stub_var = data._boxhead.vars_from_type(ColInfoTypeEnum.stub)
+        group_var = data._boxhead.vars_from_type(ColInfoTypeEnum.row_group)
 
         # TODO: special handling of "stub()"
         if isinstance(expr, list) and "stub()" in expr:
@@ -222,41 +223,13 @@ def resolve_cols_i(
         # the value of `null_means`
         if expr is None:
             if null_means == "everything":
-                # If `null_means` is "everything", we want to select all columns, perhaps
-                # excluding the stub and/or group columns depending on the values of
-                # `excl_stub` and `excl_group`; first, we get the column names and positions
-                # for all columns
+                cols_excl = [*(stub_var if excl_stub else []), *(group_var if excl_group else [])]
 
-                if not excl_stub and not excl_group:
-                    return [(col, ii) for ii, col in enumerate(data._tbl_data.columns)]
-
-                # Depending on the value of `excl_stub` and `excl_group`, we want
-                # to exclude the stub and/or group columns from the selection
-                if excl_stub and excl_group:
-                    # If `excl_stub` and `excl_group` are both True, exclude both
-                    # the stub and group columns from the selection
-                    cols_excl = stub_var + data._boxhead.vars_from_type(ColInfoTypeEnum.row_group)
-                    return [
-                        (col, ii)
-                        for ii, col in enumerate(data._tbl_data.columns)
-                        if col not in cols_excl
-                    ]
-                elif excl_stub:
-                    # If `excl_stub` is True, exclude the stub column from the selection
-                    cols_excl = stub_var
-                    return [
-                        (col, ii)
-                        for ii, col in enumerate(data._tbl_data.columns)
-                        if col not in cols_excl
-                    ]
-                elif excl_group:
-                    # If `excl_group` is True, exclude the group column from the selection
-                    cols_excl = data._boxhead.vars_from_type(ColInfoTypeEnum.row_group)
-                    return [
-                        (col, ii)
-                        for ii, col in enumerate(data._tbl_data.columns)
-                        if col not in cols_excl
-                    ]
+                return [
+                    (col, ii)
+                    for ii, col in enumerate(data._tbl_data.columns)
+                    if col not in cols_excl
+                ]
 
             else:
                 return []

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -288,9 +288,9 @@ def resolve_cols_i(
 
 
 def resolve_rows_i(
-    expr: list[str | int],
     data: GTData | list[str],
-    null_means: Literal["everything", "nothing"] = "nothing",
+    expr: list[str | int] | None = None,
+    null_means: Literal["everything", "nothing"] = "everything",
 ) -> list[tuple[str, int]]:
     """Return matching row numbers, based on expr
 
@@ -304,6 +304,12 @@ def resolve_rows_i(
     """
 
     if isinstance(data, GTData):
+        if expr is None:
+            if null_means == "everything":
+                return [(row.rowname, ii) for ii, row in enumerate(data._stub)]
+            else:
+                return []
+
         row_names = [row.rowname for row in data._stub]
     else:
         row_names = data
@@ -358,7 +364,7 @@ def _(loc: LocColumnSpanners, spanners: Spanners) -> LocColumnSpanners:
 @resolve.register
 def _(loc: LocBody, data: GTData) -> List[CellPos]:
     cols = resolve_cols_i(loc.columns, data)
-    rows = resolve_rows_i(loc.rows, data)
+    rows = resolve_rows_i(data=data, expr=loc.rows)
 
     # TODO: dplyr arranges by `Var1`, and does distinct (since you can tidyselect the same
     # thing multiple times

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -179,20 +179,28 @@ def resolve_vector_l(expr: list[str], candidates: list[str], item_label: str) ->
 
 
 def resolve_cols_c(
-    expr: SelectExpr,
     data: GTData,
+    expr: SelectExpr,
     strict: bool = True,
     excl_stub: bool = True,
     excl_group: bool = True,
     null_means: Literal["everything", "nothing"] = "everything",
 ) -> list[str]:
-    selected = resolve_cols_i(expr, data, strict, excl_stub, excl_group, null_means)
+    """Return a list of column names, selected by expr."""
+    selected = resolve_cols_i(
+        data=data,
+        expr=expr,
+        strict=strict,
+        excl_stub=excl_stub,
+        excl_group=excl_group,
+        null_means=null_means,
+    )
     return [name_pos[0] for name_pos in selected]
 
 
 def resolve_cols_i(
-    expr: SelectExpr,
     data: GTData | TblData,
+    expr: SelectExpr,
     strict: bool = True,
     excl_stub: bool = True,
     excl_group: bool = True,
@@ -363,7 +371,7 @@ def _(loc: LocColumnSpanners, spanners: Spanners) -> LocColumnSpanners:
 
 @resolve.register
 def _(loc: LocBody, data: GTData) -> List[CellPos]:
-    cols = resolve_cols_i(loc.columns, data)
+    cols = resolve_cols_i(data=data, expr=loc.columns)
     rows = resolve_rows_i(data=data, expr=loc.rows)
 
     # TODO: dplyr arranges by `Var1`, and does distinct (since you can tidyselect the same

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -138,7 +138,7 @@ def tab_spanner(
         # TODO: null_means is unimplemented
         raise NotImplementedError("columns must be specified")
 
-    selected_column_names = resolve_cols_c(columns, data, null_means="nothing")
+    selected_column_names = resolve_cols_c(data=data, expr=columns, null_means="nothing")
 
     # select spanner ids ----
     # TODO: this supports tidyselect
@@ -245,9 +245,9 @@ def cols_move(data: GTData, columns: SelectExpr, after: str) -> GTData:
     if isinstance(columns, str):
         columns = [columns]
 
-    sel_cols = resolve_cols_c(columns, data)
+    sel_cols = resolve_cols_c(data=data, expr=columns)
 
-    sel_after = resolve_cols_c([after], data)
+    sel_after = resolve_cols_c(data=data, expr=[after])
 
     vars = [col.var for col in data._boxhead]
 
@@ -327,7 +327,7 @@ def cols_move_to_start(data: GTSelf, columns: SelectExpr) -> GTSelf:
     if isinstance(columns, str):
         columns = [columns]
 
-    sel_cols = resolve_cols_c(columns, data)
+    sel_cols = resolve_cols_c(data=data, expr=columns)
 
     vars = [col.var for col in data._boxhead]
 
@@ -393,7 +393,7 @@ def cols_move_to_end(data: GTSelf, columns: SelectExpr) -> GTSelf:
     if isinstance(columns, str):
         columns = [columns]
 
-    sel_cols = resolve_cols_c(columns, data)
+    sel_cols = resolve_cols_c(data=data, expr=columns)
 
     vars = [col.var for col in data._boxhead]
 
@@ -446,7 +446,7 @@ def cols_hide(data: GTData, columns: SelectExpr) -> GTData:
     if isinstance(columns, str):
         columns = [columns]
 
-    sel_cols = resolve_cols_c(columns, data)
+    sel_cols = resolve_cols_c(data=data, expr=columns)
 
     vars = [col.var for col in data._boxhead]
 

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -186,14 +186,16 @@ class CellStyleBorders(CellStyle):
         A CellStyleBorders object, which is used for a `styles` argument if specifying cell borders.
     """
 
-    sides: List[str] | str | None = "all"
+    sides: Literal["all", "top", "bottom", "left", "right"] | List[
+        Literal["all", "top", "bottom", "left", "right"]
+    ] = "all"
     color: str = "#000000"
     style: str = "solid"
     weight: str = "1px"
 
     def _to_html_style(self) -> str:
-        # If sides is None, return an empty string
-        if self.sides is None:
+        # If sides is an empty list, return an empty string
+        if self.sides == []:
             return ""
 
         # If self.sides is a string, convert to a list
@@ -213,6 +215,8 @@ class CellStyleBorders(CellStyle):
 
         border_css_list: List[str] = []
         for side in self.sides:
+            if side not in ["top", "bottom", "left", "right"]:
+                raise ValueError(f"Invalid side '{side}' provided.")
             border_css_list.append(f"border-{side}: {weight} {style} {color};")
 
         border_css = "".join(border_css_list)

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -192,11 +192,16 @@ class CellStyleBorders(CellStyle):
     weight: str = "1px"
 
     def _to_html_style(self) -> str:
+        # If sides is None, return an empty string
         if self.sides is None:
             return ""
 
+        # If self.sides is a string, convert to a list
+        if isinstance(self.sides, str):
+            self.sides = [self.sides]
+
         # If 'all' is provided then call the function recursively with all sides
-        if self.sides == "all" or self.sides == ["all"]:
+        if "all" in self.sides:
             return CellStyleBorders(sides=["top", "bottom", "left", "right"])._to_html_style()
 
         weight = self.weight

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -186,15 +186,29 @@ class CellStyleBorders(CellStyle):
         A CellStyleBorders object, which is used for a `styles` argument if specifying cell borders.
     """
 
-    sides: Literal["all", "top", "bottom", "left", "right"]
+    sides: List[str] | str | None = "all"
     color: str = "#000000"
     style: str = "solid"
     weight: str = "1px"
 
     def _to_html_style(self) -> str:
+        if self.sides is None:
+            return ""
+
+        # If 'all' is provided then call the function recursively with all sides
+        if self.sides == "all" or self.sides == ["all"]:
+            return CellStyleBorders(sides=["top", "bottom", "left", "right"])._to_html_style()
+
+        weight = self.weight
+        if isinstance(weight, int):
+            weight = f"{weight}px"
+
+        color = self.color
+        style = self.style
+
         border_css_list: List[str] = []
         for side in self.sides:
-            border_css_list.append(f"border-{side}: {self.weight} {self.style} {self.color};")
+            border_css_list.append(f"border-{side}: {weight} {style} {color};")
 
         border_css = "".join(border_css_list)
         return border_css

--- a/tests/__snapshots__/test_utils_render_html.ambr
+++ b/tests/__snapshots__/test_utils_render_html.ambr
@@ -25,7 +25,7 @@
   </tfoot>
   '''
 # ---
-# name: test_styling_data_1
+# name: test_styling_data_01
   '''
   <tbody class="gt_table_body">
   <tr>
@@ -43,7 +43,7 @@
   </tbody>
   '''
 # ---
-# name: test_styling_data_2
+# name: test_styling_data_02
   '''
   <tbody class="gt_table_body">
   <tr>
@@ -61,7 +61,7 @@
   </tbody>
   '''
 # ---
-# name: test_styling_data_3
+# name: test_styling_data_03
   '''
   <tbody class="gt_table_body">
   <tr>
@@ -79,7 +79,7 @@
   </tbody>
   '''
 # ---
-# name: test_styling_data_4
+# name: test_styling_data_04
   '''
   <tbody class="gt_table_body">
   <tr>
@@ -97,7 +97,7 @@
   </tbody>
   '''
 # ---
-# name: test_styling_data_5
+# name: test_styling_data_05
   '''
   <tbody class="gt_table_body">
   <tr>
@@ -115,7 +115,7 @@
   </tbody>
   '''
 # ---
-# name: test_styling_data_6
+# name: test_styling_data_06
   '''
   <tbody class="gt_table_body">
   <tr>
@@ -129,6 +129,78 @@
   <tr>
     <td class="gt_row gt_right">33.33</td>
     <td class="gt_row gt_left">coconut</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_styling_data_07
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_styling_data_08
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_styling_data_09
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td style="border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td style="border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_styling_data_10
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td style="border-top: 1px solid #000000;border-bottom: 1px solid #000000;border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td style="border-top: 1px solid #000000;border-bottom: 1px solid #000000;border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">coconut</td>
   </tr>
   </tbody>
   '''

--- a/tests/__snapshots__/test_utils_render_html.ambr
+++ b/tests/__snapshots__/test_utils_render_html.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_format_snap
+# name: test_source_notes_snap
   '''
     <tfoot class="gt_sourcenotes">
     

--- a/tests/__snapshots__/test_utils_render_html.ambr
+++ b/tests/__snapshots__/test_utils_render_html.ambr
@@ -25,3 +25,111 @@
   </tfoot>
   '''
 # ---
+# name: test_styling_data_1
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td style="color: red;" class="gt_row gt_right">0.1111</td>
+    <td style="color: red;" class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td style="color: red;" class="gt_row gt_right">2.222</td>
+    <td style="color: red;" class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td style="color: red;" class="gt_row gt_right">33.33</td>
+    <td style="color: red;" class="gt_row gt_left">coconut</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_styling_data_2
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td style="color: red;" class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td style="color: red;" class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td style="color: red;" class="gt_row gt_left">coconut</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_styling_data_3
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td style="color: red;" class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td style="color: red;" class="gt_row gt_left">coconut</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_styling_data_4
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_styling_data_5
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_styling_data_6
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+  </tr>
+  </tbody>
+  '''
+# ---

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -35,15 +35,15 @@ def test_resolve_cols_i_ints():
 
 def test_resolve_rows_i_gt_data():
     gt = GT(pd.DataFrame({"x": ["a", "b", "c"]}), rowname_col="x")
-    assert resolve_rows_i(["b", "a"], gt) == [("a", 0), ("b", 1)]
+    assert resolve_rows_i(gt, ["b", "a"]) == [("a", 0), ("b", 1)]
 
 
 def test_resolve_rows_i_strings():
-    assert resolve_rows_i(["x", "a"], ["a", "x", "a", "b"]) == [("a", 0), ("x", 1), ("a", 2)]
+    assert resolve_rows_i(["a", "x", "a", "b"], ["x", "a"]) == [("a", 0), ("x", 1), ("a", 2)]
 
 
 def test_resolve_rows_i_ints():
-    assert resolve_rows_i([0, -1], ["a", "x", "a", "b"]) == [("a", 0), ("b", 3)]
+    assert resolve_rows_i(["a", "x", "a", "b"], [0, -1]) == [("a", 0), ("b", 3)]
 
 
 def test_resolve_loc_body():

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -20,17 +20,17 @@ def test_resolve_vector_i():
 
 def test_resolve_cols_i_gt_data():
     gt = GT(pd.DataFrame(columns=["a", "b", "x"]))
-    assert resolve_cols_i(["x", "a"], gt) == [("x", 2), ("a", 0)]
+    assert resolve_cols_i(gt, ["x", "a"]) == [("x", 2), ("a", 0)]
 
 
 def test_resolve_cols_i_strings():
     df = pd.DataFrame(columns=["a", "b", "x"])
-    assert resolve_cols_i(["x", "a"], df) == [("x", 2), ("a", 0)]
+    assert resolve_cols_i(df, ["x", "a"]) == [("x", 2), ("a", 0)]
 
 
 def test_resolve_cols_i_ints():
     df = pd.DataFrame(columns=["a", "b", "x"])
-    assert resolve_cols_i([-1, 0], df) == [("x", 2), ("a", 0)]
+    assert resolve_cols_i(df, [-1, 0]) == [("x", 2), ("a", 0)]
 
 
 def test_resolve_rows_i_gt_data():

--- a/tests/test_utils_render_html.py
+++ b/tests/test_utils_render_html.py
@@ -1,5 +1,7 @@
-from great_tables import GT, exibble, md, html
-from great_tables._utils_render_html import create_source_notes_component_h
+from great_tables import GT, exibble, md, html, style, loc
+from great_tables._utils_render_html import create_source_notes_component_h, create_body_component_h
+
+small_exibble = exibble[["num", "char"]].head(3)
 
 
 def assert_rendered_source_notes(snapshot, gt):
@@ -7,6 +9,13 @@ def assert_rendered_source_notes(snapshot, gt):
     source_notes = create_source_notes_component_h(built)
 
     assert snapshot == source_notes
+
+
+def assert_rendered_body(snapshot, gt):
+    built = gt._build_data("html")
+    body = create_body_component_h(built)
+
+    assert snapshot == body
 
 
 def test_source_notes_snap(snapshot):
@@ -19,3 +28,57 @@ def test_source_notes_snap(snapshot):
     )
 
     assert_rendered_source_notes(snapshot, new_gt)
+
+
+def test_styling_data_1(snapshot):
+    new_gt = GT(small_exibble).tab_style(
+        style=style.text(color="red"),
+        locations=loc.body(),
+    )
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+def test_styling_data_2(snapshot):
+    new_gt = GT(small_exibble).tab_style(
+        style=style.text(color="red"),
+        locations=loc.body(columns=["char"]),
+    )
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+def test_styling_data_3(snapshot):
+    new_gt = GT(small_exibble).tab_style(
+        style=style.text(color="red"),
+        locations=loc.body(columns="char", rows=[0, 2]),
+    )
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+def test_styling_data_4(snapshot):
+    new_gt = GT(small_exibble).tab_style(
+        style=style.text(color="red"),
+        locations=loc.body(columns=[], rows=[0, 2]),
+    )
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+def test_styling_data_5(snapshot):
+    new_gt = GT(small_exibble).tab_style(
+        style=style.text(color="red"),
+        locations=loc.body(columns="char", rows=[]),
+    )
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+def test_styling_data_6(snapshot):
+    new_gt = GT(small_exibble).tab_style(
+        style=style.text(color="red"),
+        locations=loc.body(columns=[], rows=[]),
+    )
+
+    assert_rendered_body(snapshot, new_gt)

--- a/tests/test_utils_render_html.py
+++ b/tests/test_utils_render_html.py
@@ -14,7 +14,7 @@ def assert_rendered_source_notes(snapshot, gt):
     assert snapshot == source_notes
 
 
-def test_format_snap(snapshot):
+def test_source_notes_snap(snapshot):
     new_gt = (
         GT(exibble)
         .tab_source_note(md("An **important** note."))

--- a/tests/test_utils_render_html.py
+++ b/tests/test_utils_render_html.py
@@ -30,7 +30,7 @@ def test_source_notes_snap(snapshot):
     assert_rendered_source_notes(snapshot, new_gt)
 
 
-def test_styling_data_1(snapshot):
+def test_styling_data_01(snapshot):
     new_gt = GT(small_exibble).tab_style(
         style=style.text(color="red"),
         locations=loc.body(),
@@ -39,7 +39,7 @@ def test_styling_data_1(snapshot):
     assert_rendered_body(snapshot, new_gt)
 
 
-def test_styling_data_2(snapshot):
+def test_styling_data_02(snapshot):
     new_gt = GT(small_exibble).tab_style(
         style=style.text(color="red"),
         locations=loc.body(columns=["char"]),
@@ -48,7 +48,7 @@ def test_styling_data_2(snapshot):
     assert_rendered_body(snapshot, new_gt)
 
 
-def test_styling_data_3(snapshot):
+def test_styling_data_03(snapshot):
     new_gt = GT(small_exibble).tab_style(
         style=style.text(color="red"),
         locations=loc.body(columns="char", rows=[0, 2]),
@@ -57,7 +57,7 @@ def test_styling_data_3(snapshot):
     assert_rendered_body(snapshot, new_gt)
 
 
-def test_styling_data_4(snapshot):
+def test_styling_data_04(snapshot):
     new_gt = GT(small_exibble).tab_style(
         style=style.text(color="red"),
         locations=loc.body(columns=[], rows=[0, 2]),
@@ -66,7 +66,7 @@ def test_styling_data_4(snapshot):
     assert_rendered_body(snapshot, new_gt)
 
 
-def test_styling_data_5(snapshot):
+def test_styling_data_05(snapshot):
     new_gt = GT(small_exibble).tab_style(
         style=style.text(color="red"),
         locations=loc.body(columns="char", rows=[]),
@@ -75,10 +75,46 @@ def test_styling_data_5(snapshot):
     assert_rendered_body(snapshot, new_gt)
 
 
-def test_styling_data_6(snapshot):
+def test_styling_data_06(snapshot):
     new_gt = GT(small_exibble).tab_style(
         style=style.text(color="red"),
         locations=loc.body(columns=[], rows=[]),
+    )
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+def test_styling_data_07(snapshot):
+    new_gt = GT(small_exibble).tab_style(
+        style=style.borders(sides="left"),
+        locations=loc.body(columns="char", rows=[0, 2]),
+    )
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+def test_styling_data_08(snapshot):
+    new_gt = GT(small_exibble).tab_style(
+        style=style.borders(sides=["left"]),
+        locations=loc.body(columns="char", rows=[0, 2]),
+    )
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+def test_styling_data_09(snapshot):
+    new_gt = GT(small_exibble).tab_style(
+        style=style.borders(sides=["left", "right"]),
+        locations=loc.body(columns="char", rows=[0, 2]),
+    )
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+def test_styling_data_10(snapshot):
+    new_gt = GT(small_exibble).tab_style(
+        style=style.borders(sides="all"),
+        locations=loc.body(columns="char", rows=[0, 2]),
     )
 
     assert_rendered_body(snapshot, new_gt)

--- a/tests/test_utils_render_html.py
+++ b/tests/test_utils_render_html.py
@@ -1,10 +1,5 @@
-from typing import Union
-
-import re
-
 from great_tables import GT, exibble, md, html
 from great_tables._utils_render_html import create_source_notes_component_h
-from great_tables._source_notes import tab_source_note
 
 
 def assert_rendered_source_notes(snapshot, gt):


### PR DESCRIPTION
When adding styles through the `tab_style()` method, it is far more sensible target the most number of cells and use the `columns` and `rows` arguments to constrain the cell selection. This PR enables this behavior so that this

```py
import great_tables as gt
from great_tables import style, loc, md, html
from great_tables import exibble

(
    gt.GT(exibble)
    .tab_style(
        style=style.text(color="red"),
        locations=loc.body(),
    )
)
```

results in
<img width="894" alt="tab-style-default-everything" src="https://github.com/posit-dev/great-tables/assets/5612024/3dcd136c-2ef3-4d79-afe3-0d1ec63300bd">

Fixes: https://github.com/posit-dev/great-tables/issues/76
