### PR TITLE
docs: single column examples on narrow screens

### DIFF
--- a/docs/examples/index.qmd
+++ b/docs/examples/index.qmd
@@ -11,7 +11,7 @@ format:
 :::::: {.column-page}
 ::::: {.grid}
 
-:::{.g-col-6}
+:::{.g-col-lg-6 .g-col-12}
 
 ```{python}
 from great_tables import GT, md, html
@@ -36,7 +36,7 @@ islands_mini = islands.head(10)
 ```
 
 :::
-:::{.g-col-6}
+:::{.g-col-lg-6 .g-col-12}
 
 ```{python}
 from great_tables import GT, md, html
@@ -70,7 +70,7 @@ airquality_mini = airquality.head(10).assign(Year = 1973)
 
 :::
 
-:::{.g-col-6}
+:::{.g-col-lg-6 .g-col-12}
 
 ```{python}
 from great_tables import GT
@@ -118,7 +118,7 @@ wide_pops = (
 
 :::
 
-:::{.g-col-6}
+:::{.g-col-lg-6 .g-col-12}
 
 ```{python}
 from great_tables import GT, md, html


### PR DESCRIPTION
Currently, the example page shows two columns of examples, even when on narrow screens (e.g. on mobile). This PR changes examples to only display in two columns on large screens.

**before:**

<img width="631" alt="image" src="https://github.com/posit-dev/great-tables/assets/2574498/518a8b20-6972-4254-955f-62a743a5fe01">


**after:**

<img width="635" alt="image" src="https://github.com/posit-dev/great-tables/assets/2574498/683d26d4-7a9f-4a1e-93f3-e4badcef00bb">
