### PR TITLE
feat: add style.from_column, implement for loc.body

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -110,6 +110,7 @@ quartodoc:
         - style.fill
         - style.text
         - style.borders
+        - style.from_column
     - title: Helper functions
       desc: >
         An assortment of helper functions is available in the **Great Tables** package. The `md()`

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -110,7 +110,6 @@ quartodoc:
         - style.fill
         - style.text
         - style.borders
-        - style.from_column
     - title: Helper functions
       desc: >
         An assortment of helper functions is available in the **Great Tables** package. The `md()`
@@ -120,6 +119,7 @@ quartodoc:
       contents:
         - md
         - html
+        - from_column
         #- px
         #- pct
     - title: Value formatting functions

--- a/great_tables/__init__.py
+++ b/great_tables/__init__.py
@@ -12,6 +12,7 @@ from . import data
 from . import vals
 from . import loc
 from . import style
+from ._styles import FromColumn as from_column
 from ._helpers import letters, LETTERS, px, pct, md, html, random_id
 from .data import exibble
 
@@ -26,6 +27,7 @@ __all__ = (
     "md",
     "html",
     "random_id",
+    "from_column",
     "vals",
     "loc",
     "style",

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -378,12 +378,13 @@ def _(loc: LocTitle, data: GTData, style: List[CellStyle]) -> GTData:
 
 @set_style.register
 def _(loc: LocBody, data: GTData, style: List[CellStyle]) -> GTData:
-    positions = resolve(loc, data)
+    positions: List[CellPos] = resolve(loc, data)
 
     all_info: list[StyleInfo] = []
     for col_pos in positions:
+        row_styles = [entry._from_row(data._tbl_data, col_pos.row) for entry in style]
         crnt_info = StyleInfo(
-            locname="data", locnum=5, colname=col_pos.colname, rownum=col_pos.row, styles=style
+            locname="data", locnum=5, colname=col_pos.colname, rownum=col_pos.row, styles=row_styles
         )
         all_info.append(crnt_info)
 

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -366,6 +366,11 @@ def set_style(loc: Loc, data: GTData, style: List[str]) -> GTData:
 
 @set_style.register
 def _(loc: LocTitle, data: GTData, style: List[CellStyle]) -> GTData:
+    # validate ----
+    for entry in style:
+        entry._raise_if_has_from_column(loc)
+
+    # set ----
     if loc.groups == "title":
         info = StyleInfo(locname="title", locnum=1, styles=style)
     elif loc.groups == "subtitle":

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -368,7 +368,7 @@ def set_style(loc: Loc, data: GTData, style: List[str]) -> GTData:
 def _(loc: LocTitle, data: GTData, style: List[CellStyle]) -> GTData:
     # validate ----
     for entry in style:
-        entry._raise_if_has_from_column(loc)
+        entry._raise_if_requires_data(loc)
 
     # set ----
     if loc.groups == "title":
@@ -385,9 +385,12 @@ def _(loc: LocTitle, data: GTData, style: List[CellStyle]) -> GTData:
 def _(loc: LocBody, data: GTData, style: List[CellStyle]) -> GTData:
     positions: List[CellPos] = resolve(loc, data)
 
+    # evaluate any column expressions in styles
+    style_ready = [entry._evaluate_expressions(data._tbl_data) for entry in style]
+
     all_info: list[StyleInfo] = []
     for col_pos in positions:
-        row_styles = [entry._from_row(data._tbl_data, col_pos.row) for entry in style]
+        row_styles = [entry._from_row(data._tbl_data, col_pos.row) for entry in style_ready]
         crnt_info = StyleInfo(
             locname="data", locnum=5, colname=col_pos.colname, rownum=col_pos.row, styles=row_styles
         )

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -26,13 +26,13 @@ class FromColumn:
 
     ```{python}
     import pandas as pd
-    from great_tables import GT, exibble, loc, style
+    from great_tables import GT, exibble, from_column, loc, style
 
     df = pd.DataFrame({"x": [1, 2], "color": ["red", "blue"]})
 
     gt = GT(df)
     gt.tab_style(
-        style = style.text(color = style.from_column("color")),
+        style = style.text(color = from_column("color")),
         locations = loc.body(columns = ["x"])
     )
 

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -35,7 +35,18 @@ class FromColumn:
         style = style.text(color = from_column("color")),
         locations = loc.body(columns = ["x"])
     )
+    ```
 
+    If you are using polars, you can just pass polars expressions in directly:
+
+    ```{python}
+    import polars as pl
+
+    gt_polars = GT(pl.from_pandas(df))
+    gt_polars.tab_style(
+        style = style.text(color = pl.col("color")),    # <-- polars expression
+        locations = loc.body(columns = ["x"])
+    )
     ```
     """
 

--- a/great_tables/style.py
+++ b/great_tables/style.py
@@ -2,7 +2,6 @@ from ._styles import (
     CellStyleText as text,
     CellStyleFill as fill,
     CellStyleBorders as borders,
-    FromColumn as from_column,
 )
 
-__all__ = ("text", "fill", "borders", "from_column")
+__all__ = ("text", "fill", "borders")

--- a/great_tables/style.py
+++ b/great_tables/style.py
@@ -2,6 +2,7 @@ from ._styles import (
     CellStyleText as text,
     CellStyleFill as fill,
     CellStyleBorders as borders,
+    FromColumn as from_column,
 )
 
-__all__ = ("text", "fill", "borders")
+__all__ = ("text", "fill", "borders", "from_column")

--- a/tests/__snapshots__/test_locations.ambr
+++ b/tests/__snapshots__/test_locations.ambr
@@ -1,0 +1,9 @@
+# serializer version: 1
+# name: test_set_style_loc_title_from_column_error
+  '''
+  Location type <class 'great_tables._locations.LocTitle'> cannot use FromColumn.
+  
+  Style type: <class 'great_tables._styles.CellStyleText'>
+  Field with FromColumn: color
+  '''
+# ---

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -4,6 +4,7 @@ import pytest
 from great_tables._locations import (
     LocColumnSpanners,
     LocBody,
+    LocTitle,
     CellPos,
     resolve,
     resolve_vector_i,
@@ -104,3 +105,15 @@ def test_set_style_loc_body_from_column():
     assert len(cell_info.styles) == 1
     assert isinstance(cell_info.styles[0], CellStyleText)
     assert cell_info.styles[0].color == "blue"
+
+
+def test_set_style_loc_title_from_column_error(snapshot):
+    df = pd.DataFrame({"x": [1, 2], "color": ["red", "blue"]})
+    gt_df = GT(df)
+    loc = LocTitle("title")
+    style = CellStyleText(color=FromColumn("color"))
+
+    with pytest.raises(TypeError) as exc_info:
+        set_style(loc, gt_df, [style])
+
+    assert snapshot == exc_info.value.args[0]

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -92,7 +92,11 @@ def test_resolve_column_spanners_error_missing():
 
 @pytest.mark.parametrize(
     "expr",
-    [FromColumn("color"), pl.col("color"), pl.col("color").str.to_uppercase().str.to_lowercase()],
+    [
+        FromColumn("color"),
+        pl.col("color"),
+        pl.col("color").str.to_uppercase().str.to_lowercase(),
+    ],
 )
 def test_set_style_loc_body_from_column(expr):
     df = pd.DataFrame({"x": [1, 2], "color": ["red", "blue"]})

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -9,7 +9,9 @@ from great_tables._locations import (
     resolve_vector_i,
     resolve_cols_i,
     resolve_rows_i,
+    set_style,
 )
+from great_tables._styles import CellStyleText, FromColumn
 from great_tables._gt_data import Spanners, SpannerInfo
 from great_tables import GT
 
@@ -84,3 +86,21 @@ def test_resolve_column_spanners_error_missing():
 
     with pytest.raises(ValueError):
         resolve(loc, spanners)
+
+
+def test_set_style_loc_body_from_column():
+    df = pd.DataFrame({"x": [1, 2], "color": ["red", "blue"]})
+    gt_df = GT(df)
+    loc = LocBody(["x"], [1])
+    style = CellStyleText(color=FromColumn("color"))
+
+    new_gt = set_style(loc, gt_df, [style])
+
+    # 1 style info added
+    assert len(new_gt._styles) == 1
+    cell_info = new_gt._styles[0]
+
+    # style info has single cell style, with new color
+    assert len(cell_info.styles) == 1
+    assert isinstance(cell_info.styles[0], CellStyleText)
+    assert cell_info.styles[0].color == "blue"

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import polars as pl
 import pytest
 
 from great_tables._locations import (
@@ -89,11 +90,20 @@ def test_resolve_column_spanners_error_missing():
         resolve(loc, spanners)
 
 
-def test_set_style_loc_body_from_column():
+@pytest.mark.parametrize(
+    "expr",
+    [FromColumn("color"), pl.col("color"), pl.col("color").str.to_uppercase().str.to_lowercase()],
+)
+def test_set_style_loc_body_from_column(expr):
     df = pd.DataFrame({"x": [1, 2], "color": ["red", "blue"]})
-    gt_df = GT(df)
+
+    if isinstance(expr, pl.Expr):
+        gt_df = GT(pl.DataFrame(df))
+    else:
+        gt_df = GT(df)
+
     loc = LocBody(["x"], [1])
-    style = CellStyleText(color=FromColumn("color"))
+    style = CellStyleText(color=expr)
 
     new_gt = set_style(loc, gt_df, [style])
 

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from great_tables._styles import FromColumn, CellStyleText
+
+
+def test_from_column_replace():
+    """FromColumn is replaced by the specified column's value in a row of data"""
+
+    df = pd.DataFrame({"x": [1, 2], "color": ["red", "blue"]})
+    from_col = FromColumn("color")
+
+    style = CellStyleText(color=from_col)
+    new_style = style._from_row(df, 0)
+
+    assert style.color is from_col
+    assert new_style.color == "red"
+
+
+def test_from_column_fn():
+    df = pd.DataFrame({"x": [1, 2], "color": ["red", "blue"]})
+    from_col = FromColumn("color", fn=lambda x: x.upper())
+
+    style = CellStyleText(color=from_col)
+    new_style = style._from_row(df, 0)
+
+    assert new_style.color == "RED"


### PR DESCRIPTION
This PR implements the `from_column()` behavior from gt, which allows for setting a style based on values in the data.

e.g.

```python
import pandas as pd
from great_tables import GT, exibble, loc, style

df = pd.DataFrame({"x": [1, 2], "color": ["red", "blue"]})

gt = GT(df)
gt.tab_style(
    style = style.text(color = style.from_column("color")),
    locations = loc.body(columns = ["x"])
)
```

<img width="730" alt="image" src="https://github.com/posit-dev/great-tables/assets/2574498/ca82b89a-cfac-44b7-82a2-f383ab149a7b">

NOTES:

* **scope**: currently only implemented for setting in `loc.body()`, raises if you try to use it with `loc.title()`
* **implementation**: the R gt library handles from_column inside each `fmt_*` function. This PR puts the handling inside `set_style`, by implementing a CellStyle._from_row() method. This gives each style the chance to return a new version of itself based on the data, just before setting it on the GT object.
* **importing**: I put it under `style.from_column()`, but another place it could go is with helpers like `md()` at the top-level of the package?