### PR TITLE
fix: allow lists of styles and lists of locations

### DIFF
--- a/great_tables/_tab_create_modify.py
+++ b/great_tables/_tab_create_modify.py
@@ -82,7 +82,7 @@ def tab_style(
 
     new_data = self
     for loc in locations:
-        new_data = set_style(loc, self, style)
+        new_data = set_style(loc, new_data, style)
 
     return new_data
 

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -409,8 +409,6 @@ def create_columns_component_h(data: GTData) -> str:
 
 
 def create_body_component_h(data: GTData) -> str:
-    import pandas as pd
-
     # for now, just coerce everything in the original data to a string
     # so we can fill in the body data with it
     _str_orig_data = cast_frame_to_string(data._tbl_data)
@@ -482,13 +480,10 @@ def create_body_component_h(data: GTData) -> str:
 
             # Develop the `style` attribute for the current cell
             if len(styles_i) > 0:
-                style_entries = [x.styles for x in styles_i]
-                cell_styles_list: List[str] = []
-                for style in style_entries:
-                    style_element = style[0]
-                    rendered_style = style_element._to_html_style()
-                    cell_styles_list.append(rendered_style)
-                cell_styles = f'style="{" ".join(cell_styles_list)}"' + " "
+                # flatten all StyleInfo.styles lists
+                style_entries = list(chain(*[x.styles for x in styles_i]))
+                rendered_styles = [el._to_html_style() for el in style_entries]
+                cell_styles = f'style="{" ".join(rendered_styles)}"' + " "
             else:
                 cell_styles = ""
 

--- a/tests/__snapshots__/test_utils_render_html.ambr
+++ b/tests/__snapshots__/test_utils_render_html.ambr
@@ -17,6 +17,24 @@
   </tbody>
   '''
 # ---
+# name: test_body_multiple_styles
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td style="background-color: red; border-left: 1px solid #000000;" class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+  </tr>
+  </tbody>
+  '''
+# ---
 # name: test_source_notes_snap
   '''
     <tfoot class="gt_sourcenotes">

--- a/tests/__snapshots__/test_utils_render_html.ambr
+++ b/tests/__snapshots__/test_utils_render_html.ambr
@@ -1,4 +1,22 @@
 # serializer version: 1
+# name: test_body_multiple_locations
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td style="background-color: red;" class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td style="background-color: red;" class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td style="background-color: red;" class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+  </tr>
+  </tbody>
+  '''
+# ---
 # name: test_source_notes_snap
   '''
     <tfoot class="gt_sourcenotes">

--- a/tests/test_utils_render_html.py
+++ b/tests/test_utils_render_html.py
@@ -42,6 +42,15 @@ def test_body_multiple_locations(snapshot):
     assert_rendered_body(snapshot, new_gt)
 
 
+def test_body_multiple_styles(snapshot):
+    new_gt = GT(small_exibble).tab_style(
+        style=[style.fill(color="red"), style.borders("left")],
+        locations=loc.body(columns="num", rows=[0]),
+    )
+
+    assert_rendered_body(snapshot, new_gt)
+
+
 def test_styling_data_01(snapshot):
     new_gt = GT(small_exibble).tab_style(
         style=style.text(color="red"),

--- a/tests/test_utils_render_html.py
+++ b/tests/test_utils_render_html.py
@@ -30,6 +30,18 @@ def test_source_notes_snap(snapshot):
     assert_rendered_source_notes(snapshot, new_gt)
 
 
+def test_body_multiple_locations(snapshot):
+    new_gt = GT(small_exibble).tab_style(
+        style=style.fill(color="red"),
+        locations=[
+            loc.body(columns="num", rows=[0, 2]),
+            loc.body(columns="char", rows=[1]),
+        ],
+    )
+
+    assert_rendered_body(snapshot, new_gt)
+
+
 def test_styling_data_01(snapshot):
     new_gt = GT(small_exibble).tab_style(
         style=style.text(color="red"),


### PR DESCRIPTION
This PR addresses #84 and #85 by fixing support for lists of styles and locations. Previously, only the first style in a StyleInfo.styles list was used, and the locations code needed a lil tweak to accumulate locations