### PR TITLE
docs: get started with styling page

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -24,13 +24,16 @@ website:
       contents:
         - get-started/index.qmd
         - get-started/overview.qmd
-        - section: Basic
+        - section: Table Structure
           contents:
             - get-started/basic-header.qmd
             - get-started/basic-stub.qmd
             - get-started/basic-column-labels.qmd
+        - section: Format and Style
+          contents:
             - get-started/basic-formatting.qmd
-        - section: Advanced
+            - get-started/basic-styling.qmd
+        - section: Extra Topics
           contents:
             - get-started/column-selection.qmd
 

--- a/docs/get-started/basic-header.qmd
+++ b/docs/get-started/basic-header.qmd
@@ -1,5 +1,5 @@
 ---
-title: Header and Footer
+title: Header and footer
 jupyter: python3
 html-table-processing: none
 ---

--- a/docs/get-started/basic-styling.qmd
+++ b/docs/get-started/basic-styling.qmd
@@ -40,6 +40,39 @@ Notice two important arguments to `GT.tab_style()`:
 * `style.fill(...)`: the type of style to apply. In this case the fill (background color).
 * `loc.body(...)`: the area we want to style. In this case, it's the table body with specific columns and rows specified.
 
+In addition to `style.fill()`, several other styles exist. We'll look at styling borders and text in the following sections.
+
+### Customizing borders
+
+Use [`style.borders()`](/reference/style.borders.qmd) to put a border around target cells.
+
+For example, the table below has a red dashed border at the top of a couple rows.
+
+```{python}
+border_style = style.borders(sides="top", color="red", style="dashed", weight="3px")
+
+gt_air.tab_style(
+    style = border_style,
+    locations = loc.body(rows=[1, 2])
+)
+```
+
+
+### Customizing text
+
+Use [`style.text()`](/reference/style.text.qmd) to customize the text in target cells.
+
+For example, the `Solar_R` column below has green, bolded text in a custom font.
+
+```{python}
+text_style = style.text(color = "green", font="Times New Roman", weight="bold")
+
+gt_air.tab_style(
+    style = text_style,
+    locations = loc.body(columns = "Solar_R")
+)
+```
+
 ## Specifying columns and rows
 
 If you are using polars, you can use column selectors and expressions for selecting specific rows and columns:

--- a/docs/get-started/basic-styling.qmd
+++ b/docs/get-started/basic-styling.qmd
@@ -1,0 +1,188 @@
+---
+title: Stying the table body
+jupyter: python3
+html-table-processing: none
+---
+
+Great Tables can add styles---like color, text properties, and borders---on many different parts of
+the displayed table. This page covers setting styles on the body of table, where column data is displayed.
+
+For the examples on this page, we'll use the included airquality dataset to set up GT objects for both pandas and polars DataFrames.
+
+```{python}
+import polars as pl
+
+from great_tables import GT, from_column, style, loc
+from great_tables.data import airquality
+
+air_head = airquality.head()
+
+# we'll use pandas and polars examples on this page ----
+gt_air = GT(air_head)
+gt_pl_air = GT(pl.from_pandas(air_head))
+```
+
+## Style basics
+
+Use the `GT.tab_style()` method with `loc.body()` to set styles on cells of data in the table body.
+
+For example, the code below fills in specific cells with yellow.
+
+```{python}
+gt_air.tab_style(
+    style = style.fill("yellow"),
+    locations = loc.body(columns="Temp", rows=[1, 2])
+)
+```
+
+Notice two important arguments to `GT.tab_style()`:
+
+* `style.fill(...)`: the type of style to apply. In this case the fill (background color).
+* `loc.body(...)`: the area we want to style. In this case, it's the table body with specific columns and rows specified.
+
+## Specifying columns and rows
+
+If you are using polars, you can use column selectors and expressions for selecting specific rows and columns:
+
+```{python}
+import polars.selectors as cs
+
+gt_pl_air.tab_style(
+    style.fill("yellow"),
+    loc.body(cs.starts_with("Te"), pl.col("Temp") > 70)
+)
+```
+
+See [Column Selection](./column-selection.qmd) for details on selecting columns.
+
+## Column-based styles
+
+In addition to setting styles to specific values (e.g. "yellow" background), you can also use table
+columns to specify styles.
+
+```{python}
+df = pl.DataFrame({"x": [1, 2], "background": ["lightyellow", "lightblue"]})
+
+(
+    GT(df)
+    .tab_style(
+        style=style.fill(color=from_column("background")),
+        locations=loc.body("x")
+    )
+)
+```
+
+Notice that in the code above, we used `from_column("background") to specify the fill color for each styled row.
+
+
+In the next sections, we'll first show how this combines nicely with `GT.cols_hide()`, and then how to use polars
+expressions to do everything much more simply.
+
+### Using with `cols_hide()`
+
+One common approach is to specify a style from a column, and then hide that column in the final output.
+
+For example, we can add a background column to our airquality data:
+
+
+```{python}
+color_map = {
+    True: "lightyellow",
+    False: "lightblue"
+}
+
+with_color = air_head.assign(
+    background = (air_head["Temp"] > 70).replace(color_map)
+)
+
+with_color
+```
+
+Notice that airquality now has a `background` column set to either "lightyellow" or "lightblue", depending
+on whether `Temp` is above 70.
+
+We can then use this `background` column to set fill color, and then hide it:
+
+```{python}
+(
+    GT(with_color)
+    .tab_style(
+        style.fill(color = from_column("background")),
+        loc.body("Temp")
+    )
+    .cols_hide("background")
+)
+```
+
+Note the two methods used above:
+
+* `tab_style()`: uses `from_column()` to set the color using the values of the `background` column.
+* `cols_hide()`: prevents the `background` column from being displayed in the output.
+
+
+
+### Using polars expressions
+
+Styles can also be specified using polars expressions.
+
+For example, the code below uses the `Temp` column to set color to "lightyellow" or "lightblue".
+
+```{python}
+# polars expression defines color based on temp
+temp_color = (
+    pl.when(pl.col("Temp") > 70)
+    .then(pl.lit("lightyellow"))
+    .otherwise(pl.lit("lightblue"))
+)
+
+gt_pl_air.tab_style(
+    style.fill(color = temp_color),   # <-- uses the polars expression
+    loc.body("Temp")
+)
+```
+
+
+## Multiple styles and locations
+
+Use a list of styles to apply multiple styles at once.
+
+For example, the code below sets fill and border on the same cells.
+
+```{python}
+gt_air.tab_style(
+    [style.fill("yellow"), style.borders(sides = "all")],
+    loc.body("Temp", [1, 2])
+)
+```
+
+Note that you can also pass a list of locations in.
+
+```{python}
+gt_air.tab_style(
+    style.fill("yellow"),
+    [loc.body("Temp", [1, 2]), loc.body("Ozone", [0])]
+)
+
+```
+
+You can also combine polars selectors with a row filtering expression, in order to select a combination of columns and rows.
+
+```{python}
+import polars.selectors as cs
+
+gt_pl_air.tab_style(
+    style.fill("yellow"),
+    loc.body(
+        columns = cs.all().exclude(["Month", "Day"]),
+        rows = pl.col("Temp") == pl.col("Temp").max()
+    )
+)
+```
+
+
+## Learning more
+
+* API Docs:
+  - [`GT.tab_style()`](/reference/GT.tab_style.qmd).
+  - [`style.*` and `loc.*` functions`](/reference/index.qmd#location-targeting-and-styling-classes).
+  - [`from_column()`](/reference/from_column.qmd)

--- a/docs/get-started/basic-styling.qmd
+++ b/docs/get-started/basic-styling.qmd
@@ -73,20 +73,6 @@ gt_air.tab_style(
 )
 ```
 
-## Specifying columns and rows
-
-If you are using polars, you can use column selectors and expressions for selecting specific rows and columns:
-
-```{python}
-import polars.selectors as cs
-
-gt_pl_air.tab_style(
-    style.fill("yellow"),
-    loc.body(cs.starts_with("Te"), pl.col("Temp") > 70)
-)
-```
-
-See [Column Selection](./column-selection.qmd) for details on selecting columns.
 
 ## Column-based styles
 
@@ -173,6 +159,23 @@ gt_pl_air.tab_style(
     loc.body("Temp")
 )
 ```
+
+
+## Specifying columns and rows
+
+If you are using polars, you can use column selectors and expressions for selecting specific rows and columns:
+
+```{python}
+import polars.selectors as cs
+
+gt_pl_air.tab_style(
+    style.fill("yellow"),
+    loc.body(cs.starts_with("Te"), pl.col("Temp") > 70)
+)
+```
+
+See [Column Selection](./column-selection.qmd) for details on selecting columns.
+
 
 
 ## Multiple styles and locations


### PR DESCRIPTION
This PR adds a new page to Get Started called ["Styling the table body"](https://pr-88--gt-python.netlify.app/get-started/basic-styling), which covers the basics of styling with `loc.body()`. 

Note that I tried to structure Get Started a bit more, by splitting it into Table Structure, Format and Style, and Extra Topics for now:

<img width="237" alt="image" src="https://github.com/posit-dev/great-tables/assets/2574498/d9c70595-7268-4833-9fc4-a8d04be8fe6a">

Happy to discuss / change it to anything useful! It seems like once they're implemented we could add additional pages, like:

* footnotes to the Table Structure section
* styling other locations (like header) to the Format and Style section


TODO:

* Should titles use title case, or just capitalize the first letter?