### PR TITLE
Ensure that ID value in compiled CSS is applied to all rules

### DIFF
--- a/great_tables/_scss.py
+++ b/great_tables/_scss.py
@@ -138,7 +138,7 @@ def compile_scss(data: GTData, id: Optional[str], compress: bool = True) -> str:
     if has_id:
         compiled_css = re.sub(r"\.gt_", f"#{id} .gt_", compiled_css, 0, re.MULTILINE)
         compiled_css = re.sub(r"thead", f"#{id} thead", compiled_css, 0, re.MULTILINE)
-        compiled_css = re.sub(r"^p \{", f"#{id} p " + "{", compiled_css, 0, re.MULTILINE)
+        compiled_css = re.sub(r"^ p \{", f" #{id} p " + "{", compiled_css, 0, re.MULTILINE)
 
     finalized_css = f"{gt_table_class_str}\n\n{compiled_css}"
 

--- a/great_tables/_scss.py
+++ b/great_tables/_scss.py
@@ -138,7 +138,10 @@ def compile_scss(data: GTData, id: Optional[str], compress: bool = True) -> str:
     if has_id:
         compiled_css = re.sub(r"\.gt_", f"#{id} .gt_", compiled_css, 0, re.MULTILINE)
         compiled_css = re.sub(r"thead", f"#{id} thead", compiled_css, 0, re.MULTILINE)
-        compiled_css = re.sub(r"^ p \{", f" #{id} p " + "{", compiled_css, 0, re.MULTILINE)
+        if compress:
+            compiled_css = re.sub(r"^ p \{", f" #{id} p " + "{", compiled_css, 0, re.MULTILINE)
+        else:
+            compiled_css = re.sub(r"^p \{", f"#{id} p " + "{", compiled_css, 0, re.MULTILINE)
 
     finalized_css = f"{gt_table_class_str}\n\n{compiled_css}"
 

--- a/great_tables/_scss.py
+++ b/great_tables/_scss.py
@@ -138,10 +138,7 @@ def compile_scss(data: GTData, id: Optional[str], compress: bool = True) -> str:
     if has_id:
         compiled_css = re.sub(r"\.gt_", f"#{id} .gt_", compiled_css, 0, re.MULTILINE)
         compiled_css = re.sub(r"thead", f"#{id} thead", compiled_css, 0, re.MULTILINE)
-        if compress:
-            compiled_css = re.sub(r"^ p \{", f" #{id} p " + "{", compiled_css, 0, re.MULTILINE)
-        else:
-            compiled_css = re.sub(r"^p \{", f"#{id} p " + "{", compiled_css, 0, re.MULTILINE)
+        compiled_css = re.sub(r"^( p|p) \{", f"#{id} p {{", compiled_css, 0, re.MULTILINE)
 
     finalized_css = f"{gt_table_class_str}\n\n{compiled_css}"
 


### PR DESCRIPTION
This fixes a `re.sub()` statement in the `compile_scss()` function so that the table ID is inserted before the rule for the `p` element. This corrects a regression where the compiled CSS no longer worked with one of the `re.sub()` statements. With this fix, the rule for the table's `<p>` element is specific to the table (and doesn't affect the page itself).