### PR TITLE
Add the `fmt_datetime()` method

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -100,6 +100,7 @@ quartodoc:
         - GT.fmt_roman
         - GT.fmt_date
         - GT.fmt_time
+        - GT.fmt_datetime
         - GT.fmt_markdown
         - GT.fmt
     - title: Modifying columns

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -10,7 +10,7 @@ from ._utils import _str_detect, _str_replace
 import pandas as pd
 import math
 from datetime import datetime, date, time
-from babel.dates import format_date, format_time
+from babel.dates import format_date, format_time, format_datetime
 
 if TYPE_CHECKING:
     from ._types import GTSelf

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -1813,6 +1813,28 @@ def _validate_iso_datetime_str(x: str) -> None:
     return
 
 
+def _normalize_iso_datetime_str(x: str) -> str:
+    """
+    Normalize an ISO datetime string.
+
+    Parameters
+    ----------
+    x : str
+        The string to normalize.
+
+    Returns
+    -------
+    str
+        The normalized string.
+    """
+
+    # If the string does not have a seconds value, then add one
+    if len(x) == 16:
+        x = x + ":00"
+
+    return x
+
+
 def fmt_markdown(
     self: GTSelf,
     columns: Union[str, List[str], None] = None,

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -1786,6 +1786,179 @@ def fmt_time(
     return fmt(self, fns=fmt_time_fn, columns=columns, rows=rows)
 
 
+def fmt_datetime(
+    self: GTSelf,
+    columns: Union[str, List[str], None] = None,
+    rows: Union[int, List[int], None] = None,
+    date_style: DateStyle = "iso",
+    time_style: TimeStyle = "iso",
+    pattern: str = "{x}",
+    locale: Union[str, None] = None,
+) -> GTSelf:
+    """
+    Format values as datetimes.
+
+    Format input values to datetime values using one of 17 preset date styles and one of 5 preset
+    time styles. Input can be in the form of `datetime` values, or strings in the ISO 8601 forms of
+    `YYYY-MM-DD HH:MM:SS` or `YYYY-MM-DD`.
+
+    Parameters
+    ----------
+    columns : str | List[str] | None
+        The columns to target. Can either be a single column name or a series of column names
+        provided in a list.
+    rows : int | List[int] | None
+        In conjunction with `columns`, we can specify which of their rows should undergo formatting.
+        The default is all rows, resulting in all rows in `columns` being formatted. Alternatively,
+        we can supply a list of row indices.
+    date_style: str
+        The date style to use. By default this is the short name `"iso"` which corresponds to
+        ISO 8601 date formatting. There are 41 date styles in total and their short names can be
+        viewed using `info_date_style()`.
+    time_style: str
+        The time style to use. By default this is the short name `"iso"` which corresponds to how
+        times are formatted within ISO 8601 datetime values. There are 5 time styles in total and
+        their short names can be viewed using `info_time_style()`.
+
+    Formatting with the `date_style` and `time_style` arguments
+    ------------------------------------------------------------
+    We need to supply a preset date style to the `date_style` argument and a preset time style to
+    the `time_style` argument. The date styles are numerous and can handle localization to any
+    supported locale. The following table provides a listing of all date styles and their output
+    values (corresponding to an input date of `2000-02-29 14:35:00`).
+
+    |    | Date Style            | Output                  |
+    |----|-----------------------|-------------------------|
+    | 1  | `"iso"`               | `"2000-02-29 14:35:00"`  |
+    | 2  | `"wday_month_day_year"`| `"Tuesday, February 29, 2000 14:35:00"`  |
+    | 3  | `"wd_m_day_year"`     | `"Tue, Feb 29, 2000 14:35:00"`   |
+    | 4  | `"wday_day_month_year"`| `"Tuesday 29 February 2000 14:35:00"`    |
+    | 5  | `"month_day_year"`    | `"February 29, 2000 14:35:00"`   |
+    | 6  | `"m_day_year"`        | `"Feb 29, 2000 14:35:00"`        |
+    | 7  | `"day_m_year"`        | `"29 Feb 2000 14:35:00"`         |
+    | 8  | `"day_month_year"`    | `"29 February 2000 14:35:00"`    |
+    | 9  | `"day_month"`         | `"29 February 14:35:00"`         |
+    | 10 | `"day_m"`             | `"29 Feb 14:35:00"`              |
+    | 11 | `"year"`              | `"2000 14:35:00"`                |
+    | 12 | `"month"`             | `"February 14:35:00"`            |
+    | 13 | `"day"`               | `"29 14:35:00"`                  |
+    | 14 | `"year.mn.day"`       | `"2000/02/29 14:35:00"`          |
+    | 15 | `"y.mn.day"`          | `"00/02/29 14:35:00"`            |
+    | 16 | `"year_week"`         | `"2000-W09 14:35:00"`            |
+    | 17 | `"year_quarter"`      | `"2000-Q1 14:35:00"`             |
+
+    The time styles are numerous and can handle localization to any supported locale. The following
+    table provides a listing of all time styles and their output values (corresponding to an input
+    time of `2000-02-29 14:35:00`).
+
+    |    | Time Style    | Output                          | Notes         |
+    |----|---------------|---------------------------------|---------------|
+    | 1  | `"iso"`       | `"2000-02-29 14:35:00"`         | ISO 8601, 24h |
+    | 2  | `"iso-short"` | `"2000-02-29 14:35"`            | ISO 8601, 24h |
+    | 3  | `"h_m_s_p"`   | `"2:35:00 PM"`                  | 12h           |
+    | 4  | `"h_m_p"`     | `"2:35 PM"`                     | 12h           |
+    | 5  | `"h_p"`       | `"2 PM"`                        | 12h           |
+
+    We can use the `info_date_style()` and `info_time_style()` functions within the console to view
+    similar tables of date and time styles with example output.
+
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+
+    Examples
+    --------
+    Let's use the `exibble` dataset to create a simple, two-column table (keeping only the `date`
+    and `time` columns). With the `fmt_datetime()` method, we'll format the `date` column to display
+    dates formatted with the `"month_day_year"` date style and the `time` column to display times
+    formatted with the `"h_m_s_p"` time style.
+
+    ```{python}
+    import great_tables as gt
+
+    exibble_mini = gt.data.exibble[[\"date\", \"time\"]]
+
+    (
+        gt.GT(exibble_mini)
+        .fmt_datetime(
+            columns=\"date\",
+            date_style=\"month_day_year\",
+            time_style=\"h_m_s_p\"
+        )
+    )
+    ```
+    """
+
+    # Stop if `locale` does not have a valid value; normalize locale and resolve one
+    # that might be set globally
+    _validate_locale(locale=locale)
+    locale = _normalize_locale(locale=locale)
+
+    # Get the date format string based on the `date_style` value
+    date_format_str = _get_date_format(date_style=date_style)
+
+    # Get the time format string based on the `time_style` value
+    time_format_str = _get_time_format(time_style=time_style)
+
+    # Generate a function that will operate on single `x` values in the table body using both
+    # the date and time format strings
+    def fmt_datetime_fn(
+        x: Any,
+        date_format_str: str = date_format_str,
+        time_format_str: str = time_format_str,
+        locale: Union[str, None] = locale,
+    ) -> str:
+        # If the `x` value is a Pandas 'NA', then return the same value
+        if pd.isna(x):
+            return x
+
+        # If the `x` value is infinite, then return the same value
+        if math.isinf(x):
+            # If positive infinity, return the string "Inf"
+            if x > 0:
+                return "Inf"
+            # If negative infinity, return the string "-Inf"
+            else:
+                return "-Inf"
+
+        # From the date and time format strings, create a datetime format string
+        datetime_format_str = f"{date_format_str} {time_format_str}"
+
+        # If `x` is a string, assume it is an ISO datetime string and convert it to a datetime object
+        if isinstance(x, str):
+            # Stop if `x` is not a valid ISO datetime string
+            _validate_iso_datetime_str(x=x)
+
+            # Ensure that a seconds value is present in the ISO datetime string
+            x = _normalize_iso_datetime_str(x=x)
+
+            # Convert the ISO datetime string to a datetime object
+            x = _iso_to_datetime(x)
+
+        else:
+            # Stop if `x` is not a valid datetime object
+            _validate_datetime_obj(x=x)
+
+        # Fix up the locale for `format_datetime()` by replacing any hyphens with underscores
+        if locale is None:
+            locale = "en_US"
+        else:
+            locale = _str_replace(locale, "-", "_")
+
+        # Format the datetime object to a string using Babel's `format_datetime()` function
+        x_formatted = format_datetime(x, format=datetime_format_str, locale=locale)
+
+        # Use a supplied pattern specification to decorate the formatted value
+        if pattern != "{x}":
+            x_formatted = pattern.replace("{x}", x_formatted)
+
+        return x_formatted
+
+    return fmt(self, fns=fmt_datetime_fn, columns=columns, rows=rows)
+
+
 def _validate_iso_datetime_str(x: str) -> None:
     """
     Validate an ISO datetime string.

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -3065,3 +3065,22 @@ def _validate_time_obj(x: Any) -> None:
         raise ValueError(f"Invalid time object: '{x}'. The object must be a time object.")
 
     return
+
+
+def _validate_datetime_obj(x: Any) -> None:
+    """
+    Validate if the given object is a valid datetime object.
+
+    Args:
+        x (Any): The object to be validated.
+
+    Raises:
+        ValueError: If the object is not a valid datetime object.
+
+    Returns:
+        None
+    """
+    if not isinstance(x, datetime):
+        raise ValueError(f"Invalid datetime object: '{x}'. The object must be a datetime object.")
+
+    return

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -2950,6 +2950,19 @@ def _iso_to_time(x: str) -> time:
     return datetime.strptime(x, "%H:%M:%S").time()
 
 
+def _iso_to_datetime(x: str) -> datetime:
+    """
+    Converts a string in ISO format to a datetime object.
+
+    Args:
+        x (str): The string to be converted.
+
+    Returns:
+        datetime: The converted datetime object.
+    """
+    return datetime.strptime(x, "%Y-%m-%d %H:%M:%S")
+
+
 def _validate_iso_date_str(x: str) -> None:
     """
     Validates if the given string is a valid ISO date string in the format 'YYYY-MM-DD'.

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -1786,6 +1786,33 @@ def fmt_time(
     return fmt(self, fns=fmt_time_fn, columns=columns, rows=rows)
 
 
+def _validate_iso_datetime_str(x: str) -> None:
+    """
+    Validate an ISO datetime string.
+
+    Parameters
+    ----------
+    x : str
+        The string to validate.
+
+    Raises
+    ------
+    ValueError
+        Raised if the string is not a valid ISO datetime string.
+    """
+
+    import re
+
+    # Define the regex pattern for a valid ISO datetime string
+    _ISO_DATETIME_REGEX = r"^\d{4}-\d{2}-\d{2}(T| )\d{2}:\d{2}(:\d{2})?$"
+
+    # Use regex to determine if string is a valid ISO datetime string
+    if not re.match(_ISO_DATETIME_REGEX, x):
+        raise ValueError(f'"{x}" is not a valid ISO datetime string')
+
+    return
+
+
 def fmt_markdown(
     self: GTSelf,
     columns: Union[str, List[str], None] = None,

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -1829,23 +1829,23 @@ def fmt_datetime(
 
     |    | Date Style            | Output                  |
     |----|-----------------------|-------------------------|
-    | 1  | `"iso"`               | `"2000-02-29 14:35:00"`  |
-    | 2  | `"wday_month_day_year"`| `"Tuesday, February 29, 2000 14:35:00"`  |
-    | 3  | `"wd_m_day_year"`     | `"Tue, Feb 29, 2000 14:35:00"`   |
-    | 4  | `"wday_day_month_year"`| `"Tuesday 29 February 2000 14:35:00"`    |
-    | 5  | `"month_day_year"`    | `"February 29, 2000 14:35:00"`   |
-    | 6  | `"m_day_year"`        | `"Feb 29, 2000 14:35:00"`        |
-    | 7  | `"day_m_year"`        | `"29 Feb 2000 14:35:00"`         |
-    | 8  | `"day_month_year"`    | `"29 February 2000 14:35:00"`    |
-    | 9  | `"day_month"`         | `"29 February 14:35:00"`         |
-    | 10 | `"day_m"`             | `"29 Feb 14:35:00"`              |
-    | 11 | `"year"`              | `"2000 14:35:00"`                |
-    | 12 | `"month"`             | `"February 14:35:00"`            |
-    | 13 | `"day"`               | `"29 14:35:00"`                  |
-    | 14 | `"year.mn.day"`       | `"2000/02/29 14:35:00"`          |
-    | 15 | `"y.mn.day"`          | `"00/02/29 14:35:00"`            |
-    | 16 | `"year_week"`         | `"2000-W09 14:35:00"`            |
-    | 17 | `"year_quarter"`      | `"2000-Q1 14:35:00"`             |
+    | 1  | `"iso"`               | `"2000-02-29"`          |
+    | 2  | `"wday_month_day_year"`| `"Tuesday, February 29, 2000"`  |
+    | 3  | `"wd_m_day_year"`     | `"Tue, Feb 29, 2000"`   |
+    | 4  | `"wday_day_month_year"`| `"Tuesday 29 February 2000"`    |
+    | 5  | `"month_day_year"`    | `"February 29, 2000"`   |
+    | 6  | `"m_day_year"`        | `"Feb 29, 2000"`        |
+    | 7  | `"day_m_year"`        | `"29 Feb 2000"`         |
+    | 8  | `"day_month_year"`    | `"29 February 2000"`    |
+    | 9  | `"day_month"`         | `"29 February"`         |
+    | 10 | `"day_m"`             | `"29 Feb"`              |
+    | 11 | `"year"`              | `"2000"`                |
+    | 12 | `"month"`             | `"February"`            |
+    | 13 | `"day"`               | `"29"`                  |
+    | 14 | `"year.mn.day"`       | `"2000/02/29"`          |
+    | 15 | `"y.mn.day"`          | `"00/02/29"`            |
+    | 16 | `"year_week"`         | `"2000-W09"`            |
+    | 17 | `"year_quarter"`      | `"2000-Q1"`             |
 
     The time styles are numerous and can handle localization to any supported locale. The following
     table provides a listing of all time styles and their output values (corresponding to an input
@@ -1853,8 +1853,8 @@ def fmt_datetime(
 
     |    | Time Style    | Output                          | Notes         |
     |----|---------------|---------------------------------|---------------|
-    | 1  | `"iso"`       | `"2000-02-29 14:35:00"`         | ISO 8601, 24h |
-    | 2  | `"iso-short"` | `"2000-02-29 14:35"`            | ISO 8601, 24h |
+    | 1  | `"iso"`       | `"14:35:00"`                    | ISO 8601, 24h |
+    | 2  | `"iso-short"` | `"14:35"`                       | ISO 8601, 24h |
     | 3  | `"h_m_s_p"`   | `"2:35:00 PM"`                  | 12h           |
     | 4  | `"h_m_p"`     | `"2:35 PM"`                     | 12h           |
     | 5  | `"h_p"`       | `"2 PM"`                        | 12h           |

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -1792,6 +1792,7 @@ def fmt_datetime(
     rows: Union[int, List[int], None] = None,
     date_style: DateStyle = "iso",
     time_style: TimeStyle = "iso",
+    sep: str = " ",
     pattern: str = "{x}",
     locale: Union[str, None] = None,
 ) -> GTSelf:
@@ -1908,6 +1909,7 @@ def fmt_datetime(
         x: Any,
         date_format_str: str = date_format_str,
         time_format_str: str = time_format_str,
+        sep: str = sep,
         locale: Union[str, None] = locale,
     ) -> str:
         # If the `x` value is a Pandas 'NA', then return the same value
@@ -1915,7 +1917,7 @@ def fmt_datetime(
             return x
 
         # From the date and time format strings, create a datetime format string
-        datetime_format_str = f"{date_format_str} {time_format_str}"
+        datetime_format_str = f"{date_format_str}'{sep}'{time_format_str}"
 
         # If `x` is a string, assume it is an ISO datetime string and convert it to a datetime object
         if isinstance(x, str):

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -1914,15 +1914,6 @@ def fmt_datetime(
         if pd.isna(x):
             return x
 
-        # If the `x` value is infinite, then return the same value
-        if math.isinf(x):
-            # If positive infinity, return the string "Inf"
-            if x > 0:
-                return "Inf"
-            # If negative infinity, return the string "-Inf"
-            else:
-                return "-Inf"
-
         # From the date and time format strings, create a datetime format string
         datetime_format_str = f"{date_format_str} {time_format_str}"
 

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -21,6 +21,7 @@ from great_tables._formats import (
     fmt_roman,
     fmt_date,
     fmt_time,
+    fmt_datetime,
     fmt_markdown,
 )
 from great_tables._heading import tab_header
@@ -202,6 +203,7 @@ class GT(
     fmt_roman = fmt_roman
     fmt_date = fmt_date
     fmt_time = fmt_time
+    fmt_datetime = fmt_datetime
     fmt_markdown = fmt_markdown
 
     tab_options = tab_options


### PR DESCRIPTION
This adds a basic implementation of the `fmt_datetime()` method, which allows for the formatting of datetime values/strings using separate patterns for the date and time parts. A separator between date and time parts is permitted here through the `sep` argument.