### PR TITLE
ci: restore deploy url

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -72,6 +72,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           env: ${{ steps.deployment.outputs.env }}
+          env_url: "https://${{ steps.deployment.outputs.env }}--gt-python.netlify.app"
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
 
       - uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
This PR re-adds the deployment url to our docs CI, so there is a clickable link to a PR's preview docs