### PR TITLE
Fix tab spanner column name

### DIFF
--- a/docs/get-started/index.qmd
+++ b/docs/get-started/index.qmd
@@ -86,7 +86,7 @@ gt_airquality = (
         subtitle="Daily measurements in New York City (May 1-10, 1973)",
     )
     .tab_spanner(label="Time", columns=["Year", "Month", "Day"])
-    .tab_spanner(label="Measurement", columns=["Ozone", "Solar.R", "Wind", "Temp"])
+    .tab_spanner(label="Measurement", columns=["Ozone", "Solar_R", "Wind", "Temp"])
     .cols_move_to_start(columns=["Year", "Month", "Day"])
     .cols_label(
         Ozone=html("Ozone,<br>ppbV"),


### PR DESCRIPTION
The example tab_spanner doesn't use the right name, so the table in the docs isn't created as intended.

# Summary

Fixes the air quality example so the output table includes the correct columns in the label spanner, as intended by the code.

# Related GitHub Issues and PRs

- Ref: #110 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.
