### PR TITLE
Fix validate frame

### DIFF
--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -7,7 +7,7 @@ from typing import overload, TypeVar, Dict, Optional
 from typing_extensions import Self, TypeAlias
 from dataclasses import dataclass, field, replace
 from ._utils import _str_detect
-from ._tbl_data import create_empty_frame, to_list
+from ._tbl_data import create_empty_frame, to_list, validate_frame
 
 from ._styles import CellStyle
 
@@ -62,6 +62,7 @@ class GTData:
         auto_align: bool = True,
         locale: str | None = None,
     ):
+        validate_frame(data)
         stub = Stub(data, rowname_col=rowname_col, groupname_col=groupname_col)
         boxhead = Boxhead(
             data, auto_align=auto_align, rowname_col=rowname_col, groupname_col=groupname_col

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -461,7 +461,7 @@ def validate_frame(df: DataFrameLike) -> None:
 @validate_frame.register
 def _(df: PdDataFrame):
     dupes = df.columns[df.columns.duplicated()]
-    if dupes:
+    if len(dupes):
         raise ValueError(
             "Column names must be unique. Detected duplicate columns:\n\n" f"    {list(dupes)}"
         )

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -451,3 +451,22 @@ def _(df: PlDataFrame, expr: PlExpr) -> List[Any]:
         )
 
     return res.to_list()
+
+
+@singledispatch
+def validate_frame(df: DataFrameLike) -> None:
+    raise NotImplementedError(f"Unsupported type: {type(df)}")
+
+
+@validate_frame.register
+def _(df: PdDataFrame):
+    dupes = df.columns[df.columns.duplicated()]
+    if dupes:
+        raise ValueError(
+            "Column names must be unique. Detected duplicate columns:\n\n" f"    {list(dupes)}"
+        )
+
+
+@validate_frame.register
+def _(df: PlDataFrame):
+    return None

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -463,7 +463,7 @@ def _(df: PdDataFrame):
     dupes = df.columns[df.columns.duplicated()]
     if len(dupes):
         raise ValueError(
-            "Column names must be unique. Detected duplicate columns:\n\n" f"    {list(dupes)}"
+            f"Column names must be unique. Detected duplicate columns:\n\n {list(dupes)}"
         )
 
 

--- a/tests/test_tbl_data.py
+++ b/tests/test_tbl_data.py
@@ -86,3 +86,14 @@ def test_validate_frame_dupe_cols():
         validate_frame(df)
 
     assert "Column names must be unique" in str(exc_info.value.args[0])
+
+
+def test_validate_frame_multi_index():
+    df = pd.DataFrame(
+        [[1, 2, 3]], columns=pd.MultiIndex.from_tuples([("a", "x"), ("a", "y"), ("b", "x")])
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_frame(df)
+
+    assert "MultiIndex columns are not supported" in str(exc_info.value.args[0])

--- a/tests/test_tbl_data.py
+++ b/tests/test_tbl_data.py
@@ -12,6 +12,7 @@ from great_tables._tbl_data import (
     reorder,
     eval_select,
     create_empty_frame,
+    validate_frame,
 )
 
 
@@ -76,3 +77,12 @@ def test_create_empty_frame(df: DataFrameLike):
         dst = pl.DataFrame({"col1": col, "col2": col, "col3": col}).cast(pl.Utf8)
 
     assert_frame_equal(res, dst)
+
+
+def test_validate_frame_dupe_cols():
+    df = pd.DataFrame([[1, 2, 3]], columns=["x", "x", "y"])
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_frame(df)
+
+    assert "Column names must be unique" in str(exc_info.value.args[0])


### PR DESCRIPTION
Addresses #117 by giving a hopefully diagnostic error message, when a pandas DataFrame with duplicate column names is passed: `Column names must be unique. Detected duplicate columns:\n\n <specific list>`

~TODO: we should also fail DataFrames with multi-index columns.~ (done!)

Fixes: https://github.com/posit-dev/great-tables/issues/117