### PR TITLE
fix: validate_frame now coerces non string column names

### DIFF
--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -62,7 +62,7 @@ class GTData:
         auto_align: bool = True,
         locale: str | None = None,
     ):
-        validate_frame(data)
+        data = validate_frame(data)
         stub = Stub(data, rowname_col=rowname_col, groupname_col=groupname_col)
         boxhead = Boxhead(
             data, auto_align=auto_align, rowname_col=rowname_col, groupname_col=groupname_col

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -519,7 +519,7 @@ def _(df: PdDataFrame) -> PdDataFrame:
     non_str_cols = [(ii, el) for ii, el in enumerate(df.columns) if not isinstance(el, str)]
 
     if non_str_cols:
-        _col_msg = "\n".join(f"  * Position {ii}: {col}" for ii, col in non_str_cols)
+        _col_msg = "\n".join(f"  * Position {ii}: {col}" for ii, col in non_str_cols[:3])
         warnings.warn(
             "pandas DataFrame contains non-string column names. Coercing to strings."
             "Here are the first three non-string columns:\n\n"

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 from functools import singledispatch
 from typing import Any, Dict, List, Union, Callable, Tuple, TYPE_CHECKING
 from typing_extensions import TypeAlias
@@ -486,7 +488,7 @@ def _(df: PlDataFrame, x: Any) -> bool:
 
 
 @singledispatch
-def validate_frame(df: DataFrameLike) -> None:
+def validate_frame(df: DataFrameLike) -> DataFrameLike:
     """Raises an error if a DataFrame is not supported by Great Tables.
 
     Note that this is only relevant for pandas, which allows duplicate names
@@ -496,7 +498,7 @@ def validate_frame(df: DataFrameLike) -> None:
 
 
 @validate_frame.register
-def _(df: PdDataFrame):
+def _(df: PdDataFrame) -> PdDataFrame:
     import pandas as pd
 
     # case 1: multi-index columns ----
@@ -514,7 +516,23 @@ def _(df: PdDataFrame):
             f"Column names must be unique. Detected duplicate columns:\n\n {list(dupes)}"
         )
 
+    non_str_cols = [(ii, el) for ii, el in enumerate(df.columns) if not isinstance(el, str)]
+
+    if non_str_cols:
+        _col_msg = "\n".join(f"  * Position {ii}: {col}" for ii, col in non_str_cols)
+        warnings.warn(
+            "pandas DataFrame contains non-string column names. Coercing to strings."
+            "Here are the first three non-string columns:\n\n"
+            f"{_col_msg}",
+            category=UserWarning,
+        )
+        new_df = df.copy()
+        new_df.columns = [str(el) for el in df.columns]
+        return new_df
+
+    return df
+
 
 @validate_frame.register
-def _(df: PlDataFrame):
-    return None
+def _(df: PlDataFrame) -> PlDataFrame:
+    return df

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -521,8 +521,8 @@ def _(df: PdDataFrame) -> PdDataFrame:
     if non_str_cols:
         _col_msg = "\n".join(f"  * Position {ii}: {col}" for ii, col in non_str_cols[:3])
         warnings.warn(
-            "pandas DataFrame contains non-string column names. Coercing to strings."
-            "Here are the first three non-string columns:\n\n"
+            "pandas DataFrame contains non-string column names. Coercing to strings. "
+            "Here are the first few non-string columns:\n\n"
             f"{_col_msg}",
             category=UserWarning,
         )

--- a/tests/__snapshots__/test_tbl_data.ambr
+++ b/tests/__snapshots__/test_tbl_data.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: test_validate_frame_non_str_cols_warning
   '''
-  pandas DataFrame contains non-string column names. Coercing to strings.Here are the first three non-string columns:
+  pandas DataFrame contains non-string column names. Coercing to strings. Here are the first few non-string columns:
   
     * Position 1: 55
     * Position 3: 99

--- a/tests/__snapshots__/test_tbl_data.ambr
+++ b/tests/__snapshots__/test_tbl_data.ambr
@@ -1,0 +1,9 @@
+# serializer version: 1
+# name: test_validate_frame_non_str_cols_warning
+  '''
+  pandas DataFrame contains non-string column names. Coercing to strings.Here are the first three non-string columns:
+  
+    * Position 1: 55
+    * Position 3: 99
+  '''
+# ---

--- a/tests/test_tbl_data.py
+++ b/tests/test_tbl_data.py
@@ -97,3 +97,22 @@ def test_validate_frame_multi_index():
         validate_frame(df)
 
     assert "MultiIndex columns are not supported" in str(exc_info.value.args[0])
+
+
+def test_validate_frame_non_str_cols_warning(snapshot):
+    df = pd.DataFrame({"x": [1], 55: [2], "y": [3], 99: [4]})
+
+    with pytest.warns(UserWarning) as record:
+        validate_frame(df)
+
+    assert len(record) == 1
+    assert snapshot == record[0].message.args[0]
+
+
+def test_validate_frame_non_str_cols_result():
+    df = pd.DataFrame({"x": [1], 55: [2], "y": [3], 99: [4]})
+
+    with pytest.warns(UserWarning):
+        res = validate_frame(df)
+
+    assert list(res.columns) == ["x", "55", "y", "99"]


### PR DESCRIPTION
This PR addresses #125 by...

* coercing non-string column names in pandas to strings.
* giving a UserWarning, with details on which columns were coerced

Note that polars requires column names to be strings, so shouldn't be affected by this particular case.