### PR TITLE
Add example for sza and `data_color()`

### DIFF
--- a/docs/examples/index.qmd
+++ b/docs/examples/index.qmd
@@ -36,6 +36,7 @@ islands_mini = islands.head(10)
 ```
 
 :::
+
 :::{.g-col-lg-6 .g-col-12}
 
 ```{python}
@@ -124,7 +125,6 @@ wide_pops = (
 from great_tables import GT, md, html
 from great_tables.data import towny
 
-
 towny_mini = (towny[["name", "website", "density_2021", "land_area_km2",
               "latitude", "longitude"]].sort_values("density_2021",
               ascending=False).head(10))
@@ -135,7 +135,6 @@ towny_mini["url_name"] = (["["] + towny_mini["name"] + ["]"] +
 towny_mini["location"] =( ["[map](http://maps.google.com/?ie=UTF8&hq=&ll="] +
                           towny_mini["latitude"].astype(str) + [","] +
                           towny_mini["longitude"].astype(str) + ["&z=13)"])
-
 
 (
     GT(towny_mini[["url_name", "location", "land_area_km2","density_2021"]], rowname_col = "url_name")
@@ -157,6 +156,37 @@ towny_mini["location"] =( ["[map](http://maps.google.com/?ie=UTF8&hq=&ll="] +
 )
 
 
+```
+
+:::
+
+:::{.g-col-lg-6 .g-col-12}
+
+```{python}
+from great_tables import html
+from great_tables.data import sza
+import polars.selectors as cs
+
+sza_pivot = (
+    pl.from_pandas(sza)
+    .filter((pl.col("latitude") == "20") & (pl.col("tst") <= "1200"))
+    .select(pl.col("*").exclude("latitude"))
+    .drop_nulls()
+    .pivot(values="sza", index="month", columns="tst", sort_columns=True)
+)
+
+(
+    GT(sza_pivot, rowname_col="month")
+    .data_color(
+        domain=[90, 0],
+        palette=["rebeccapurple", "white", "orange"],
+        na_color="white",
+    )
+    .tab_header(
+        title="Solar Zenith Angles from 05:30 to 12:00",
+        subtitle=html("Average monthly values at latitude of 20&deg;N."),
+    )
+)
 ```
 
 :::


### PR DESCRIPTION
This adds an example (the `sza`/`data_color()` one) to the Examples page.

Fixes: #135 