### PR TITLE
Add the `cols_width()` method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,4 +113,3 @@ playground.html
 playground_files
 manual-testing.py
 manual-testing.ipynb
-

--- a/.gitignore
+++ b/.gitignore
@@ -106,8 +106,11 @@ typings/
 docs/source/generated/
 docs/source/reference/
 
-# Playground Scripts
+# Playground Scripts and temporary outputs
 playground*.py
 playground*.qmd
+playground.html
+playground_files
 manual-testing.py
 manual-testing.ipynb
+

--- a/.gitignore
+++ b/.gitignore
@@ -108,5 +108,6 @@ docs/source/reference/
 
 # Playground Scripts
 playground*.py
+playground*.qmd
 manual-testing.py
 manual-testing.ipynb

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -115,6 +115,7 @@ quartodoc:
         `cols_move*()` methods).
       contents:
         - GT.cols_align
+        - GT.cols_width
         - GT.cols_label
         - GT.cols_move
         - GT.cols_move_to_start

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -144,8 +144,6 @@ quartodoc:
         - md
         - html
         - from_column
-        #- px
-        #- pct
     - title: Value formatting functions
       desc: >
         If you have single values (or lists of them) in need of formatting, we have a set of

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -467,6 +467,22 @@ class Boxhead(_Sequence[ColInfo]):
 
         return n_data_cols
 
+    def _set_column_width(self, colname: str, width: str) -> Self:
+        out_cols: List[ColInfo] = []
+
+        colnames = [x.var for x in self._d]
+
+        if colname not in colnames:
+            raise ValueError(f"Column name {colname} not found in table.")
+
+        for x in self._d:
+            if x.var == colname:
+                out_cols.append(replace(x, column_width=width))
+            else:
+                out_cols.append(x)
+
+        return self.__class__(out_cols)
+
 
 # Stub ----
 __Stub = None

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -580,6 +580,31 @@ def cols_width(data: GTSelf, cases: Dict[str, str]) -> GTSelf:
         The GT object is returned. This is the same object that the method is called on so that we
         can facilitate method chaining.
 
+    Examples
+    --------
+    Let's use select columns from the [`exibble`] dataset to create a new table. We can specify the
+    widths of columns with `cols_width()`. This is done by specifying the exact widths for table
+    columns in a dictionary. In this example, we'll set the width of the `num` column to `150px`,
+    the `char` column to `100px`, the `date` column to `300px`. All other columns won't be affected
+    (their widths will be automatically set by their content).
+
+    ```python
+    import great_tables as gt
+    from great_tables.data import exibble
+
+    exibble_mini = exibble[[\"num\", \"char\", \"date\", \"datetime\", \"row\"]].head(5)
+
+    (
+        gt.GT(exibble_mini)
+        .cols_width(
+            cases={
+                "num": \"150px\",
+                "char": \"100px\",
+                "date": \"300px\"
+            }
+        )
+    )
+    ```
     """
 
     curr_boxhead = data._boxhead

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -639,9 +639,10 @@ def cols_width(data: GTSelf, cases: Dict[str, str]) -> GTSelf:
     )
     ```
 
-    If we set the width of all columns, the table will be forced to use the specified widths. In
-    this example, we'll set widths for all columns. This is a good way to ensure that the widths
-    you specify are fully respected (and not overridden by automatic width calculations).
+    If we set the width of all columns, the table will be forced to use the specified widths (i.e.,
+    a column width less than the content width will be honored). In this next example, we'll set
+    widths for all columns. This is a good way to ensure that the widths you specify are fully
+    respected (and not overridden by automatic width calculations).
 
     ```{python}
     (
@@ -657,6 +658,11 @@ def cols_width(data: GTSelf, cases: Dict[str, str]) -> GTSelf:
         )
     )
     ```
+
+    Notice that in the above example, the `num` column is very small (only `30px`) and the content
+    overflows. When not specifying the width of all columns, the table will automatically adjust the
+    column widths based on the content (and you wouldn't get the overflowing behavior seen in the
+    previous example).
     """
 
     curr_boxhead = data._boxhead

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -605,6 +605,58 @@ def cols_width(data: GTSelf, cases: Dict[str, str]) -> GTSelf:
         )
     )
     ```
+
+    We can also specify the widths of columns as percentages. In this example, we'll set the width
+    of the `num` column to `20%`, the `char` column to `10%`, and the `date` column to `30%`. Note
+    that the percentages are relative and don't need to sum to 100%.
+
+    ```python
+    (
+        gt.GT(exibble_mini)
+        .cols_width(
+            cases={
+                "num": \"20%\",
+                "char": \"10%\",
+                "date": \"30%\"
+            }
+        )
+    )
+    ```
+
+    We can also mix and match pixel and percentage widths. In this example, we'll set the width of
+    the `num` column to `150px`, the `char` column to `10%`, and the `date` column to `30%`.
+
+    ```python
+    (
+        gt.GT(exibble_mini)
+        .cols_width(
+            cases={
+                "num": \"150px\",
+                "char": \"10%\",
+                "date": \"30%\"
+            }
+        )
+    )
+    ```
+
+    If we set the width of all columns, the table will be forced to use the specified widths. In
+    this example, we'll set widths for all columns. This is a good way to ensure that the widths
+    you specify are fully respected (and not overridden by automatic width calculations).
+
+    ```python
+    (
+        gt.GT(exibble_mini)
+        .cols_width(
+            cases={
+                "num": \"30px\",
+                "char": \"100px\",
+                "date": \"100px\",
+                "datetime": \"200px\",
+                "row": \"50px\"
+            }
+        )
+    )
+    ```
     """
 
     curr_boxhead = data._boxhead

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -558,3 +558,33 @@ def seq_groups(seq: list[str]):
 
 def is_equal(x: Any, y: Any) -> bool:
     return x is not None and x == y
+
+
+def cols_width(data: GTSelf, cases: Dict[str, str]) -> GTSelf:
+    """Set the widths of columns.
+
+    Manual specifications of column widths can be performed using the `cols_width()` method. We
+    choose which columns get specific widths. This can be in units of pixels or as percentages.
+    Width assignments are supplied inside of a dictionary where columns are the keys and the
+    corresponding width is the value.
+
+    Parameters
+    ----------
+    cases : Dict[str, str]
+        A dictionary where the keys are column names and the values are the widths. Widths can be
+        specified in pixels (e.g., `"50px"`) or as percentages (e.g., `"20%"`).
+
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+
+    """
+
+    curr_boxhead = data._boxhead
+
+    for col, width in cases.items():
+        curr_boxhead = curr_boxhead._set_column_width(col, width)
+
+    return data._replace(_boxhead=curr_boxhead)

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -588,7 +588,7 @@ def cols_width(data: GTSelf, cases: Dict[str, str]) -> GTSelf:
     the `char` column to `100px`, the `date` column to `300px`. All other columns won't be affected
     (their widths will be automatically set by their content).
 
-    ```python
+    ```{python}
     import great_tables as gt
     from great_tables.data import exibble
 
@@ -610,7 +610,7 @@ def cols_width(data: GTSelf, cases: Dict[str, str]) -> GTSelf:
     of the `num` column to `20%`, the `char` column to `10%`, and the `date` column to `30%`. Note
     that the percentages are relative and don't need to sum to 100%.
 
-    ```python
+    ```{python}
     (
         gt.GT(exibble_mini)
         .cols_width(
@@ -626,7 +626,7 @@ def cols_width(data: GTSelf, cases: Dict[str, str]) -> GTSelf:
     We can also mix and match pixel and percentage widths. In this example, we'll set the width of
     the `num` column to `150px`, the `char` column to `10%`, and the `date` column to `30%`.
 
-    ```python
+    ```{python}
     (
         gt.GT(exibble_mini)
         .cols_width(
@@ -643,7 +643,7 @@ def cols_width(data: GTSelf, cases: Dict[str, str]) -> GTSelf:
     this example, we'll set widths for all columns. This is a good way to ensure that the widths
     you specify are fully respected (and not overridden by automatic width calculations).
 
-    ```python
+    ```{python}
     (
         gt.GT(exibble_mini)
         .cols_width(

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -661,9 +661,8 @@ def _get_table_defs(data: GTData) -> dict[str, Any]:
     # TODO: ensure that the stub column is set first in the list
     widths = data._boxhead._get_column_widths()
 
-    # If all of the widths are defined as px values for all columns,
-    # then ensure that the width values are strictly respected as
-    # absolute width values (even if a table width has already been set)
+    # If all of the widths are defined as px values for all columns, then ensure that the width
+    # values are strictly respected as absolute width values (even if table width already set)
     if (
         all(isinstance(width, str) and width is not None and "px" in width for width in widths)
         and table_width == "auto"

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -640,7 +640,6 @@ def _get_spanners_matrix_height(
 
 # Get the attributes needed for the <table> tag
 def _get_table_defs(data: GTData) -> dict[str, Any]:
-
     # Get the `table-layout` value, which is set in `_options`
     table_layout = data._options.table_layout.value
     table_style = f"table-layout: {table_layout};"

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -645,18 +645,19 @@ def _get_table_defs(data: GTData) -> dict[str, Any]:
     table_style = f"table-layout: {table_layout};"
 
     # Get the number of columns that have a width set
-    n_column_width = len(data._boxhead._get_column_widths())
+    column_widths = data._boxhead._get_column_widths()
 
-    # In the case that column widths are not set for any columns,
-    # there should not be a `<colgroup>` tag requirement
-    if n_column_width < 1:
+    # If all values in the `column_widths` lists are None, then return a dictionary with
+    # `table_style` and `table_colgroups` set to None; this is the case where column widths are
+    # not set for any columns and, as a result, there should not be a `<colgroup>` tag requirement
+    if all(width is None for width in column_widths):
         return dict(table_style=None, table_colgroups=None)
 
     # Get the table's width (which or may not have been set)
     table_width = data._options.table_width.value
 
-    # Get all the widths for the columns as a list where None values mean
-    # that the width is not set for that column
+    # Get all the widths for the columns as a list where None values mean that the width is
+    # not set for that column
     # TODO: ensure that the stub column is set first in the list
     widths = data._boxhead._get_column_widths()
 
@@ -685,4 +686,6 @@ def _get_table_defs(data: GTData) -> dict[str, Any]:
     # Create the `<colgroup>` tag
     table_colgroups = tags.colgroup([tags.col(style=css(width=width)) for width in widths])
 
-    return dict(table_style=table_style, table_colgroups=table_colgroups)
+    table_defs_dict = dict(table_style=table_style, table_colgroups=table_colgroups)
+
+    return table_defs_dict

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -639,7 +639,8 @@ def _get_spanners_matrix_height(
 
 
 # Get the attributes needed for the <table> tag
-def _get_table_defs(data: GTData):
+def _get_table_defs(data: GTData) -> dict[str, Any]:
+
     # Get the `table-layout` value, which is set in `_options`
     table_layout = data._options.table_layout.value
     table_style = f"table-layout: {table_layout};"

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -287,8 +287,14 @@ class GT(
         quarto_disable_processing = str(self._options.quarto_disable_processing.value).lower()
         quarto_use_bootstrap = str(self._options.quarto_use_bootstrap.value).lower()
 
-        html_table = f"""<table class=\"gt_table\" data-quarto-disable-processing="{quarto_disable_processing}" data-quarto-bootstrap="{quarto_use_bootstrap}">
-{table_defs["table_colgroups"]}
+        # If table_defs["table_colgroups"] is None, then we set table_colgroups to an empty string;
+        # if present, wrap the value with newlines
+        if table_defs["table_colgroups"] is None:
+            table_colgroups = ""
+        else:
+            table_colgroups = f"\n{table_defs['table_colgroups']}\n"
+
+        html_table = f"""<table class=\"gt_table\" data-quarto-disable-processing="{quarto_disable_processing}" data-quarto-bootstrap="{quarto_use_bootstrap}">{table_colgroups}
 {heading_component.make_string()}
 {column_labels_component}
 {body_component}

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -294,7 +294,12 @@ class GT(
         else:
             table_colgroups = f"\n{table_defs['table_colgroups']}\n"
 
-        html_table = f"""<table class=\"gt_table\" data-quarto-disable-processing="{quarto_disable_processing}" data-quarto-bootstrap="{quarto_use_bootstrap}">{table_colgroups}
+        if table_defs["table_style"] is None:
+            table_tag_open = f'<table class="gt_table" data-quarto-disable-processing="{quarto_disable_processing}" data-quarto-bootstrap="{quarto_use_bootstrap}">'
+        else:
+            table_tag_open = f'<table class="gt_table" data-quarto-disable-processing="{quarto_disable_processing}" data-quarto-bootstrap="{quarto_use_bootstrap}">'
+
+        html_table = f"""{table_tag_open}{table_colgroups}
 {heading_component.make_string()}
 {column_labels_component}
 {body_component}

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -41,6 +41,7 @@ from great_tables._spanners import (
     cols_move_to_start,
     cols_move_to_end,
     cols_hide,
+    cols_width
 )
 from great_tables._stub import reorder_stub_df
 from great_tables._stubhead import tab_stubhead
@@ -223,6 +224,7 @@ class GT(
     cols_move_to_start = cols_move_to_start
     cols_move_to_end = cols_move_to_end
     cols_hide = cols_hide
+    cols_width = cols_width
 
     tab_stubhead = tab_stubhead
 

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -41,7 +41,7 @@ from great_tables._spanners import (
     cols_move_to_start,
     cols_move_to_end,
     cols_hide,
-    cols_width
+    cols_width,
 )
 from great_tables._stub import reorder_stub_df
 from great_tables._stubhead import tab_stubhead
@@ -52,6 +52,7 @@ from great_tables._utils_render_html import (
     create_body_component_h,
     create_source_notes_component_h,
     create_footnotes_component_h,
+    _get_table_defs,
 )
 from great_tables._tab_create_modify import tab_style
 
@@ -279,13 +280,15 @@ class GT(
         source_notes_component = create_source_notes_component_h(data=self)
         footnotes_component = create_footnotes_component_h(data=self)
 
+        # Get attributes for the table
+        table_defs = _get_table_defs(data=self)
+
         # Determine whether Quarto processing of the table is enabled
-        quarto_disable_processing = self._options.quarto_disable_processing.value
-        quarto_use_bootstrap = self._options.quarto_use_bootstrap.value
-        quarto_disable_processing = str(quarto_disable_processing).lower()
-        quarto_use_bootstrap = str(quarto_use_bootstrap).lower()
+        quarto_disable_processing = str(self._options.quarto_disable_processing.value).lower()
+        quarto_use_bootstrap = str(self._options.quarto_use_bootstrap.value).lower()
 
         html_table = f"""<table class=\"gt_table\" data-quarto-disable-processing="{quarto_disable_processing}" data-quarto-bootstrap="{quarto_use_bootstrap}">
+{table_defs["table_colgroups"]}
 {heading_component.make_string()}
 {column_labels_component}
 {body_component}
@@ -325,6 +328,23 @@ class GT(
         """
 
         return finalized_table
+
+    def _finalize_html_table(
+        style: str, quarto_disable_processing: str, quarto_use_bootstrap: str, *args: Any
+    ) -> str:
+        from htmltools import tags, HTML, css, TagList
+
+        html_tbl = tags.table(
+            data_quarto_disable_processing=quarto_disable_processing,
+            data_quarto_bootstrap=quarto_use_bootstrap,
+            *args,
+            class_="gt_table",
+            style=style,
+        )
+
+        html_tbl = str(html_tbl)
+
+        return html_tbl
 
 
 # =============================================================================

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -297,7 +297,7 @@ class GT(
         if table_defs["table_style"] is None:
             table_tag_open = f'<table class="gt_table" data-quarto-disable-processing="{quarto_disable_processing}" data-quarto-bootstrap="{quarto_use_bootstrap}">'
         else:
-            table_tag_open = f'<table class="gt_table" data-quarto-disable-processing="{quarto_disable_processing}" data-quarto-bootstrap="{quarto_use_bootstrap}">'
+            table_tag_open = f'<table style="{table_defs["table_style"]}" class="gt_table" data-quarto-disable-processing="{quarto_disable_processing}" data-quarto-bootstrap="{quarto_use_bootstrap}">'
 
         html_table = f"""{table_tag_open}{table_colgroups}
 {heading_component.make_string()}

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -179,3 +179,48 @@ def test_cols_move_polars():
 
     new_gt = cols_move(src_gt, columns=cs.starts_with("a"), after="b")
     assert [col.var for col in new_gt._boxhead] == ["b", "a", "c"]
+
+
+def test_cols_width_partial_set():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    gt_tbl = GT(df).cols_width({"a": "10px"})
+
+    assert gt_tbl._boxhead[0].column_width == "10px"
+    assert gt_tbl._boxhead[1].column_width == None
+    assert gt_tbl._boxhead[2].column_width == None
+
+
+def test_cols_width_fully_set():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    gt_tbl = GT(df).cols_width({"a": "10px", "b": "20px", "c": "30px"})
+
+    assert gt_tbl._boxhead[0].column_width == "10px"
+    assert gt_tbl._boxhead[1].column_width == "20px"
+    assert gt_tbl._boxhead[2].column_width == "30px"
+
+
+def test_cols_width_partial_set_pct():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    gt_tbl = GT(df).cols_width({"a": "20%"})
+
+    assert gt_tbl._boxhead[0].column_width == "20%"
+    assert gt_tbl._boxhead[1].column_width == None
+    assert gt_tbl._boxhead[2].column_width == None
+
+
+def test_cols_width_fully_set_pct():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    gt_tbl = GT(df).cols_width({"a": "20%", "b": "20%", "c": "60%"})
+
+    assert gt_tbl._boxhead[0].column_width == "20%"
+    assert gt_tbl._boxhead[1].column_width == "20%"
+    assert gt_tbl._boxhead[2].column_width == "60%"
+
+
+def test_cols_width_fully_set_pct_2():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    gt_tbl = GT(df).cols_width({"a": "10%", "b": "10%", "c": "40%"})
+
+    assert gt_tbl._boxhead[0].column_width == "10%"
+    assert gt_tbl._boxhead[1].column_width == "10%"
+    assert gt_tbl._boxhead[2].column_width == "40%"


### PR DESCRIPTION
This adds the `cols_width()` method, which allows for sizing of columns with CSS length or percentage values. The list of columns and sizes is to be provided in a dictionary.