### PR TITLE
Add `opt*` methods to vertical and horizontal padding

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -154,6 +154,7 @@ quartodoc:
         - GT.opt_align_table_header
         - GT.opt_all_caps
         - GT.opt_vertical_padding
+        - GT.opt_horizontal_padding
     - title: Value formatting functions
       desc: >
         If you have single values (or lists of them) in need of formatting, we have a set of

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -153,6 +153,7 @@ quartodoc:
       contents:
         - GT.opt_align_table_header
         - GT.opt_all_caps
+        - GT.opt_vertical_padding
     - title: Value formatting functions
       desc: >
         If you have single values (or lists of them) in need of formatting, we have a set of

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -736,16 +736,16 @@ def opt_align_table_header(self: GTSelf, align: str = "center") -> GTSelf:
     (
       GT(
         exibble[["num", "char", "currency", "row", "group"]],
-        rowname_col = "row",
-        groupname_col = "group"
+        rowname_col="row",
+        groupname_col="group"
       )
       .tab_header(
-        title = md("Data listing from **exibble**"),
-        subtitle = md("`exibble` is a **Great Tables** dataset.")
+        title=md("Data listing from **exibble**"),
+        subtitle=md("`exibble` is a **Great Tables** dataset.")
       )
-      .fmt_number(columns = "num")
-      .fmt_currency(columns = "currency")
-      .tab_source_note(source_note = "This is only a subset of the dataset.")
+      .fmt_number(columns="num")
+      .fmt_currency(columns="currency")
+      .tab_source_note(source_note="This is only a subset of the dataset.")
       .opt_align_table_header(align="left")
     )
     ```
@@ -756,9 +756,102 @@ def opt_align_table_header(self: GTSelf, align: str = "center") -> GTSelf:
     return tab_options(self, heading_align=align)
 
 
-# TODO: create the `opt_vertical_padding()` method
+def opt_vertical_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
+    """
+    Option to scale the vertical padding of the table.
 
-# TODO: create the `opt_horizontal_padding()` method
+    This method allows us to scale the vertical padding of the table by a factor of `scale`. The
+    default value is `1.0` and this method serves as a convenient shortcut for
+    `gt.tab_options(heading_padding=<new_val>, column_labels_padding=<new_val>,
+    data_row_padding=<new_val>, row_group_padding=<new_val>, summary_row_padding=<new_val>,
+    grand_summary_row_padding=<new_val>, footnotes_padding=<new_val>,
+    source_notes_padding=<new_val>)`.
+
+    Parameters
+    ----------
+    scale : float
+        The factor by which to scale the vertical padding. The default value is `1.0`. A value
+        less than `1.0` will reduce the padding, and a value greater than `1.0` will increase the
+        padding. The value must be between `0` and `3`.
+
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+
+    Examples
+    --------
+    Using select columns from the `exibble` dataset, let's create a table with a number of
+    components added. Following that, we'll scale the vertical padding of the table by a factor of
+    `1.5` using the `opt_vertical_padding()` method.
+
+    ```{python}
+    from great_tables import GT, exibble, md
+
+    gt_tbl = (
+        GT(
+            exibble[["num", "char", "currency", "row", "group"]],
+            rowname_col="row",
+            groupname_col="group"
+        )
+        .tab_header(
+            title=md("Data listing from **exibble**"),
+            subtitle=md("`exibble` is a **Great Tables** dataset.")
+        )
+        .fmt_number(columns = "num")
+        .fmt_currency(columns = "currency")
+        .tab_source_note(source_note = "This is only a subset of the dataset.")
+    )
+
+    gt_tbl.opt_vertical_padding(scale=1.5)
+    ```
+
+    Let's go the other way and scale the vertical padding of the table by a factor of `0.5` using
+    the `opt_vertical_padding()` method.
+
+    ```{python}
+    gt_tbl.opt_vertical_padding(scale=0.5)
+    ```
+    """
+
+    # Stop if `scale` is beyond an acceptable range
+    if scale < 0 or scale > 3:
+        raise ValueError("`scale` must be a value between `0` and `3`.")
+
+    # Get the parameters from the options that relate to vertical padding
+    vertical_padding_params = [
+        "heading_padding",
+        "column_labels_padding",
+        "data_row_padding",
+        "row_group_padding",
+        "summary_row_padding",
+        "grand_summary_row_padding",
+        "footnotes_padding",
+        "source_notes_padding",
+    ]
+
+    # Get the current values for the vertical padding parameters
+    vertical_padding_vals = [
+        self._options.heading_padding.value,
+        self._options.column_labels_padding.value,
+        self._options.data_row_padding.value,
+        self._options.row_group_padding.value,
+        self._options.summary_row_padding.value,
+        self._options.grand_summary_row_padding.value,
+        self._options.footnotes_padding.value,
+        self._options.source_notes_padding.value,
+    ]
+
+    # Multiply each of the padding values by the `scale` factor but strip off the units first
+    # then reattach the units after the multiplication
+    # TODO: a current limitation is that the padding values must be in pixels and not percentages
+    # TODO: another limitation is that the returned values must be in integer pixel values
+    new_vertical_padding_vals = [
+        str(int(float(v.split("px")[0]) * scale)) + "px" for v in vertical_padding_vals
+    ]
+
+    return tab_options(self, **dict(zip(vertical_padding_params, new_vertical_padding_vals)))
 
 
 def opt_all_caps(

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -931,14 +931,14 @@ def opt_horizontal_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
 
     # Get the current values for the horizontal padding parameters
     horizontal_padding_vals = [
-        self._options.heading_padding.value,
-        self._options.column_labels_padding.value,
-        self._options.data_row_padding.value,
-        self._options.row_group_padding.value,
-        self._options.summary_row_padding.value,
-        self._options.grand_summary_row_padding.value,
-        self._options.footnotes_padding.value,
-        self._options.source_notes_padding.value,
+        self._options.heading_padding_horizontal.value,
+        self._options.column_labels_padding_horizontal.value,
+        self._options.data_row_padding_horizontal.value,
+        self._options.row_group_padding_horizontal.value,
+        self._options.summary_row_padding_horizontal.value,
+        self._options.grand_summary_row_padding_horizontal.value,
+        self._options.footnotes_padding_horizontal.value,
+        self._options.source_notes_padding_horizontal.value,
     ]
 
     # Multiply each of the padding values by the `scale` factor but strip off the units first

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -854,6 +854,104 @@ def opt_vertical_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
     return tab_options(self, **dict(zip(vertical_padding_params, new_vertical_padding_vals)))
 
 
+def opt_horizontal_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
+    """
+    Option to scale the horizontal padding of the table.
+
+    This method allows us to scale the horizontal padding of the table by a factor of `scale`. The
+    default value is `1.0` and this method serves as a convenient shortcut for `gt.tab_options(
+    heading_padding_horizontal=<new_val>, column_labels_padding_horizontal=<new_val>,
+    data_row_padding_horizontal=<new_val>, row_group_padding_horizontal=<new_val>,
+    summary_row_padding_horizontal=<new_val>, grand_summary_row_padding_horizontal=<new_val>,
+    footnotes_padding_horizontal=<new_val>, source_notes_padding_horizontal=<new_val>)`.
+
+    Parameters
+    ----------
+    scale : float
+        The factor by which to scale the horizontal padding. The default value is `1.0`. A value
+        less than `1.0` will reduce the padding, and a value greater than `1.0` will increase the
+        padding. The value must be between `0` and `3`.
+
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+
+    Examples
+    --------
+    Using select columns from the `exibble` dataset, let's create a table with a number of
+    components added. Following that, we'll scale the horizontal padding of the table by a factor of
+    `1.5` using the `opt_horizontal_padding()` method.
+
+    ```{python}
+    from great_tables import GT, exibble, md
+
+    gt_tbl = (
+        GT(
+            exibble[["num", "char", "currency", "row", "group"]],
+            rowname_col="row",
+            groupname_col="group"
+        )
+        .tab_header(
+            title=md("Data listing from **exibble**"),
+            subtitle=md("`exibble` is a **Great Tables** dataset.")
+        )
+        .fmt_number(columns = "num")
+        .fmt_currency(columns = "currency")
+        .tab_source_note(source_note = "This is only a subset of the dataset.")
+    )
+
+    gt_tbl.opt_horizontal_padding(scale=1.5)
+    ```
+
+    Let's go the other way and scale the horizontal padding of the table by a factor of `0.5` using
+    the `opt_horizontal_padding()` method.
+
+    ```{python}
+    gt_tbl.opt_horizontal_padding(scale=0.5)
+    ```
+    """
+
+    # Stop if `scale` is beyond an acceptable range
+    if scale < 0 or scale > 3:
+        raise ValueError("`scale` must be a value between `0` and `3`.")
+
+    # Get the parameters from the options that relate to horizontal padding
+    horizontal_padding_params = [
+        "heading_padding_horizontal",
+        "column_labels_padding_horizontal",
+        "data_row_padding_horizontal",
+        "row_group_padding_horizontal",
+        "summary_row_padding_horizontal",
+        "grand_summary_row_padding_horizontal",
+        "footnotes_padding_horizontal",
+        "source_notes_padding_horizontal",
+    ]
+
+    # Get the current values for the horizontal padding parameters
+    horizontal_padding_vals = [
+        self._options.heading_padding.value,
+        self._options.column_labels_padding.value,
+        self._options.data_row_padding.value,
+        self._options.row_group_padding.value,
+        self._options.summary_row_padding.value,
+        self._options.grand_summary_row_padding.value,
+        self._options.footnotes_padding.value,
+        self._options.source_notes_padding.value,
+    ]
+
+    # Multiply each of the padding values by the `scale` factor but strip off the units first
+    # then reattach the units after the multiplication
+    # TODO: a current limitation is that the padding values must be in pixels and not percentages
+    # TODO: another limitation is that the returned values must be in integer pixel values
+    new_horizontal_padding_vals = [
+        str(int(float(v.split("px")[0]) * scale)) + "px" for v in horizontal_padding_vals
+    ]
+
+    return tab_options(self, **dict(zip(horizontal_padding_params, new_horizontal_padding_vals)))
+
+
 def opt_all_caps(
     self: GTSelf,
     all_caps: bool = True,

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -807,16 +807,22 @@ def opt_vertical_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
     gt_tbl.opt_vertical_padding(scale=3)
     ```
 
-    Let's go the other way and scale the vertical padding of the table by a factor of `0.5` using
-    the `opt_vertical_padding()` method.
+    Now that's a tall table! The overall effect of scaling the vertical padding is that the table
+    will appear taller and there will be more buffer space between the table elements. A value of
+    `3` is pretty extreme and is likely to be too much in most cases, so, feel free to experiment
+    with different values when looking to increase the vertical padding.
+
+    Let's go the other way (using a value less than `1`) and try to condense the content vertically
+    with a `scale` factor of `0.5`. This will reduce the top and bottom padding globally and make
+    the table appear more compact.
 
     ```{python}
     gt_tbl.opt_vertical_padding(scale=0.5)
     ```
 
-    Notice that with values less than `1.0` the padding is reduced and more rows will fit into a
-    given space. With values greater than `1.0` the padding is increased and fewer rows will be
-    displayed per unit of space.
+    A value of `0.5` provides a reasonable amount of vertical padding and the table will appear more
+    compact. This is useful when space is limited and, in such a situation, this is a practical
+    solution to that problem.
     """
 
     # Stop if `scale` is beyond an acceptable range

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -784,7 +784,7 @@ def opt_vertical_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
     --------
     Using select columns from the `exibble` dataset, let's create a table with a number of
     components added. Following that, we'll scale the vertical padding of the table by a factor of
-    `1.5` using the `opt_vertical_padding()` method.
+    `3` using the `opt_vertical_padding()` method.
 
     ```{python}
     from great_tables import GT, exibble, md
@@ -804,7 +804,7 @@ def opt_vertical_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
         .tab_source_note(source_note = "This is only a subset of the dataset.")
     )
 
-    gt_tbl.opt_vertical_padding(scale=1.5)
+    gt_tbl.opt_vertical_padding(scale=3)
     ```
 
     Let's go the other way and scale the vertical padding of the table by a factor of `0.5` using
@@ -813,6 +813,10 @@ def opt_vertical_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
     ```{python}
     gt_tbl.opt_vertical_padding(scale=0.5)
     ```
+
+    Notice that with values less than `1.0` the padding is reduced and more rows will fit into a
+    given space. With values greater than `1.0` the padding is increased and fewer rows will be
+    displayed per unit of space.
     """
 
     # Stop if `scale` is beyond an acceptable range
@@ -882,7 +886,7 @@ def opt_horizontal_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
     --------
     Using select columns from the `exibble` dataset, let's create a table with a number of
     components added. Following that, we'll scale the horizontal padding of the table by a factor of
-    `1.5` using the `opt_horizontal_padding()` method.
+    `3` using the `opt_horizontal_padding()` method.
 
     ```{python}
     from great_tables import GT, exibble, md
@@ -902,8 +906,12 @@ def opt_horizontal_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
         .tab_source_note(source_note = "This is only a subset of the dataset.")
     )
 
-    gt_tbl.opt_horizontal_padding(scale=1.5)
+    gt_tbl.opt_horizontal_padding(scale=3)
     ```
+
+    The overall effect of scaling the horizontal padding is that the table will appear wider or
+    and there will added buffer space between the table elements. The overall look of the table will
+    be more spacious and neigboring pieces of text will be less cramped.
 
     Let's go the other way and scale the horizontal padding of the table by a factor of `0.5` using
     the `opt_horizontal_padding()` method.
@@ -911,6 +919,10 @@ def opt_horizontal_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
     ```{python}
     gt_tbl.opt_horizontal_padding(scale=0.5)
     ```
+
+    What you get in this case is more condensed text across the horizontal axis. This may not always
+    be desired when cells consist mainly of text, but it could be useful when the table is more
+    visual and the cells are filled with graphics or other non-textual elements.
     """
 
     # Stop if `scale` is beyond an acceptable range

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -34,6 +34,7 @@ from great_tables._options import (
     opt_footnote_marks,
     opt_row_striping,
     opt_vertical_padding,
+    opt_horizontal_padding,
 )
 from great_tables._source_notes import tab_source_note
 from great_tables._spanners import (
@@ -218,6 +219,7 @@ class GT(
     opt_footnote_marks = opt_footnote_marks
     opt_row_striping = opt_row_striping
     opt_vertical_padding = opt_vertical_padding
+    opt_horizontal_padding = opt_horizontal_padding
 
     tab_header = tab_header
 

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -33,6 +33,7 @@ from great_tables._options import (
     opt_all_caps,
     opt_footnote_marks,
     opt_row_striping,
+    opt_vertical_padding,
 )
 from great_tables._source_notes import tab_source_note
 from great_tables._spanners import (
@@ -216,6 +217,7 @@ class GT(
     opt_all_caps = opt_all_caps
     opt_footnote_marks = opt_footnote_marks
     opt_row_striping = opt_row_striping
+    opt_vertical_padding = opt_vertical_padding
 
     tab_header = tab_header
 


### PR DESCRIPTION
Given there is padding in the cells of different locations, we could set these globally through modification of parameters in `tab_options()`. This is cumbersome because cleanly scaling an entire table up and down should involve a single scaling factor, and the user would need to scale current length values for the appropriate padding options and set those in one go.

Having the `opt*` methods `opt_vertical_padding()` and `opt_horizontal_padding()` makes this much easier. The only parameter needed here is `scale`. 

Fixes: https://github.com/posit-dev/great-tables/issues/153