### PR TITLE
docs: blog superbowl, add source

### DIFF
--- a/docs/blog/superbowl-squares/_code.py
+++ b/docs/blog/superbowl-squares/_code.py
@@ -1,6 +1,6 @@
 import polars as pl
 import polars.selectors as cs
-from great_tables import GT
+from great_tables import GT, md
 
 
 # Utilities -----
@@ -60,4 +60,9 @@ joint = (
     .tab_stubhead("")
     .tab_spanner("San Francisco 49ers", cs.all())
     .tab_stubhead("KC Chiefs")
+    .tab_source_note(
+        md(
+            '<span style="float: right;">Source: [Lee Sharpe, nflverse](https://github.com/nflverse/nfldata)</span>'
+        )
+    )
 )

--- a/docs/blog/superbowl-squares/_code.py
+++ b/docs/blog/superbowl-squares/_code.py
@@ -62,7 +62,7 @@ joint = (
     .tab_stubhead("KC Chiefs")
     .tab_source_note(
         md(
-            '<span style="float: right;">Source: [Lee Sharpe, nflverse](https://github.com/nflverse/nfldata)</span>'
+            '<span style="float: right;">Source data: [Lee Sharpe, nflverse](https://github.com/nflverse/nfldata)</span>'
         )
     )
 )


### PR DESCRIPTION
This PR makes a small tweak to the Super Bowl blogpost, to add a source data reference to Lee Sharpe and the nflverse