### PR TITLE
Clean up examples in API docs

### DIFF
--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -33,10 +33,10 @@ def cols_label(self: GTSelf, **kwargs: Any) -> GTSelf:
     Parameters
     ----------
     **kwargs : str
-        The column names and new labels. The column names are provided as keyword arguments
-        and the new labels are provided as the values for those keyword arguments. For example,
-        `cols_label(col1="Column 1", col2="Column 2")` would relabel columns `col1`
-        and `col2` with the labels `"Column 1"` and `"Column 2"`, respectively.
+        The column names and new labels. The column names are provided as keyword arguments and the
+        new labels are provided as the values for those keyword arguments. For example,
+        `cols_label(col1="Column 1", col2="Column 2")` would relabel columns `col1` and `col2` with
+        the labels `"Column 1"` and `"Column 2"`, respectively.
 
     Returns
     -------
@@ -51,33 +51,36 @@ def cols_label(self: GTSelf, **kwargs: Any) -> GTSelf:
     case we are supplying the name of the column as the key, and the label text as the value.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT
     from great_tables.data import countrypops
 
-    countrypops_mini = countrypops.loc[countrypops[\"country_name\"] == \"Uganda\"][
-        [\"country_name\", \"year\", \"population\"]
+    countrypops_mini = countrypops.loc[countrypops["country_name"] == "Uganda"][
+        ["country_name", "year", "population"]
     ].tail(5)
 
     (
-        gt.GT(countrypops_mini)
+        GT(countrypops_mini)
         .cols_label(
-            country_name=\"Name\",
-            year=\"Year\",
-            population=\"Population\"
+            country_name="Name",
+            year="Year",
+            population="Population"
         )
     )
     ```
 
     We can also use Markdown formatting for the column labels. In this example, we'll use
-    `gt.md("*Population*")` to make the label italicized.
+    `md("*Population*")` to make the label italicized.
 
     ```{python}
+    from great_tables import GT, md
+    from great_tables.data import countrypops
+
     (
-        gt.GT(countrypops_mini)
+        GT(countrypops_mini)
         .cols_label(
-            country_name=\"Name\",
-            year=\"Year\",
-            population=gt.md(\"*Population*\")
+            country_name="Name",
+            year="Year",
+            population=md("*Population*")
         )
     )
     ```
@@ -132,16 +135,16 @@ def cols_align(self: GTSelf, align: str = "left", columns: Optional[str] = None)
     `population` will be aligned to the left.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT
     from great_tables.data import countrypops
 
-    countrypops_mini = countrypops.loc[countrypops[\"country_name\"] == \"San Marino\"][
-        [\"country_name\", \"year\", \"population\"]
+    countrypops_mini = countrypops.loc[countrypops["country_name"] == "San Marino"][
+        ["country_name", "year", "population"]
     ].tail(5)
 
     (
-        gt.GT(countrypops_mini, rowname_col=\"year\", groupname_col=\"country_name\")
-        .cols_align(align=\"left\", columns=\"population\")
+        GT(countrypops_mini, rowname_col="year", groupname_col="country_name")
+        .cols_align(align="left", columns="population")
     )
     ```
 

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -3341,6 +3341,7 @@ def fmt_image(
             file_pattern="metro_{}.svg"
         )
         .fmt_integer(columns="passengers")
+    )
     ```
     """
 

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -1073,11 +1073,15 @@ def fmt_currency(
     format the `currency` column to display monetary values.
 
     ```{python}
-    from great_tables import GT
+    from great_tables import GT, exibble
 
     (
         GT(exibble)
-        .fmt_currency(columns="currency", decimals=3, use_seps=False)
+        .fmt_currency(
+            columns="currency",
+            decimals=3,
+            use_seps=False
+        )
     )
     ```
 

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -229,9 +229,12 @@ def fmt_number(
     separators (with `use_seps=False`).
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT, exibble
 
-    gt.GT(gt.data.exibble).fmt_number(columns=\"num\", decimals=3, use_seps=False)
+    (
+        GT(exibble)
+        .fmt_number(columns="num", decimals=3, use_seps=False)
+    )
     ```
 
     See Also
@@ -403,9 +406,12 @@ def fmt_integer(
     `use_seps=False` option).
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT, exibble
 
-    gt.GT(gt.data.exibble).fmt_integer(columns=\"num\", use_seps=False)
+    (
+        GT(exibble)
+        .fmt_integer(columns="num", use_seps=False)
+    )
     ```
 
     See Also
@@ -604,9 +610,12 @@ def fmt_scientific(
     formatting.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT, exibble
 
-    gt.GT(gt.data.exibble).fmt_scientific(columns=\"num\")
+    (
+        GT(exibble)
+        .fmt_scientific(columns="num")
+    )
     ```
 
     See Also
@@ -1064,9 +1073,12 @@ def fmt_currency(
     format the `currency` column to display monetary values.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT
 
-    gt.GT(gt.data.exibble).fmt_currency(columns=\"currency\", decimals=3, use_seps=False)
+    (
+        GT(exibble)
+        .fmt_currency(columns="currency", decimals=3, use_seps=False)
+    )
     ```
 
     See Also
@@ -1220,11 +1232,14 @@ def fmt_roman(
 
     ```{python}
     import pandas as pd
-    import great_tables as gt
+    from great_tables import GT
 
-    numbers_tbl = pd.DataFrame({\"arabic\": [1, 8, 24, 85], \"roman\": [1, 8, 24, 85]})
+    numbers_tbl = pd.DataFrame({"arabic": [1, 8, 24, 85], "roman": [1, 8, 24, 85]})
 
-    gt.GT(numbers_tbl, rowname_col=\"arabic\").fmt_roman(columns=\"roman\")
+    (
+        GT(numbers_tbl, rowname_col="arabic")
+        .fmt_roman(columns="roman")
+    )
     ```
 
     See Also
@@ -1399,9 +1414,12 @@ def fmt_bytes(
     method.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT, exibble
 
-    gt.GT(gt.data.exibble[[\"num\"]]).fmt_bytes(columns=\"num\", standard=\"decimal\")
+    (
+        GT(exibble[["num"]])
+        .fmt_bytes(columns="num", standard="decimal")
+    )
     ```
 
     See Also
@@ -1603,11 +1621,14 @@ def fmt_date(
     dates formatted with the `"month_day_year"` date style.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT, exibble
 
-    exibble_mini = gt.data.exibble[[\"date\", \"time\"]]
+    exibble_mini = exibble[["date", "time"]]
 
-    gt.GT(exibble_mini).fmt_date(columns=\"date\", date_style=\"month_day_year\")
+    (
+        GT(exibble_mini)
+        .fmt_date(columns="date", date_style="month_day_year")
+    )
     ```
 
     See Also
@@ -1736,11 +1757,14 @@ def fmt_time(
     times formatted with the `"h_m_s_p"` time style.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT, exibble
 
-    exibble_mini = gt.data.exibble[[\"date\", \"time\"]]
+    exibble_mini = exibble[["date", "time"]]
 
-    gt.GT(exibble_mini).fmt_time(columns=\"time\", time_style=\"h_m_s_p\")
+    (
+        GT(exibble_mini)
+        .fmt_time(columns="time", time_style="h_m_s_p")
+    )
     ```
 
     See Also
@@ -1890,16 +1914,16 @@ def fmt_datetime(
     formatted with the `"h_m_s_p"` time style.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT, exibble
 
-    exibble_mini = gt.data.exibble[[\"date\", \"time\"]]
+    exibble_mini = exibble[["date", "time"]]
 
     (
-        gt.GT(exibble_mini)
+        GT(exibble_mini)
         .fmt_datetime(
-            columns=\"date\",
-            date_style=\"month_day_year\",
-            time_style=\"h_m_s_p\"
+            columns="date",
+            date_style="month_day_year",
+            time_style="h_m_s_p"
         )
     )
     ```
@@ -3305,8 +3329,18 @@ def fmt_image(
     from great_tables.data import metro
     from importlib_resources import files
 
-    img_paths = files("great_tables")  / "data/metro_images"
-    GT(metro).fmt_image("lines", path = img_paths, file_pattern="metro_{}.svg")
+    img_paths = files("great_tables") / "data/metro_images"
+
+    metro_mini = metro[["name", "lines", "passengers"]].head(5)
+
+    (
+        GT(metro_mini)
+        .fmt_image(
+            columns="lines",
+            path=img_paths,
+            file_pattern="metro_{}.svg"
+        )
+        .fmt_integer(columns="passengers")
     ```
     """
 

--- a/great_tables/_heading.py
+++ b/great_tables/_heading.py
@@ -50,15 +50,16 @@ def tab_header(
     formatting is interpreted and transformed.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT, md
+    from great_tables.data import gtcars
 
-    gtcars_mini = gt.data.gtcars[[\"mfr\", \"model\", \"msrp\"]].head(5)
+    gtcars_mini = gtcars[["mfr", "model", "msrp"]].head(5)
 
     (
-        gt.GT(gtcars_mini)
+        GT(gtcars_mini)
         .tab_header(
-            title=gt.md(\"Data listing from **gtcars**\"),
-            subtitle=gt.md(\"`gtcars` is an R dataset\")
+            title=md("Data listing from **gtcars**"),
+            subtitle=md("`gtcars` is an R dataset")
         )
     )
     ```
@@ -67,11 +68,16 @@ def tab_header(
     elements in the text.
 
     ```{python}
+    from great_tables import GT, md, html
+    from great_tables.data import gtcars
+
+    gtcars_mini = gtcars[["mfr", "model", "msrp"]].head(5)
+
     (
-        gt.GT(gtcars_mini)
+        GT(gtcars_mini)
         .tab_header(
-            title=gt.md("Data listing <strong>gtcars</strong>"),
-            subtitle=gt.html("From <span style='color:red;'>gtcars</span>")
+            title=md("Data listing <strong>gtcars</strong>"),
+            subtitle=html("From <span style='color:red;'>gtcars</span>")
         )
     )
     ```

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -478,17 +478,17 @@ def tab_options(
 
     gt_tbl = (
       GT(
-        exibble[[\"num\", \"char\", \"currency\", \"row\", \"group\"]],
-        rowname_col = \"row\",
-        groupname_col = \"group\"
+        exibble[["num", "char", "currency", "row", "group"]],
+        rowname_col="row",
+        groupname_col="group"
       )
       .tab_header(
-        title = md(\"Data listing from **exibble**\"),
-        subtitle = md(\"`exibble` is a **Great Tables** dataset.\")
+        title=md("Data listing from **exibble**"),
+        subtitle=md("`exibble` is a **Great Tables** dataset.")
       )
-      .fmt_number(columns = \"num\")
-      .fmt_currency(columns = \"currency\")
-      .tab_source_note(source_note = \"This is only a subset of the dataset.\")
+      .fmt_number(columns="num")
+      .fmt_currency(columns="currency")
+      .tab_source_note(source_note="This is only a subset of the dataset.")
     )
 
     gt_tbl
@@ -710,9 +710,9 @@ def opt_vertical_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
             title=md("Data listing from **exibble**"),
             subtitle=md("`exibble` is a **Great Tables** dataset.")
         )
-        .fmt_number(columns = "num")
-        .fmt_currency(columns = "currency")
-        .tab_source_note(source_note = "This is only a subset of the dataset.")
+        .fmt_number(columns="num")
+        .fmt_currency(columns="currency")
+        .tab_source_note(source_note="This is only a subset of the dataset.")
     )
 
     gt_tbl.opt_vertical_padding(scale=3)
@@ -811,9 +811,9 @@ def opt_horizontal_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
             title=md("Data listing from **exibble**"),
             subtitle=md("`exibble` is a **Great Tables** dataset.")
         )
-        .fmt_number(columns = "num")
-        .fmt_currency(columns = "currency")
-        .tab_source_note(source_note = "This is only a subset of the dataset.")
+        .fmt_number(columns="num")
+        .fmt_currency(columns="currency")
+        .tab_source_note(source_note="This is only a subset of the dataset.")
     )
 
     gt_tbl.opt_horizontal_padding(scale=3)
@@ -911,16 +911,16 @@ def opt_all_caps(
     (
       GT(
         exibble[["num", "char", "currency", "row", "group"]],
-        rowname_col = "row",
-        groupname_col = "group"
+        rowname_col="row",
+        groupname_col="group"
       )
       .tab_header(
-        title = md("Data listing from **exibble**"),
-        subtitle = md("`exibble` is a **Great Tables** dataset.")
+        title=md("Data listing from **exibble**"),
+        subtitle=md("`exibble` is a **Great Tables** dataset.")
       )
-      .fmt_number(columns = "num")
-      .fmt_currency(columns = "currency")
-      .tab_source_note(source_note = "This is only a subset of the dataset.")
+      .fmt_number(columns="num")
+      .fmt_currency(columns="currency")
+      .tab_source_note(source_note="This is only a subset of the dataset.")
       .opt_all_caps()
     )
     ```

--- a/great_tables/_source_notes.py
+++ b/great_tables/_source_notes.py
@@ -38,13 +38,14 @@ def tab_source_note(data: GTSelf, source_note: Union[str, Text]) -> GTSelf:
     component of the table.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT
+    from great_tables.data import gtcars
 
-    gtcars_mini = gt.data.gtcars[[\"mfr\", \"model\", \"msrp\"]].head(5)
+    gtcars_mini = gtcars[["mfr", "model", "msrp"]].head(5)
 
     (
-        gt.GT(gtcars_mini, rowname_col=\"model\")
-        .tab_source_note(source_note=\"From edmunds.com\")
+        GT(gtcars_mini, rowname_col="model")
+        .tab_source_note(source_note="From edmunds.com")
     )
     ```
     """

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -89,16 +89,17 @@ def tab_spanner(
     performance under a unifying label.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT
+    from great_tables.data import gtcars
 
-    colnames = [\"model\", \"hp\", \"hp_rpm\", \"trq\", \"trq_rpm\", \"mpg_c\", \"mpg_h\"]
-    gtcars_mini = gt.data.gtcars[colnames].head(10)
+    colnames = ["model", "hp", "hp_rpm", "trq", "trq_rpm", "mpg_c", "mpg_h"]
+    gtcars_mini = gtcars[colnames].head(10)
 
     (
-        gt.GT(gtcars_mini)
+        GT(gtcars_mini)
         .tab_spanner(
-            label=\"performance\",
-            columns=[\"hp\", \"hp_rpm\", \"trq\", \"trq_rpm\", \"mpg_c\", \"mpg_h\"]
+            label="performance",
+            columns=["hp", "hp_rpm", "trq", "trq_rpm", "mpg_c", "mpg_h"]
         )
     )
     ```
@@ -107,11 +108,17 @@ def tab_spanner(
     `gt.md("*Performance*")` to make the label italicized.
 
     ```{python}
+    from great_tables import GT, md
+    from great_tables.data import gtcars
+
+    colnames = ["model", "hp", "hp_rpm", "trq", "trq_rpm", "mpg_c", "mpg_h"]
+    gtcars_mini = gtcars[colnames].head(10)
+
     (
         gt.GT(gtcars_mini)
         .tab_spanner(
-            label=gt.md(\"*Performance*\"),
-            columns=[\"hp\", \"hp_rpm\", \"trq\", \"trq_rpm\", \"mpg_c\", \"mpg_h\"]
+            label=md("*Performance*"),
+            columns=["hp", "hp_rpm", "trq", "trq_rpm", "mpg_c", "mpg_h"]
         )
     )
     ```
@@ -227,18 +234,18 @@ def cols_move(data: GTSelf, columns: SelectExpr, after: str) -> GTSelf:
     column after the `country_name` column by using the `cols_move()` method.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT
     from great_tables.data import countrypops
 
-    countrypops_mini = countrypops.loc[countrypops[\"country_name\"] == \"Japan\"][
-        [\"country_name\", \"year\", \"population\"]
+    countrypops_mini = countrypops.loc[countrypops["country_name"] == "Japan"][
+        ["country_name", "year", "population"]
     ].tail(5)
 
     (
-        gt.GT(countrypops_mini)
+        GT(countrypops_mini)
         .cols_move(
-            columns=\"population\",
-            after=\"country_name\"
+            columns="population",
+            after="country_name"
         )
     )
     ```
@@ -309,21 +316,22 @@ def cols_move_to_start(data: GTSelf, columns: SelectExpr) -> GTSelf:
     the `cols_move_to_start()` method.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT
     from great_tables.data import countrypops
 
-    countrypops_mini = countrypops.loc[countrypops[\"country_name\"] == \"Fiji\"][
-        [\"country_name\", \"year\", \"population\"]
+    countrypops_mini = countrypops.loc[countrypops["country_name"] == "Fiji"][
+        ["country_name", "year", "population"]
     ].tail(5)
 
-    gt.GT(countrypops_mini).cols_move_to_start(columns=\"year\")
+    GT(countrypops_mini).cols_move_to_start(columns="year")
     ```
 
-    We can also move multiple columns at a time. With the same `countrypops`-based table, let's move
-    both the `year` and `population` columns to the start of the column series.
+    We can also move multiple columns at a time. With the same `countrypops`-based table
+    (`countrypops_mini`), let's move both the `year` and `population` columns to the start of the
+    column series.
 
     ```{python}
-    gt.GT(countrypops_mini).cols_move_to_start(columns=[\"year\", \"population\"])
+    GT(countrypops_mini).cols_move_to_start(columns=["year", "population"])
     ```
     """
 
@@ -377,21 +385,22 @@ def cols_move_to_end(data: GTSelf, columns: SelectExpr) -> GTSelf:
     the `cols_move_to_end()` method.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT
     from great_tables.data import countrypops
 
-    countrypops_mini = countrypops.loc[countrypops[\"country_name\"] == \"Benin\"][
-        [\"country_name\", \"year\", \"population\"]
+    countrypops_mini = countrypops.loc[countrypops["country_name"] == "Benin"][
+        ["country_name", "year", "population"]
     ].tail(5)
 
-    gt.GT(countrypops_mini).cols_move_to_end(columns=\"year\")
+    GT(countrypops_mini).cols_move_to_end(columns="year")
     ```
 
-    We can also move multiple columns at a time. With the same `countrypops`-based table, let's move
-    both the `year` and `country_name` columns to the end of the column series.
+    We can also move multiple columns at a time. With the same `countrypops`-based table
+    (`countrypops_mini`), let's move both the `year` and `country_name` columns to the end of the
+    column series.
 
     ```{python}
-    gt.GT(countrypops_mini).cols_move_to_end(columns=[\"year\", \"country_name\"])
+    GT(countrypops_mini).cols_move_to_end(columns=["year", "country_name"])
     """
 
     # If `columns` is a string, convert it to a list
@@ -584,56 +593,55 @@ def cols_width(data: GTSelf, cases: Dict[str, str]) -> GTSelf:
     --------
     Let's use select columns from the `exibble` dataset to create a new table. We can specify the
     widths of columns with `cols_width()`. This is done by specifying the exact widths for table
-    columns in a dictionary. In this example, we'll set the width of the `num` column to `150px`,
-    the `char` column to `100px`, the `date` column to `300px`. All other columns won't be affected
-    (their widths will be automatically set by their content).
+    columns in a dictionary. In this example, we'll set the width of the `num` column to `"150px"`,
+    the `char` column to `"100px"`, the `date` column to `"300px"`. All other columns won't be
+    affected (their widths will be automatically set by their content).
 
     ```{python}
-    import great_tables as gt
-    from great_tables.data import exibble
+    from great_tables import GT, exibble
 
-    exibble_mini = exibble[[\"num\", \"char\", \"date\", \"datetime\", \"row\"]].head(5)
+    exibble_mini = exibble[["num", "char", "date", "datetime", "row"]].head(5)
 
     (
-        gt.GT(exibble_mini)
+        GT(exibble_mini)
         .cols_width(
             cases={
-                "num": \"150px\",
-                "char": \"100px\",
-                "date": \"300px\"
+                "num": "150px",
+                "char": "100px",
+                "date": "300px"
             }
         )
     )
     ```
 
     We can also specify the widths of columns as percentages. In this example, we'll set the width
-    of the `num` column to `20%`, the `char` column to `10%`, and the `date` column to `30%`. Note
-    that the percentages are relative and don't need to sum to 100%.
+    of the `num` column to `"20%"`, the `char` column to `"10%"`, and the `date` column to `"30%"`.
+    Note that the percentages are relative and don't need to sum to 100%.
 
     ```{python}
     (
-        gt.GT(exibble_mini)
+        GT(exibble_mini)
         .cols_width(
             cases={
-                "num": \"20%\",
-                "char": \"10%\",
-                "date": \"30%\"
+                "num": "20%",
+                "char": "10%",
+                "date": "30%"
             }
         )
     )
     ```
 
     We can also mix and match pixel and percentage widths. In this example, we'll set the width of
-    the `num` column to `150px`, the `char` column to `10%`, and the `date` column to `30%`.
+    the `num` column to `"150px"`, the `char` column to `"10%"`, and the `date` column to `"30%"`.
 
     ```{python}
     (
-        gt.GT(exibble_mini)
+        GT(exibble_mini)
         .cols_width(
             cases={
-                "num": \"150px\",
-                "char": \"10%\",
-                "date": \"30%\"
+                "num": "150px",
+                "char": "10%",
+                "date": "30%"
             }
         )
     )
@@ -646,14 +654,14 @@ def cols_width(data: GTSelf, cases: Dict[str, str]) -> GTSelf:
 
     ```{python}
     (
-        gt.GT(exibble_mini)
+        GT(exibble_mini)
         .cols_width(
             cases={
-                "num": \"30px\",
-                "char": \"100px\",
-                "date": \"100px\",
-                "datetime": \"200px\",
-                "row": \"50px\"
+                "num": "30px",
+                "char": "100px",
+                "date": "100px",
+                "datetime": "200px",
+                "row": "50px"
             }
         )
     )

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -115,7 +115,7 @@ def tab_spanner(
     gtcars_mini = gtcars[colnames].head(10)
 
     (
-        gt.GT(gtcars_mini)
+        GT(gtcars_mini)
         .tab_spanner(
             label=md("*Performance*"),
             columns=["hp", "hp_rpm", "trq", "trq_rpm", "mpg_c", "mpg_h"]

--- a/great_tables/_stubhead.py
+++ b/great_tables/_stubhead.py
@@ -38,18 +38,28 @@ def tab_stubhead(self: GTSelf, label: Union[str, Text]) -> GTSelf:
     describe what's in the stub.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT
+    from great_tables.data import gtcars
 
-    gtcars_mini = gt.data.gtcars[[\"model\", \"year\", \"hp\", \"trq\"]].head(5)
+    gtcars_mini = gtcars[["model", "year", "hp", "trq"]].head(5)
 
-    gt.GT(gtcars_mini, rowname_col=\"model\").tab_stubhead(label=\"car\")
+    (
+        GT(gtcars_mini, rowname_col="model")
+        .tab_stubhead(label="car")
+    )
     ```
 
     We can also use Markdown formatting for the stubhead label. In this example, we'll use
     `md("*Car*")` to make the label italicized.
 
     ```{python}
-    gt.GT(gtcars_mini, rowname_col="model").tab_stubhead(label=gt.md("*Car*"))
+    from great_tables import GT, md
+    from great_tables.data import gtcars
+
+    (
+        GT(gtcars_mini, rowname_col="model")
+        .tab_stubhead(label=md("*Car*"))
+    )
     ```
     """
 

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -45,7 +45,7 @@ class FromColumn:
     import polars as pl
     from great_tables import GT, exibble, from_column, loc, style
 
-    df_polars = GT(pl.from_pandas(df))
+    df_polars = pl.from_pandas(df)
 
     (
         GT(df_polars)

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -30,10 +30,12 @@ class FromColumn:
 
     df = pd.DataFrame({"x": [1, 2], "color": ["red", "blue"]})
 
-    gt = GT(df)
-    gt.tab_style(
-        style = style.text(color = from_column("color")),
-        locations = loc.body(columns = ["x"])
+    (
+        GT(df)
+        .tab_style(
+            style=style.text(color=from_column("color")),
+            locations=loc.body(columns=["x"])
+        )
     )
     ```
 
@@ -41,11 +43,16 @@ class FromColumn:
 
     ```{python}
     import polars as pl
+    from great_tables import GT, exibble, from_column, loc, style
 
-    gt_polars = GT(pl.from_pandas(df))
-    gt_polars.tab_style(
-        style = style.text(color = pl.col("color")),    # <-- polars expression
-        locations = loc.body(columns = ["x"])
+    df_polars = GT(pl.from_pandas(df))
+
+    (
+        GT(df_polars)
+        .tab_style(
+            style=style.text(color=pl.col("color")),
+            locations=loc.body(columns=["x"])
+        )
     )
     ```
     """

--- a/great_tables/_tab_create_modify.py
+++ b/great_tables/_tab_create_modify.py
@@ -49,14 +49,12 @@ def tab_style(
     larger font size to the cells in the `fctr` column for the last four rows of the table.
 
     ```{python}
-    import great_tables as gt
-    from great_tables import style, loc
-    from great_tables import exibble
+    from great_tables import GT, style, loc, exibble
 
     exibble_sm = exibble[["num", "fctr", "row", "group"]]
 
     (
-        gt.GT(exibble_sm, rowname_col="row", groupname_col="group")
+        GT(exibble_sm, rowname_col="row", groupname_col="group")
         .tab_style(
             style=style.fill(color="lightcyan"),
             locations=loc.body(columns="num", rows=["row_1", "row_2"]),
@@ -76,10 +74,12 @@ def tab_style(
     the use of `loc.body()`, which is used here with different columns being targeted.
 
     ```{python}
+    from great_tables import GT, style, loc, exibble
+
     (
-        gt.GT(exibble[["num", "currency"]])
-        .fmt_number(columns = "num", decimals=1)
-        .fmt_currency(columns = "currency")
+        GT(exibble[["num", "currency"]])
+        .fmt_number(columns="num", decimals=1)
+        .fmt_currency(columns="currency")
         .tab_style(
             style=[
                 style.fill(color="lightcyan"),
@@ -89,8 +89,8 @@ def tab_style(
         )
         .tab_style(
             style=[
-                style.fill(color = "#F9E3D6"),
-                style.text(style = "italic")
+                style.fill(color="#F9E3D6"),
+                style.text(style="italic")
             ],
             locations=loc.body(columns="currency")
         )

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -170,7 +170,7 @@ class GT(
     from great_tables import GT, exibble
 
     (
-        GT(gt.exibble, rowname_col="row", locale="fr")
+        GT(exibble, rowname_col="row", locale="fr")
         .fmt_currency(columns="currency")
         .fmt_scientific(columns="num")
         .fmt_date(columns="date", date_style="day_month_year")

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -77,10 +77,10 @@ class GT(
     take advantage of numerous methods to get the desired display table for publication.
 
     There are a few table structuring options we can consider at this stage. We can choose to create
-    a table stub containing row labels through the use of the `rowname_col` argument. Further to
-    this, row groups can be created with the `groupname_col` argument. Both arguments take the name
-    of a column in the input table data. Typically, the data in the `groupname_col` column will
-    consist of categorical text whereas the data in the `rowname_col` column will often contain
+    a table stub containing row labels through the use of the `rowname_col=` argument. Further to
+    this, row groups can be created with the `groupname_col=` argument. Both arguments take the name
+    of a column in the input table data. Typically, the data in the `groupname_col=` column will
+    consist of categorical text whereas the data in the `rowname_col=` column will often contain
     unique labels (perhaps being unique across the entire table or unique only within the different
     row groups).
 
@@ -89,14 +89,14 @@ class GT(
     data : Any
         A DataFrame object.
     rowname_col : str | None
-        The column name in the input `data` table to use as row labels to be placed in the table
+        The column name in the input `data=` table to use as row labels to be placed in the table
         stub.
     groupname_col : str | None
-        The column name in the input `data` table to use as group labels for generation of row
+        The column name in the input `data=` table to use as group labels for generation of row
         groups.
     auto_align : bool
         Optionally have column data be aligned depending on the content contained in each column of
-        the input `data`.
+        the input `data=`.
     locale : str
         An optional locale identifier that can be set as the default locale for all functions that
         take a `locale` argument. Examples include `"en"` for English (United States) and `"fr"`
@@ -114,29 +114,33 @@ class GT(
     dataset as the input.
 
     ```{python}
-    import great_tables as gt
+    from great_tables import GT, exibble
 
-    gt.GT(gt.exibble)
+    GT(exibble)
     ```
 
     This dataset has the `row` and `group` columns. The former contains unique values that are ideal
     for labeling rows, and this often happens in what is called the 'stub' (a reserved area that
     serves to label rows). With the `GT()` class, we can immediately place the contents of the `row`
-    column into the stub column. To do this, we use the `rowname_col` argument with the appropriate
+    column into the stub column. To do this, we use the `rowname_col=` argument with the appropriate
     column name.
 
     ```{python}
-    gt.GT(gt.exibble, rowname_col=\"row\")
+    from great_tables import GT, exibble
+
+    GT(exibble, rowname_col="row")
     ```
 
     This sets up a table with a stub, the row labels are placed within the stub column, and a
     vertical dividing line has been placed on the right-hand side.
 
     The `group` column contains categorical values that are ideal for grouping rows. We can use the
-    `groupname_col` argument to place these values into row groups.
+    `groupname_col=` argument to place these values into row groups.
 
     ```{python}
-    gt.GT(gt.exibble, rowname_col=\"row\", groupname_col=\"group\")
+    from great_tables import GT, exibble
+
+    GT(exibble, rowname_col="row", groupname_col="group")
     ```
 
     By default, values in the body of a table (and their column labels) are automatically aligned.
@@ -144,28 +148,32 @@ class GT(
     of auto-alignment, the `auto_align=False` option can be taken.
 
     ```{python}
-    gt.GT(gt.exibble, rowname_col=\"row\", auto_align=False)
+    from great_tables import GT, exibble
+
+    GT(exibble, rowname_col="row", auto_align=False)
     ```
 
     What you'll get from that is center-alignment of all table body values and all column labels.
-    Note that row labels in the the stub are still left-aligned; and `auto_align` has no effect on
+    Note that row labels in the the stub are still left-aligned; and `auto_align=` has no effect on
     alignment within the table stub.
 
     However which way you generate the initial table object, you can modify it with a huge variety
     of methods to further customize the presentation. Formatting body cells is commonly done with
     the family of formatting methods (e.g., `fmt_number()`, `fmt_date()`, etc.). The package
     supports formatting with internationalization ('i18n' features) and so locale-aware methods
-    all come with a `locale` argument. To avoid having to use that argument repeatedly, the `GT()`
-    class has its own `locale` argument. Setting a locale in that will make it available globally.
+    all come with a `locale=` argument. To avoid having to use that argument repeatedly, the `GT()`
+    class has its own `locale=` argument. Setting a locale in that will make it available globally.
     Here's an example of how that works in practice when setting `locale = "fr"` in `GT()` prior to
     using formatting methods:
 
     ```{python}
+    from great_tables import GT, exibble
+
     (
-        gt.GT(gt.exibble, rowname_col=\"row\", locale=\"fr\")
-          .fmt_currency(columns=\"currency\")
-          .fmt_scientific(columns=\"num\")
-          .fmt_date(columns=\"date\", date_style=\"day_month_year\")
+        GT(gt.exibble, rowname_col="row", locale="fr")
+        .fmt_currency(columns="currency")
+        .fmt_scientific(columns="num")
+        .fmt_date(columns="date", date_style="day_month_year")
     )
     ```
 


### PR DESCRIPTION
This modifies the examples slightly so that the coding style is more in line with the doc site's top-level examples page (and getting started guides).