### PR TITLE
Fix `FutureWarning` for `DataFrameGroupBy.grouper`

### DIFF
--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -233,7 +233,7 @@ def group_splits(data: DataFrameLike, group_key: str) -> Dict[Any, List[int]]:
 @group_splits.register
 def _(data: PdDataFrame, group_key: str) -> Dict[Any, List[int]]:
     g_df = data.groupby(group_key)
-    return {k: list(v) for k, v in g_df.grouper.indices.items()}
+    return {k: list(v) for k, v in g_df.indices.items()}
 
 
 @group_splits.register


### PR DESCRIPTION
There's a future warning displayed in the [stub](https://posit-dev.github.io/great-tables/get-started/basic-stub.html):
```
FutureWarning: DataFrameGroupBy.grouper is deprecated and will be removed in a future version of pandas.
```
More details related to this warning can be found in the [Pandas v2.2.0 release notes](https://pandas.pydata.org/docs/whatsnew/v2.2.0.html) and issue [GH 56521](https://github.com/pandas-dev/pandas/issues/56521).

Instead of using `g_df.grouper.indices`, it might be better to directly use `g_df.indices`. By using `g_df.indices`, we shouldn't encounter any backward compatibility issues IMO.