### PR TITLE
Ensure that np.nan values are replaced with 'na_color=` vals

### DIFF
--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -255,7 +255,7 @@ def data_color(
         color_vals = color_scale_fn(scaled_vals)
 
         # Replace 'None' and 'np.nan' values in `color_vals` with the `na_color=` color
-        color_vals = [na_color if x is None or x != x else x for x in color_vals]
+        color_vals = [na_color if is_na(data_table, x) else x for x in color_vals]
 
         # for every color value in color_vals, apply a fill to the corresponding cell
         # by using `tab_style()`

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -254,8 +254,8 @@ def data_color(
         # Call the color scale function on the scaled values to get a list of colors
         color_vals = color_scale_fn(scaled_vals)
 
-        # Replace 'None' values in `color_vals` with the `na_color=` color
-        color_vals = [na_color if x is None else x for x in color_vals]
+        # Replace 'None' and 'np.nan' values in `color_vals` with the `na_color=` color
+        color_vals = [na_color if x is None or x != x else x for x in color_vals]
 
         # for every color value in color_vals, apply a fill to the corresponding cell
         # by using `tab_style()`

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -488,8 +488,11 @@ def _(df: PdDataFrame, x: Any) -> bool:
 @is_na.register
 def _(df: PlDataFrame, x: Any) -> bool:
     import polars as pl
+    import numpy as np
 
-    return isinstance(x, (pl.Null, type(None)))
+    from math import nan
+
+    return isinstance(x, (pl.Null, type(None))) or x is np.nan or x is nan
 
 
 @singledispatch

--- a/tests/data_color/test_data_color.py
+++ b/tests/data_color/test_data_color.py
@@ -1,11 +1,17 @@
-from great_tables import GT
+from great_tables import GT, style
 from great_tables.data import exibble
 from great_tables._utils_render_html import create_body_component_h
+from great_tables._gt_data import StyleInfo, CellStyle
+from typing import Type, TypeVar
+
+import numpy as np
 import pandas as pd
 import polars as pl
 import pytest
 from great_tables._tbl_data import DataFrameLike
 
+
+T_CellStyle = TypeVar("T_CellStyle", bound=CellStyle)
 
 params_frames = [pytest.param(pd.DataFrame, id="pandas"), pytest.param(pl.DataFrame, id="polars")]
 
@@ -20,6 +26,14 @@ def assert_rendered_body(snapshot, gt):
     body = create_body_component_h(built)
 
     assert snapshot == body
+
+
+def get_first_style(obj: StyleInfo, cls: Type[T_CellStyle]) -> Type[T_CellStyle]:
+    for cell_style in obj.styles:
+        if isinstance(cell_style, cls):
+            return cell_style
+
+    raise KeyError(f"No style entry of type {cls} found.")
 
 
 def test_data_color_simple_df_snap(snapshot):
@@ -40,6 +54,22 @@ def test_data_color_simple_exibble_snap(snapshot, df: DataFrameLike):
     gt = GT(df).data_color()
 
     assert_rendered_body(snapshot, gt)
+
+
+@pytest.mark.parametrize("none_val", [None, np.nan, float("nan"), pd.NA])
+@pytest.mark.parametrize("df_cls", [pd.DataFrame, pl.DataFrame])
+def test_data_color_missing_value(df_cls, none_val):
+    from great_tables import GT
+
+    # skip the case where pd.NA would be passed to polars
+    # since it raises an error on DataFrame construction
+    if df_cls is pl.DataFrame and none_val is pd.NA:
+        pytest.skip()
+
+    df = df_cls({"x": [1.0, 2.0, none_val], "y": [3, 4, 5]})
+    new_gt = GT(df).data_color("x", na_color="#FFFFF0")
+    assert len(new_gt._styles) == 3
+    assert get_first_style(new_gt._styles[-1], style.fill).color == "#FFFFF0"
 
 
 def test_data_color_palette_snap(snapshot, df: DataFrameLike):


### PR DESCRIPTION
The `data_color()` method relies on `mizani.palettes.gradient_n_pal()` to create color palette functions. However, In older versions of mizani, a function produced by `gradient_n_pal()` returns `np.nan` when given missing values. The current version of mizani returns `None` on missing values.

This PR provides wider compatibility with mizani by ensuring both behaviors are handled. The only change required is to the list comprehension here

```python
color_vals = [na_color if x is None else x for x in color_vals] 
```

becoming:

```python
color_vals = [na_color if x is None or x != x else x for x in color_vals]
```

Fixes: https://github.com/posit-dev/great-tables/issues/204