### PR TITLE
Remove type annotations from docstrings

### DIFF
--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -32,7 +32,7 @@ def cols_label(self: GTSelf, **kwargs: Any) -> GTSelf:
 
     Parameters
     ----------
-    **kwargs : str
+    **kwargs
         The column names and new labels. The column names are provided as keyword arguments and the
         new labels are provided as the values for those keyword arguments. For example,
         `cols_label(col1="Column 1", col2="Column 2")` would relabel columns `col1` and `col2` with
@@ -116,9 +116,9 @@ def cols_align(self: GTSelf, align: str = "left", columns: Optional[str] = None)
 
     Parameters
     ----------
-    align : str
+    align
         The alignment to apply. Must be one of `"left"`, `"center"`, or `"right"`.
-    columns : Union[str, List[str], None]
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list. If `None`, the alignment is applied to all columns.
 

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -14,7 +14,7 @@ from typing import (
     Literal,
 )
 from typing_extensions import TypeAlias
-from ._tbl_data import PlExpr, n_rows
+from ._tbl_data import PlExpr
 from ._gt_data import GTData, FormatFns, FormatFn, FormatInfo
 from ._locale import _get_locales_data, _get_default_locales_data, _get_currencies_data
 from ._locations import resolve_rows_i
@@ -77,12 +77,12 @@ def fmt(
 
     Parameters
     ----------
-    fns : Union[FormatFn, FormatFns]
+    fns
         Either a single formatting function or a named list of functions.
-    columns : Union[str, List[str], None]
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    rows : Union[int, List[int], None]
+    rows
         In conjunction with `columns`, we can specify which of their rows should undergo
         formatting. The default is all rows, resulting in all rows in `columns` being formatted.
         Alternatively, we can supply a list of row indices.
@@ -145,62 +145,62 @@ def fmt_number(
 
     Parameters
     ----------
-    columns : str | List[str] | None
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    rows : int | List[int] | None
+    rows
         In conjunction with `columns`, we can specify which of their rows should undergo formatting.
         The default is all rows, resulting in all rows in `columns` being formatted. Alternatively,
         we can supply a list of row indices.
-    decimals : int
+    decimals
         The `decimals` values corresponds to the exact number of decimal places to use. A value such
         as `2.34` can, for example, be formatted with `0` decimal places and it would result in
         `"2"`. With `4` decimal places, the formatted value becomes `"2.3400"`. The trailing zeros
         can be removed with `drop_trailing_zeros=True`. If you always need `decimals = 0`, the
         [`fmt_integer()`](`great_tables.GT.fmt_integer`) method should be considered.
-    n_sigfig : Optional[int]
+    n_sigfig
         A option to format numbers to *n* significant figures. By default, this is `None` and thus
         number values will be formatted according to the number of decimal places set via
         `decimals`. If opting to format according to the rules of significant figures, `n_sigfig`
         must be a number greater than or equal to `1`. Any values passed to the `decimals` and
         `drop_trailing_zeros` arguments will be ignored.
-    drop_trailing_zeros : bool
+    drop_trailing_zeros
         A boolean value that allows for removal of trailing zeros (those redundant zeros after the
         decimal mark).
-    drop_trailing_dec_mark : bool
+    drop_trailing_dec_mark
         A boolean value that determines whether decimal marks should always appear even if there are
         no decimal digits to display after formatting (e.g., `23` becomes `23.` if `False`). By
         default trailing decimal marks are not shown.
-    use_seps : bool
+    use_seps
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
-    scale_by : float
+    scale_by
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
         value is supplied.
-    compact : bool
+    compact
         A boolean value that allows for compact formatting of numeric values. Values will be scaled
         and decorated with the appropriate suffixes (e.g., `1230` becomes `1.23K`, and `1230000`
         becomes `1.23M`). The `compact` option is `False` by default.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    sep_mark : str
+    sep_mark
         The string to use as a separator between groups of digits. For example, using `sep_mark=","`
         with a value of `1000` would result in a formatted value of `"1,000"`. This argument is
         ignored if a `locale` is supplied (i.e., is not `None`).
-    dec_mark : str
+    dec_mark
         The string to be used as the decimal mark. For example, using `dec_mark=","` with the value
         `0.152` would result in a formatted value of `"0,152"`). This argument is ignored if a
         `locale` is supplied (i.e., is not `None`).
-    force_sign : bool
+    force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
         negative numbers will display a minus sign. This option is disregarded when using accounting
         notation with `accounting = True`.
-    locale : str | None
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -346,39 +346,39 @@ def fmt_integer(
 
     Parameters
     ----------
-    columns : str | List[str] | None
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    rows : int | List[int] | None
+    rows
         In conjunction with `columns`, we can specify which of their rows should undergo formatting.
         The default is all rows, resulting in all rows in `columns` being formatted. Alternatively,
         we can supply a list of row indices.
-    use_seps : bool
+    use_seps
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
-    scale_by : float
+    scale_by
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
         value is supplied.
-    compact : bool
+    compact
         A boolean value that allows for compact formatting of numeric values. Values will be scaled
         and decorated with the appropriate suffixes (e.g., `1230` becomes `1K`, and `1230000`
         becomes `1M`). The `compact` option is `False` by default.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    sep_mark : str
+    sep_mark
         The string to use as a separator between groups of digits. For example, using `sep_mark=","`
         with a value of `1000` would result in a formatted value of `"1,000"`. This argument is
         ignored if a `locale` is supplied (i.e., is not `None`).
-    force_sign : bool
+    force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
         negative numbers will display a minus sign. This option is disregarded when using accounting
         notation with `accounting = True`.
-    locale : str | None
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -505,7 +505,7 @@ def fmt_scientific(
     """
     Format values to scientific notation.
 
-    With numeric values in a **gt** table, we can perform formatting so that the targeted values are
+    With numeric values in a table, we can perform formatting so that the targeted values are
     rendered in scientific notation, where extremely large or very small numbers can be expressed in
     a more practical fashion. Here, numbers are written in the form of a mantissa (`m`) and an
     exponent (`n`) with the construction *m* x 10^*n* or *m*E*n*. The mantissa component is a number
@@ -525,63 +525,63 @@ def fmt_scientific(
 
     Parameters
     ----------
-    columns : str | List[str] | None
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    rows : int | List[int] | None
+    rows
         In conjunction with `columns`, we can specify which of their rows should undergo formatting.
         The default is all rows, resulting in all rows in `columns` being formatted. Alternatively,
         we can supply a list of row indices.
-    decimals : int
+    decimals
         The `decimals` values corresponds to the exact number of decimal places to use. A value such
         as `2.34` can, for example, be formatted with `0` decimal places and it would result in
         `"2"`. With `4` decimal places, the formatted value becomes `"2.3400"`. The trailing zeros
         can be removed with `drop_trailing_zeros=True`.
-    n_sigfig : Optional[int]
+    n_sigfig
         A option to format numbers to *n* significant figures. By default, this is `None` and thus
         number values will be formatted according to the number of decimal places set via
         `decimals`. If opting to format according to the rules of significant figures, `n_sigfig`
         must be a number greater than or equal to `1`. Any values passed to the `decimals` and
         `drop_trailing_zeros` arguments will be ignored.
-    drop_trailing_zeros : bool
+    drop_trailing_zeros
         A boolean value that allows for removal of trailing zeros (those redundant zeros after the
         decimal mark).
-    drop_trailing_dec_mark : bool
+    drop_trailing_dec_mark
         A boolean value that determines whether decimal marks should always appear even if there are
         no decimal digits to display after formatting (e.g., `23` becomes `23.` if `False`). By
         default trailing decimal marks are not shown.
-    scale_by : float
+    scale_by
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
         value is supplied.
-    exp_style : str
+    exp_style
         Style of formatting to use for the scientific notation formatting. By default this is
         `"x10n"` but other options include using a single letter (e.g., `"e"`, `"E"`, etc.), a
         letter followed by a `"1"` to signal a minimum digit width of one, or `"low-ten"` for using
         a stylized `"10"` marker.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    sep_mark : str
+    sep_mark
         The string to use as a separator between groups of digits. For example, using `sep_mark=","`
         with a value of `1000` would result in a formatted value of `"1,000"`. This argument is
         ignored if a `locale` is supplied (i.e., is not `None`).
-    dec_mark : str
+    dec_mark
         The string to be used as the decimal mark. For example, using `dec_mark=","` with the value
         `0.152` would result in a formatted value of `"0,152"`). This argument is ignored if a
         `locale` is supplied (i.e., is not `None`).
-    force_sign_m : bool
+    force_sign_m
         Should the plus sign be shown for positive values of the mantissa (first component)? This
         would effectively show a sign for all values except zero on the first numeric component of
         the notation. If so, use `True` (the default for this is `False`), where only negative
         numbers will display a sign.
-    force_sign_n : bool
+    force_sign_n
         Should the plus sign be shown for positive values of the exponent (second component)? This
         would effectively show a sign for all values except zero on the second numeric component of
         the notation. If so, use `True` (the default for this is `False`), where only negative
         numbers will display a sign.
-    locale : str | None
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -787,58 +787,58 @@ def fmt_percent(
 
     Parameters
     ----------
-    columns : str | List[str] | None
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    rows : int | List[int] | None
+    rows
         In conjunction with `columns`, we can specify which of their rows should undergo formatting.
         The default is all rows, resulting in all rows in `columns` being formatted. Alternatively,
         we can supply a list of row indices.
-    decimals : int
+    decimals
         The `decimals` values corresponds to the exact number of decimal places to use. A value such
         as `2.34` can, for example, be formatted with `0` decimal places and it would result in
         `"2"`. With `4` decimal places, the formatted value becomes `"2.3400"`. The trailing zeros
         can be removed with `drop_trailing_zeros=True`.
-    drop_trailing_zeros : bool
+    drop_trailing_zeros
         A boolean value that allows for removal of trailing zeros (those redundant zeros after the
         decimal mark).
-    drop_trailing_dec_mark : bool
+    drop_trailing_dec_mark
         A boolean value that determines whether decimal marks should always appear even if there are
         no decimal digits to display after formatting (e.g., `23` becomes `23.` if `False`). By
         default trailing decimal marks are not shown.
-    scale_values : bool
+    scale_values
         Should the values be scaled through multiplication by 100? By default this scaling is
         performed since the expectation is that incoming values are usually proportional. Setting to
         `False` signifies that the values are already scaled and require only the percent sign when
         formatted.
-    use_seps : bool
+    use_seps
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    sep_mark : str
+    sep_mark
         The string to use as a separator between groups of digits. For example, using `sep_mark=","`
         with a value of `1000` would result in a formatted value of `"1,000"`. This argument is
         ignored if a `locale` is supplied (i.e., is not `None`).
-    dec_mark : str
+    dec_mark
         The string to be used as the decimal mark. For example, using `dec_mark=","` with the value
         `0.152` would result in a formatted value of `"0,152"`). This argument is ignored if a
         `locale` is supplied (i.e., is not `None`).
-    force_sign : bool
+    force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
         negative numbers will display a minus sign. This option is disregarded when using accounting
         notation with `accounting = True`.
-    placement : str
+    placement
         This option governs the placement of the percent sign. This can be either be `"right"` (the
         default) or `"left"`.
-    incl_space : bool
+    incl_space
         An option for whether to include a space between the value and the percent sign. The default
         is to not introduce a space character.
-    locale : str | None
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -989,62 +989,62 @@ def fmt_currency(
 
     Parameters
     ----------
-    columns : str | List[str] | None
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    rows : int | List[int] | None
+    rows
         In conjunction with `columns`, we can specify which of their rows should undergo formatting.
         The default is all rows, resulting in all rows in `columns` being formatted. Alternatively,
         we can supply a list of row indices.
-    currency : str | None
+    currency
         The currency to use for the numeric value. This input can be supplied as a 3-letter currency
         code (e.g., `"USD"` for U.S. Dollars, `"EUR"` for the Euro currency).
-    use_subunits: bool
+    use_subunits
         An option for whether the subunits portion of a currency value should be displayed. For
         example, with an input value of `273.81`, the default formatting will produce `"$273.81"`.
         Removing the subunits (with `use_subunits = False`) will give us `"$273"`.
-    decimals : int
+    decimals
         The `decimals` values corresponds to the exact number of decimal places to use. This value
         is optional as a currency has an intrinsic number of decimal places (i.e., the subunits).
         A value such as `2.34` can, for example, be formatted with `0` decimal places and if the
         currency used is `"USD"` it would result in `"$2"`. With `4` decimal places, the formatted
         value becomes `"$2.3400"`.
-    drop_trailing_dec_mark : bool
+    drop_trailing_dec_mark
         A boolean value that determines whether decimal marks should always appear even if there are
         no decimal digits to display after formatting (e.g., `23` becomes `23.` if `False`). By
         default trailing decimal marks are not shown.
-    use_seps : bool
+    use_seps
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
-    scale_by : float
+    scale_by
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
         value is supplied.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    sep_mark : str
+    sep_mark
         The string to use as a separator between groups of digits. For example, using `sep_mark=","`
         with a value of `1000` would result in a formatted value of `"1,000"`. This argument is
         ignored if a `locale` is supplied (i.e., is not `None`).
-    dec_mark : str
+    dec_mark
         The string to be used as the decimal mark. For example, using `dec_mark=","` with the value
         `0.152` would result in a formatted value of `"0,152"`). This argument is ignored if a
         `locale` is supplied (i.e., is not `None`).
-    force_sign : bool
+    force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
         negative numbers will display a minus sign. This option is disregarded when using accounting
         notation with `accounting = True`.
-    placement : str
+    placement
         The placement of the currency symbol. This can be either be `"left"` (as in `"$450"`) or
         `"right"` (which yields `"450$"`).
-    incl_space : bool
+    incl_space
         An option for whether to include a space between the value and the currency symbol. The
         default is to not introduce a space character.
-    locale : str | None
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -1207,17 +1207,17 @@ def fmt_roman(
 
     Parameters
     ----------
-    columns : str | List[str] | None
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    rows : int | List[int] | None
+    rows
         In conjunction with `columns`, we can specify which of their rows should undergo formatting.
         The default is all rows, resulting in all rows in `columns` being formatted. Alternatively,
         we can supply a list of row indices.
-    case : str
+    case
         Should Roman numerals should be rendered as uppercase (`"upper"`) or lowercase (`"lower"`)
         letters? By default, this is set to `"upper"`.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
@@ -1341,55 +1341,55 @@ def fmt_bytes(
 
     Parameters
     ----------
-    columns : str | List[str] | None
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    rows : int | List[int] | None
+    rows
         In conjunction with `columns`, we can specify which of their rows should undergo formatting.
         The default is all rows, resulting in all rows in `columns` being formatted. Alternatively,
         we can supply a list of row indices.
-    standard: str
+    standard
         The form of expressing large byte sizes is divided between: (1) decimal units (powers of
         1000; e.g., `"kB"` and `"MB"`), and (2) binary units (powers of 1024; e.g., `"KiB"` and
         `"MiB"`). The default is to use decimal units with the `"decimal"` option. The alternative
         is to use binary units with the `"binary"` option.
-    decimals : int
+    decimals
         This corresponds to the exact number of decimal places to use. A value such as `2.34` can,
         for example, be formatted with `0` decimal places and it would result in `"2"`. With `4`
         decimal places, the formatted value becomes `"2.3400"`. The trailing zeros can be removed
         with `drop_trailing_zeros=True`.
-    drop_trailing_zeros : bool
+    drop_trailing_zeros
         A boolean value that allows for removal of trailing zeros (those redundant zeros after the
         decimal mark).
-    drop_trailing_dec_mark : bool
+    drop_trailing_dec_mark
         A boolean value that determines whether decimal marks should always appear even if there are
         no decimal digits to display after formatting (e.g., `23` becomes `23.` if `False`). By
         default trailing decimal marks are not shown.
-    use_seps : bool
+    use_seps
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    sep_mark : str
+    sep_mark
         The string to use as a separator between groups of digits. For example, using `sep_mark=","`
         with a value of `1000` would result in a formatted value of `"1,000"`. This argument is
         ignored if a `locale` is supplied (i.e., is not `None`).
-    dec_mark : str
+    dec_mark
         The string to be used as the decimal mark. For example, using `dec_mark=","` with the value
         `0.152` would result in a formatted value of `"0,152"`). This argument is ignored if a
         `locale` is supplied (i.e., is not `None`).
-    force_sign : bool
+    force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
         negative numbers will display a minus sign. This option is disregarded when using accounting
         notation with `accounting = True`.
-    incl_space : bool
+    incl_space
         An option for whether to include a space between the value and the currency symbol. The
         default is to not introduce a space character.
-    locale : str | None
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -1556,22 +1556,22 @@ def fmt_date(
 
     Parameters
     ----------
-    columns : str | List[str] | None
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    rows : int | List[int] | None
+    rows
         In conjunction with `columns`, we can specify which of their rows should undergo formatting.
         The default is all rows, resulting in all rows in `columns` being formatted. Alternatively,
         we can supply a list of row indices.
-    date_style: str
+    date_style
         The date style to use. By default this is the short name `"iso"` which corresponds to
         ISO 8601 date formatting. There are 41 date styles in total and their short names can be
         viewed using `info_date_style()`.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    locale : str | None
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -1704,22 +1704,22 @@ def fmt_time(
 
     Parameters
     ----------
-    columns : str | List[str] | None
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    rows : int | List[int] | None
+    rows
         In conjunction with `columns`, we can specify which of their rows should undergo formatting.
         The default is all rows, resulting in all rows in `columns` being formatted. Alternatively,
         we can supply a list of row indices.
-    time_style: str
+    time_style
         The time style to use. By default this is the short name `"iso"` which corresponds to how
         times are formatted within ISO 8601 datetime values. There are 5 time styles in total and
         their short names can be viewed using `info_time_style()`.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    locale : str | None
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -1846,18 +1846,18 @@ def fmt_datetime(
 
     Parameters
     ----------
-    columns : str | List[str] | None
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    rows : int | List[int] | None
+    rows
         In conjunction with `columns`, we can specify which of their rows should undergo formatting.
         The default is all rows, resulting in all rows in `columns` being formatted. Alternatively,
         we can supply a list of row indices.
-    date_style: str
+    date_style
         The date style to use. By default this is the short name `"iso"` which corresponds to
         ISO 8601 date formatting. There are 41 date styles in total and their short names can be
         viewed using `info_date_style()`.
-    time_style: str
+    time_style
         The time style to use. By default this is the short name `"iso"` which corresponds to how
         times are formatted within ISO 8601 datetime values. There are 5 time styles in total and
         their short names can be viewed using `info_time_style()`.
@@ -1999,7 +1999,7 @@ def _validate_iso_datetime_str(x: str) -> None:
 
     Parameters
     ----------
-    x : str
+    x
         The string to validate.
 
     Raises
@@ -2026,7 +2026,7 @@ def _normalize_iso_datetime_str(x: str) -> str:
 
     Parameters
     ----------
-    x : str
+    x
         The string to normalize.
 
     Returns
@@ -2055,10 +2055,10 @@ def fmt_markdown(
 
     Parameters
     ----------
-    columns : str | List[str] | None
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    rows : int | List[int] | None
+    rows
         In conjunction with `columns`, we can specify which of their rows should undergo formatting.
         The default is all rows, resulting in all rows in `columns` being formatted. Alternatively,
         we can supply a list of row indices.
@@ -2467,14 +2467,10 @@ def _listify(
 
     Parameters
     ----------
-
-    x : Union[T, List[T], None]
-
+    x
         The input value to be converted into a list. It can be a single value of type T, a list of
         values of type T, or None.
-
-    default : Callable[[], List[T]]
-
+    default
         A callable that returns a default list when the input value is None.
 
     Returns
@@ -3310,24 +3306,25 @@ def fmt_image(
 
     Parameters
     ----------
-    columns:
+    columns
         The columns to format.
-    rows:
+    rows
         The rows to format, specified using row numbers.
-    height, width:
-        Height and width of images.
-    sep:
+    height
+        The height of the rendered images.
+    width
+        The width of the rendered images.
+    sep
         Separator between images.
-    path:
+    path
         Path to image files.
-    file_pattern:
+    file_pattern
         File pattern specification.
-    encode:
+    encode
         Whether to use Base64 encoding.
 
     Examples
     --------
-
     ```{python}
     from great_tables import GT
     from great_tables.data import metro

--- a/great_tables/_formats_vals.py
+++ b/great_tables/_formats_vals.py
@@ -63,58 +63,58 @@ def val_fmt_number(
 
     Parameters
     ----------
-    x : Union[Any, List[Any]]
+    x
         A list of values to be formatted.
-    decimals : int
+    decimals
         The `decimals` values corresponds to the exact number of decimal places to use. A value such
         as `2.34` can, for example, be formatted with `0` decimal places and it would result in
         `"2"`. With `4` decimal places, the formatted value becomes `"2.3400"`. The trailing zeros
         can be removed with `drop_trailing_zeros=True`. If you always need `decimals = 0`, the
         [`val_fmt_integer()`](`great_tables._formats_vals.val_fmt_integer`) function should be
         considered.
-    n_sigfig : Optional[int]
+    n_sigfig
         A option to format numbers to *n* significant figures. By default, this is `None` and thus
         number values will be formatted according to the number of decimal places set via
         `decimals`. If opting to format according to the rules of significant figures, `n_sigfig`
         must be a number greater than or equal to `1`. Any values passed to the `decimals` and
         `drop_trailing_zeros` arguments will be ignored.
-    drop_trailing_zeros : bool
+    drop_trailing_zeros
         A boolean value that allows for removal of trailing zeros (those redundant zeros after the
         decimal mark).
-    drop_trailing_dec_mark : bool
+    drop_trailing_dec_mark
         A boolean value that determines whether decimal marks should always appear even if there are
         no decimal digits to display after formatting (e.g., `23` becomes `23.` if `False`). By
         default trailing decimal marks are not shown.
-    use_seps : bool
+    use_seps
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
-    scale_by : float
+    scale_by
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
         value is supplied.
-    compact : bool
+    compact
         A boolean value that allows for compact formatting of numeric values. Values will be scaled
         and decorated with the appropriate suffixes (e.g., `1230` becomes `1.23K`, and `1230000`
         becomes `1.23M`). The `compact` option is `False` by default.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    sep_mark : str
+    sep_mark
         The string to use as a separator between groups of digits. For example, using `sep_mark=","`
         with a value of `1000` would result in a formatted value of `"1,000"`. This argument is
         ignored if a `locale` is supplied (i.e., is not `None`).
-    dec_mark : str
+    dec_mark
         The string to be used as the decimal mark. For example, using `dec_mark=","` with the value
         `0.152` would result in a formatted value of `"0,152"`). This argument is ignored if a
         `locale` is supplied (i.e., is not `None`).
-    force_sign : bool
+    force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
         negative numbers will display a minus sign. This option is disregarded when using accounting
         notation with `accounting = True`.
-    locale : str
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -176,34 +176,34 @@ def val_fmt_integer(
 
     Parameters
     ----------
-    x : Union[Any, List[Any]]
+    x
         A list of values to be formatted.
-    use_seps : bool
+    use_seps
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
-    scale_by : float
+    scale_by
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
         value is supplied.
-    compact : bool
+    compact
         A boolean value that allows for compact formatting of numeric values. Values will be scaled
         and decorated with the appropriate suffixes (e.g., `1230` becomes `1K`, and `1230000`
         becomes `1M`). The `compact` option is `False` by default.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    sep_mark : str
+    sep_mark
         The string to use as a separator between groups of digits. For example, using `sep_mark=","`
         with a value of `1000` would result in a formatted value of `"1,000"`. This argument is
         ignored if a `locale` is supplied (i.e., is not `None`).
-    force_sign : bool
+    force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
         negative numbers will display a minus sign. This option is disregarded when using accounting
         notation with `accounting = True`.
-    locale : str
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -269,58 +269,58 @@ def val_fmt_scientific(
 
     Parameters
     ----------
-    x : Union[Any, List[Any]]
+    x
         A list of values to be formatted.
-    decimals : int
+    decimals
         The `decimals` values corresponds to the exact number of decimal places to use. A value such
         as `2.34` can, for example, be formatted with `0` decimal places and it would result in
         `"2"`. With `4` decimal places, the formatted value becomes `"2.3400"`. The trailing zeros
         can be removed with `drop_trailing_zeros=True`.
-    n_sigfig : Optional[int]
+    n_sigfig
         A option to format numbers to *n* significant figures. By default, this is `None` and thus
         number values will be formatted according to the number of decimal places set via
         `decimals`. If opting to format according to the rules of significant figures, `n_sigfig`
         must be a number greater than or equal to `1`. Any values passed to the `decimals` and
         `drop_trailing_zeros` arguments will be ignored.
-    drop_trailing_zeros : bool
+    drop_trailing_zeros
         A boolean value that allows for removal of trailing zeros (those redundant zeros after the
         decimal mark).
-    drop_trailing_dec_mark : bool
+    drop_trailing_dec_mark
         A boolean value that determines whether decimal marks should always appear even if there are
         no decimal digits to display after formatting (e.g., `23` becomes `23.` if `False`). By
         default trailing decimal marks are not shown.
-    scale_by : float
+    scale_by
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
         value is supplied.
-    exp_style : str
+    exp_style
         Style of formatting to use for the scientific notation formatting. By default this is
         `"x10n"` but other options include using a single letter (e.g., `"e"`, `"E"`, etc.), a
         letter followed by a `"1"` to signal a minimum digit width of one, or `"low-ten"` for using
         a stylized `"10"` marker.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    sep_mark : str
+    sep_mark
         The string to use as a separator between groups of digits. For example, using `sep_mark=","`
         with a value of `1000` would result in a formatted value of `"1,000"`. This argument is
         ignored if a `locale` is supplied (i.e., is not `None`).
-    dec_mark : str
+    dec_mark
         The string to be used as the decimal mark. For example, using `dec_mark=","` with the value
         `0.152` would result in a formatted value of `"0,152"`). This argument is ignored if a
         `locale` is supplied (i.e., is not `None`).
-    force_sign_m : bool
+    force_sign_m
         Should the plus sign be shown for positive values of the mantissa (first component)? This
         would effectively show a sign for all values except zero on the first numeric component of
         the notation. If so, use `True` (the default for this is `False`), where only negative
         numbers will display a sign.
-    force_sign_n : bool
+    force_sign_n
         Should the plus sign be shown for positive values of the exponent (second component)? This
         would effectively show a sign for all values except zero on the second numeric component of
         the notation. If so, use `True` (the default for this is `False`), where only negative
         numbers will display a sign.
-    locale : str
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -391,53 +391,53 @@ def val_fmt_percent(
 
     Parameters
     ----------
-    x : Union[Any, List[Any]]
+    x
         A list of values to be formatted.
-    decimals : int
+    decimals
         The `decimals` values corresponds to the exact number of decimal places to use. A value such
         as `2.34` can, for example, be formatted with `0` decimal places and it would result in
         `"2"`. With `4` decimal places, the formatted value becomes `"2.3400"`. The trailing zeros
         can be removed with `drop_trailing_zeros=True`.
-    drop_trailing_zeros : bool
+    drop_trailing_zeros
         A boolean value that allows for removal of trailing zeros (those redundant zeros after the
         decimal mark).
-    drop_trailing_dec_mark : bool
+    drop_trailing_dec_mark
         A boolean value that determines whether decimal marks should always appear even if there are
         no decimal digits to display after formatting (e.g., `23` becomes `23.` if `False`). By
         default trailing decimal marks are not shown.
-    scale_values : bool
+    scale_values
         Should the values be scaled through multiplication by 100? By default this scaling is
         performed since the expectation is that incoming values are usually proportional. Setting to
         `False` signifies that the values are already scaled and require only the percent sign when
         formatted.
-    use_seps : bool
+    use_seps
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    sep_mark : str
+    sep_mark
         The string to use as a separator between groups of digits. For example, using `sep_mark=","`
         with a value of `1000` would result in a formatted value of `"1,000"`. This argument is
         ignored if a `locale` is supplied (i.e., is not `None`).
-    dec_mark : str
+    dec_mark
         The string to be used as the decimal mark. For example, using `dec_mark=","` with the value
         `0.152` would result in a formatted value of `"0,152"`). This argument is ignored if a
         `locale` is supplied (i.e., is not `None`).
-    force_sign : bool
+    force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
         negative numbers will display a minus sign. This option is disregarded when using accounting
         notation with `accounting = True`.
-    placement : str
+    placement
         This option governs the placement of the percent sign. This can be either be `"right"` (the
         default) or `"left"`.
-    incl_space : bool
+    incl_space
         An option for whether to include a space between the value and the percent sign. The default
         is to not introduce a space character.
-    locale : str
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -508,57 +508,57 @@ def val_fmt_currency(
 
     Parameters
     ----------
-    x : Union[Any, List[Any]]
+    x
         A list of values to be formatted.
-    currency : Union[str, None]
+    currency
         The currency to use for the numeric value. This input can be supplied as a 3-letter currency
         code (e.g., `"USD"` for U.S. Dollars, `"EUR"` for the Euro currency).
-    use_subunits: bool
+    use_subunits
         An option for whether the subunits portion of a currency value should be displayed. For
         example, with an input value of `273.81`, the default formatting will produce `"$273.81"`.
         Removing the subunits (with `use_subunits = False`) will give us `"$273"`.
-    decimals : int
+    decimals
         The `decimals` values corresponds to the exact number of decimal places to use. This value
         is optional as a currency has an intrinsic number of decimal places (i.e., the subunits).
         A value such as `2.34` can, for example, be formatted with `0` decimal places and if the
         currency used is `"USD"` it would result in `"$2"`. With `4` decimal places, the formatted
         value becomes `"$2.3400"`.
-    drop_trailing_dec_mark : bool
+    drop_trailing_dec_mark
         A boolean value that determines whether decimal marks should always appear even if there are
         no decimal digits to display after formatting (e.g., `23` becomes `23.` if `False`). By
         default trailing decimal marks are not shown.
-    use_seps : bool
+    use_seps
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
-    scale_by : float
+    scale_by
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
         value is supplied.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    sep_mark : str
+    sep_mark
         The string to use as a separator between groups of digits. For example, using `sep_mark=","`
         with a value of `1000` would result in a formatted value of `"1,000"`. This argument is
         ignored if a `locale` is supplied (i.e., is not `None`).
-    dec_mark : str
+    dec_mark
         The string to be used as the decimal mark. For example, using `dec_mark=","` with the value
         `0.152` would result in a formatted value of `"0,152"`). This argument is ignored if a
         `locale` is supplied (i.e., is not `None`).
-    force_sign : bool
+    force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
         negative numbers will display a minus sign. This option is disregarded when using accounting
         notation with `accounting = True`.
-    placement : str
+    placement
         The placement of the currency symbol. This can be either be `"left"` (as in `"$450"`) or
         `"right"` (which yields `"450$"`).
-    incl_space : bool
+    incl_space
         An option for whether to include a space between the value and the currency symbol. The
         default is to not introduce a space character.
-    locale : str
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -604,12 +604,12 @@ def val_fmt_roman(
 
     Parameters
     ----------
-    x : Union[Any, List[Any]]
+    x
         A list of values to be formatted.
-    case : str
+    case
         Should Roman numerals should be rendered as uppercase (`"upper"`) or lowercase (`"lower"`)
         letters? By default, this is set to `"upper"`.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
@@ -670,50 +670,50 @@ def val_fmt_bytes(
 
     Parameters
     ----------
-    x : Union[Any, List[Any]]
+    x
         A list of values to be formatted.
-    standard: str
+    standard
         The form of expressing large byte sizes is divided between: (1) decimal units (powers of
         1000; e.g., `"kB"` and `"MB"`), and (2) binary units (powers of 1024; e.g., `"KiB"` and
         `"MiB"`). The default is to use decimal units with the `"decimal"` option. The alternative
         is to use binary units with the `"binary"` option.
-    decimals : int
+    decimals
         This corresponds to the exact number of decimal places to use. A value such as `2.34` can,
         for example, be formatted with `0` decimal places and it would result in `"2"`. With `4`
         decimal places, the formatted value becomes `"2.3400"`. The trailing zeros can be removed
         with `drop_trailing_zeros=True`.
-    drop_trailing_zeros : bool
+    drop_trailing_zeros
         A boolean value that allows for removal of trailing zeros (those redundant zeros after the
         decimal mark).
-    drop_trailing_dec_mark : bool
+    drop_trailing_dec_mark
         A boolean value that determines whether decimal marks should always appear even if there are
         no decimal digits to display after formatting (e.g., `23` becomes `23.` if `False`). By
         default trailing decimal marks are not shown.
-    use_seps : bool
+    use_seps
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    sep_mark : str
+    sep_mark
         The string to use as a separator between groups of digits. For example, using `sep_mark=","`
         with a value of `1000` would result in a formatted value of `"1,000"`. This argument is
         ignored if a `locale` is supplied (i.e., is not `None`).
-    dec_mark : str
+    dec_mark
         The string to be used as the decimal mark. For example, using `dec_mark=","` with the value
         `0.152` would result in a formatted value of `"0,152"`). This argument is ignored if a
         `locale` is supplied (i.e., is not `None`).
-    force_sign : bool
+    force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
         negative numbers will display a minus sign. This option is disregarded when using accounting
         notation with `accounting = True`.
-    incl_space : bool
+    incl_space
         An option for whether to include a space between the value and the currency symbol. The
         default is to not introduce a space character.
-    locale : str
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -760,17 +760,17 @@ def val_fmt_date(
 
     Parameters
     ----------
-    x : Union[Any, List[Any]]
+    x
         A list of values to be formatted.
-    date_style: str
+    date_style
         The date style to use. By default this is the short name `"iso"` which corresponds to
         ISO 8601 date formatting. There are 41 date styles in total and their short names can be
         viewed using `info_date_style()`.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    locale : str
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -838,17 +838,17 @@ def val_fmt_time(
 
     Parameters
     ----------
-    x : Union[Any, List[Any]]
+    x
         A list of values to be formatted.
-    time_style: str
+    time_style
         The time style to use. By default this is the short name `"iso"` which corresponds to how
         times are formatted within ISO 8601 datetime values. There are 5 time styles in total and
         their short names can be viewed using `info_time_style()`.
-    pattern : str
+    pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
         characters will be interpreted as string literals.
-    locale : str
+    locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
 
@@ -900,7 +900,7 @@ def val_fmt_markdown(
 
     Parameters
     ----------
-    x : Union[Any, List[Any]]
+    x
         A list of values to be formatted.
 
     Returns

--- a/great_tables/_heading.py
+++ b/great_tables/_heading.py
@@ -24,15 +24,15 @@ def tab_header(
 
     Parameters
     ----------
-    title : str | Text
+    title
         Text to be used in the table title. We can elect to use the [`md()`](`great_tables.md`) and
         [`html()`](`great_tables.html`) helper functions to style the text as Markdown or to retain
         HTML elements in the text.
-    subtitle : Optional[str | Text]
+    subtitle
         Text to be used in the table subtitle. We can elect to use the [`md()`](`great_tables.md`)
         and [`html()`](`great_tables.html`) helper functions to style the text as Markdown or to
         retain HTML elements in the text.
-    preheader: Optional[str | List[str]]
+    preheader
         Optional preheader content that is rendered above the table. Can be supplied as a list
         of strings.
 

--- a/great_tables/_helpers.py
+++ b/great_tables/_helpers.py
@@ -34,7 +34,7 @@ def px(x: Union[int, float]) -> str:
 
     Parameters
     ----------
-    x : Union[int, float]
+    x
         The integer or float value to format as a string (e.g., `"12px"`) for some arguments that
         can take values as units of pixels.
 
@@ -61,7 +61,7 @@ def pct(x: Union[int, float]) -> str:
 
     Parameters
     ----------
-    x : Union[int, float]
+    x
         The integer or float value to format as a string-based percentage value for some arguments
         that can take percentage values.
 
@@ -84,7 +84,7 @@ def md(text: str) -> Text:
 
     Parameters
     ----------
-    text : str
+    text
         The text that is understood to contain Markdown formatting.
 
     Returns
@@ -105,7 +105,7 @@ def html(text: str) -> Text:
 
     Parameters
     ----------
-    text : str
+    text
         The text that is understood to contain HTML formatting.
 
     Returns
@@ -121,7 +121,7 @@ def random_id(n: int = 10) -> str:
 
     Parameters
     ----------
-    n : int
+    n
         The number of lowercase letters to use in the random ID string. Defaults to 10.
 
     Returns
@@ -218,7 +218,7 @@ def system_fonts(name: FontStackName = "system-ui") -> List[str]:
 
     Parameters
     ----------
-    name : FontStackName, optional
+    name
         The name of a font stack. Must be drawn from the set of `"system-ui"` (the default),
         `"transitional"`, `"old-style"`, `"humanist"`, `"geometric-humanist"`,
         `"classical-humanist"`, `"neo-grotesque"`, `"monospace-slab-serif"`, `"monospace-code"`,

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -93,10 +93,10 @@ class LocBody(Loc):
 
     Parameters
     ----------
-    columns : SelectExpr
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    rows : list[str | int]
+    rows
         The rows to target. Can either be a single row name or a series of row names provided in a
         list.
 

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -170,295 +170,295 @@ def tab_options(
 
     Parameters
     ----------
-    container_width : str
+    container_width
         The width of the table's container. Can be specified as a single-length
         character with units of pixels or as a percentage. If provided as a scalar numeric
         value, it is assumed that the value is given in units of pixels.
-    container_height: str
+    container_height
         The height of the table's container.
-    container_overflow_x : bool
+    container_overflow_x
         An option to enable scrolling in the horizontal direction when the table content overflows
         the container dimensions. Using `True` (the default) means that horizontal scrolling is
         enabled to view the entire table in those directions. With `False`, the table may be clipped
         if the table width or height exceeds the `container_width`.
-    container_overflow_y : bool
+    container_overflow_y
         An option to enable scrolling in the vertical direction when the table content overflows.
         Same rules apply as for `container_overflow_x`; the dependency here is that of the table
         height (`container_height`).
-    table_width : str
+    table_width
         The width of the table. Can be specified as a string with units of pixels or as a
         percentage. If provided as a numeric value, it is assumed that the value is given in
         units of pixels.
-    table_layout : str
+    table_layout
         The value for the `table-layout` CSS style in the HTML output context. By default, this
         is `"fixed"` but another valid option is `"auto"`.
-    table_margin_left : str
+    table_margin_left
         The size of the margins on the left of the table within the container. Can be
         specified as a single-length value with units of pixels or as a percentage. If
         provided as a numeric value, it is assumed that the value is given in units of pixels.
         Using `table_margin_left` will overwrite any values set by `table_align`.
-    table_margin_right : str
+    table_margin_right
         The size of the margins on the right of the table within the container. Same rules apply
         as for `table_margin_left`. Using `table_margin_right` will overwrite any values set by
         `table_align`.
-    table_background_color : str
+    table_background_color
         The background color for the table. A color name or a hexadecimal color code should be
         provided.
-    table_font_names : Union[str, List[str]]
+    table_font_names
         The names of the fonts used for the table. This should be provided as a list of font
         names. If the first font isn't available, then the next font is tried (and so on).
-    table_font_size : str
+    table_font_size
         The font size for the table. Can be specified as a string with units of pixels or as a
         percentage. If provided as a numeric value, it is assumed that the value is given in
         units of pixels.
-    table_font_weight : str
+    table_font_weight
         The font weight of the table. Can be a text-based keyword such as `"normal"`, `"bold"`,
         `"lighter"`, `"bolder"`, or, a numeric value between `1` and `1000`, inclusive. Note that
         only variable fonts may support the numeric mapping of weight.
-    table_font_style : str
+    table_font_style
         The font style for the table. Can be one of either `"normal"`, `"italic"`, or `"oblique"`.
-    table_font_color : str
+    table_font_color
         The text color used throughout the table. A color name or a hexadecimal color code should be
         provided.
-    table_font_color_light : str
+    table_font_color_light
         The text color used throughout the table when the background color is dark. A color name or
         a hexadecimal color code should be provided.
-    table_border_top_style : str
+    table_border_top_style
         The style of the table's absolute top border. Can be one of either `"solid"`, `"dotted"`,
         `"dashed"`, `"double"`, `"groove"`, `"ridge"`, `"inset"`, or `"outset"`.
-    table_border_top_width : str
+    table_border_top_width
         The width of the table's absolute top border. Can be specified as a string with units of
         pixels or as a percentage. If provided as a numeric value, it is assumed that the value is
         given in units of pixels.
-    table_border_top_color : str
+    table_border_top_color
         The color of the table's absolute top border. A color name or a hexadecimal color code
         should be provided.
-    table_border_bottom_style : str
+    table_border_bottom_style
         The style of the table's absolute bottom border.
-    table_border_bottom_width : str
+    table_border_bottom_width
         The width of the table's absolute bottom border.
-    table_border_bottom_color : str
+    table_border_bottom_color
         The color of the table's absolute bottom border.
-    table_border_left_style : str
+    table_border_left_style
         The style of the table's absolute left border.
-    table_border_left_width : str
+    table_border_left_width
         The width of the table's absolute left border.
-    table_border_left_color : str
+    table_border_left_color
         The color of the table's absolute left border.
-    table_border_right_style : str
+    table_border_right_style
         The style of the table's absolute right border.
-    table_border_right_width : str
+    table_border_right_width
         The width of the table's absolute right border.
-    table_border_right_color : str
+    table_border_right_color
         The color of the table's absolute right border.
-    heading_background_color : str
+    heading_background_color
         The background color for the heading. A color name or a hexadecimal color code should be
         provided.
-    heading_align : str
+    heading_align
         Controls the horizontal alignment of the heading title and subtitle. We can either use
         `"center"`, `"left"`, or `"right"`.
-    heading_title_font_size : str
+    heading_title_font_size
         The font size for the heading title element.
-    heading_title_font_weight : str
+    heading_title_font_weight
         The font weight of the heading title.
-    heading_subtitle_font_size : str
+    heading_subtitle_font_size
         The font size for the heading subtitle element.
-    heading_subtitle_font_weight : str
+    heading_subtitle_font_weight
         The font weight of the heading subtitle.
-    heading_padding : str
+    heading_padding
         The amount of vertical padding to incorporate in the `heading` (title and subtitle). Can be
         specified as a string with units of pixels or as a percentage. If provided as a numeric
         value, it is assumed that the value is given in units of pixels.
-    heading_padding_horizontal : str
+    heading_padding_horizontal
         The amount of horizontal padding to incorporate in the `heading` (title and subtitle). Can
         be specified as a string with units of pixels or as a percentage. If provided as a numeric
         value, it is assumed that the value is given in units of pixels.
-    heading_border_bottom_style : str
+    heading_border_bottom_style
         The style of the header's bottom border.
-    heading_border_bottom_width : str
+    heading_border_bottom_width
         The width of the header's bottom border. If the `width` of this border is larger, then it
         will be the visible border.
-    heading_border_bottom_color : str
+    heading_border_bottom_color
         The color of the header's bottom border.
-    heading_border_lr_style : str
+    heading_border_lr_style
         The style of the left and right borders of the `heading` location.
-    heading_border_lr_width : str
+    heading_border_lr_width
         The width of the left and right borders of the `heading` location. If the `width` of this
         border is larger, then it will be the visible border.
-    heading_border_lr_color : str
+    heading_border_lr_color
         The color of the left and right borders of the `heading` location.
-    column_labels_background_color : str
+    column_labels_background_color
         The background color for the column labels. A color name or a hexadecimal color code should
         be provided.
-    column_labels_font_size : str
+    column_labels_font_size
         The font size to use for all column labels.
-    column_labels_font_weight : str
+    column_labels_font_weight
         The font weight of the table's column labels.
-    column_labels_text_transform : str
+    column_labels_text_transform
         The text transformation for the column labels. Either of the `"uppercase"`, `"lowercase"`,
         or `"capitalize"` keywords can be used.
-    column_labels_padding : str
+    column_labels_padding
         The amount of vertical padding to incorporate in the `column_labels` (this includes the
         column spanners).
-    column_labels_padding_horizontal : str
+    column_labels_padding_horizontal
         The amount of horizontal padding to incorporate in the `column_labels` (this includes the
         column spanners).
-    column_labels_vlines_style : str
+    column_labels_vlines_style
         The style of all vertical lines ('vlines') of the `column_labels`.
-    column_labels_vlines_width : str
+    column_labels_vlines_width
         The width of all vertical lines ('vlines') of the `column_labels`.
-    column_labels_vlines_color : str
+    column_labels_vlines_color
         The color of all vertical lines ('vlines') of the `column_labels`.
-    column_labels_border_top_style : str
+    column_labels_border_top_style
         The style of the top border of the `column_labels` location.
-    column_labels_border_top_width : str
+    column_labels_border_top_width
         The width of the top border of the `column_labels` location. If the `width` of this border
         is larger, then it will be the visible border.
-    column_labels_border_top_color : str
+    column_labels_border_top_color
         The color of the top border of the `column_labels` location.
-    column_labels_border_bottom_style : str
+    column_labels_border_bottom_style
         The style of the bottom border of the `column_labels` location.
-    column_labels_border_bottom_width : str
+    column_labels_border_bottom_width
         The width of the bottom border of the `column_labels` location. If the `width` of this
         border is larger, then it will be the visible border.
-    column_labels_border_bottom_color : str
+    column_labels_border_bottom_color
         The color of the bottom border of the `column_labels` location.
-    column_labels_border_lr_style : str
+    column_labels_border_lr_style
         The style of the left and right borders of the `column_labels` location.
-    column_labels_border_lr_width: str
+    column_labels_border_lr_width
         The width of the left and right borders of the `column_labels` location. If the `width` of
         this border is larger, then it will be the visible border.
-    column_labels_border_lr_color : str
+    column_labels_border_lr_color
         The color of the left and right borders of the `column_labels` location.
-    column_labels_hidden : bool
+    column_labels_hidden
         An option to hide the column labels. If providing `True` then the entire `column_labels`
         location won't be seen and the table header (if present) will collapse downward.
-    row_group_background_color : str
+    row_group_background_color
         The background color for the row group labels. A color name or a hexadecimal color code
         should be provided.
-    row_group_font_weight : str
+    row_group_font_weight
         The font weight for all row group labels present in the table.
-    row_group_font_size : str
+    row_group_font_size
         The font size to use for all row group labels.
-    row_group_padding : str
+    row_group_padding
         The amount of vertical padding to incorporate in the row group labels.
-    row_group_border_top_style : str
+    row_group_border_top_style
         The style of the top border of the `row_group` location.
-    row_group_border_top_width : str
+    row_group_border_top_width
         The width of the top border of the `row_group` location. If the `width` of this border is
         larger, then it will be the visible border.
-    row_group_border_top_color : str
+    row_group_border_top_color
         The color of the top border of the `row_group` location.
-    row_group_border_bottom_style : str
+    row_group_border_bottom_style
         The style of the bottom border of the `row_group` location.
-    row_group_border_bottom_width : str
+    row_group_border_bottom_width
         The width of the bottom border of the `row_group` location. If the `width` of this border
         is larger, then it will be the visible border.
-    row_group_border_bottom_color : str
+    row_group_border_bottom_color
         The color of the bottom border of the `row_group` location.
-    row_group_border_left_style : str
+    row_group_border_left_style
         The style of the left border of the `row_group` location.
-    row_group_border_left_width : str
+    row_group_border_left_width
         The width of the left border of the `row_group` location. If the `width` of this border is
         larger, then it will be the visible border.
-    row_group_border_left_color : str
+    row_group_border_left_color
         The color of the left border of the `row_group` location.
-    row_group_border_right_style : str
+    row_group_border_right_style
         The style of the right border of the `row_group` location.
-    row_group_border_right_width : str
+    row_group_border_right_width
         The width of the right border of the `row_group` location. If the `width` of this border is
-    row_group_border_right_color : str
+    row_group_border_right_color
         The color of the right border of the `row_group` location.
-    row_group_as_column : bool
+    row_group_as_column
         An option to render the row group labels as a column. If `True`, then the row group labels
         will be rendered as a column to the left of the table body. If `False`, then the row group
         labels will be rendered as a separate row above the grouping of rows.
-    table_body_hlines_style : str
+    table_body_hlines_style
         The style of all horizontal lines ('hlines') in the `table_body`.
-    table_body_hlines_width : str
+    table_body_hlines_width
         The width of all horizontal lines ('hlines') in the `table_body`.
-    table_body_hlines_color : str
+    table_body_hlines_color
         The color of all horizontal lines ('hlines') in the `table_body`.
-    table_body_vlines_style : str
+    table_body_vlines_style
         The style of all vertical lines ('vlines') in the `table_body`.
-    table_body_vlines_width : str
+    table_body_vlines_width
         The width of all vertical lines ('vlines') in the `table_body`.
-    table_body_vlines_color : str
+    table_body_vlines_color
         The color of all vertical lines ('vlines') in the `table_body`.
-    table_body_border_top_style : str
+    table_body_border_top_style
         The style of the top border of the `table_body` location.
-    table_body_border_top_width : str
+    table_body_border_top_width
         The width of the top border of the `table_body` location. If the `width` of this border is
         larger, then it will be the visible border.
-    table_body_border_top_color : str
+    table_body_border_top_color
         The color of the top border of the `table_body` location.
-    table_body_border_bottom_style : str
+    table_body_border_bottom_style
         The style of the bottom border of the `table_body` location.
-    table_body_border_bottom_width : str
+    table_body_border_bottom_width
         The width of the bottom border of the `table_body` location. If the `width` of this border
-    table_body_border_bottom_color : str
+    table_body_border_bottom_color
         The color of the bottom border of the `table_body` location.
-    stub_background_color : str
+    stub_background_color
         The background color for the stub. A color name or a hexadecimal color code should be
         provided.
-    stub_font_size : str
+    stub_font_size
         The font size to use for all row labels present in the table stub.
-    stub_font_weight : str
+    stub_font_weight
         The font weight for all row labels present in the table stub.
-    stub_text_transform : str
+    stub_text_transform
         The text transformation for the row labels present in the table stub.
-    stub_border_style : str
+    stub_border_style
         The style of the vertical border of the table stub.
-    stub_border_width : str
+    stub_border_width
         The width of the vertical border of the table stub.
-    stub_border_color : str
+    stub_border_color
         The color of the vertical border of the table stub.
-    stub_row_group_font_size : str
+    stub_row_group_font_size
         The font size for the row group column in the stub.
-    stub_row_group_font_weight : str
+    stub_row_group_font_weight
         The font weight for the row group column in the stub.
-    stub_row_group_text_transform : str
+    stub_row_group_text_transform
         The text transformation for the row group column in the stub.
-    stub_row_group_border_style : str
+    stub_row_group_border_style
         The style of the vertical border of the row group column in the stub.
-    stub_row_group_border_width : str
+    stub_row_group_border_width
         The width of the vertical border of the row group column in the stub.
-    stub_row_group_border_color : str
+    stub_row_group_border_color
         The color of the vertical border of the row group column in the stub.
-    data_row_padding : str
+    data_row_padding
         The amount of vertical padding to incorporate in the body/stub rows.
-    data_row_padding_horizontal : str
+    data_row_padding_horizontal
         The amount of horizontal padding to incorporate in the body/stub rows.
-    source_notes_background_color : str
+    source_notes_background_color
         The background color for the source notes. A color name or a hexadecimal color code should
         be provided.
-    source_notes_font_size : str
+    source_notes_font_size
         The font size to use for all source note text.
-    source_notes_padding : str
+    source_notes_padding
         The amount of vertical padding to incorporate in the source notes.
-    source_notes_padding_horizontal : str
+    source_notes_padding_horizontal
         The amount of horizontal padding to incorporate in the source notes.
-    source_notes_multiline : bool
+    source_notes_multiline
         An option to either put source notes in separate lines (the default, or `True`) or render
         them as a continuous line of text with `source_notes_sep` providing the separator (by
         default `" "`) between notes.
-    source_notes_sep : str
+    source_notes_sep
         The separating characters between adjacent source notes when rendered as a continuous line
         of text (when `source_notes_multiline` is `False`). The default value is a single space
         character (`" "`).
-    source_notes_border_bottom_style : str
+    source_notes_border_bottom_style
         The style of the bottom border of the `source_notes` location.
-    source_notes_border_bottom_width : str
+    source_notes_border_bottom_width
         The width of the bottom border of the `source_notes` location. If the `width` of this border
         is larger, then it will be the visible border.
-    source_notes_border_bottom_color : str
+    source_notes_border_bottom_color
         The color of the bottom border of the `source_notes` location.
-    source_notes_border_lr_style : str
+    source_notes_border_lr_style
         The style of the left and right borders of the `source_notes` location.
-    source_notes_border_lr_width : str
+    source_notes_border_lr_width
         The width of the left and right borders of the `source_notes` location. If the `width` of
         this border is larger, then it will be the visible border.
-    source_notes_border_lr_color : str
+    source_notes_border_lr_color
         The color of the left and right borders of the `source_notes` location.
 
     Returns
@@ -570,7 +570,7 @@ def opt_footnote_marks(self: GTSelf, marks: Union[str, List[str]] = "numbers") -
 
     Parameters
     ----------
-    marks : Union[str, List[str]]
+    marks
         Either a list of strings that will represent the series of marks or a keyword string
         that represents a preset sequence of marks. The valid keywords are: `"numbers"` (for
         numeric marks), `"letters"` and `"LETTERS"` (for lowercase and uppercase alphabetic
@@ -603,7 +603,7 @@ def opt_row_striping(self: GTSelf, row_striping: bool = True) -> GTSelf:
 
     Parameters
     ----------
-    row_striping : bool
+    row_striping
         A boolean that indicates whether row striping should be added or removed. Defaults to
         `True`.
 
@@ -627,7 +627,7 @@ def opt_align_table_header(self: GTSelf, align: str = "center") -> GTSelf:
 
     Parameters
     ----------
-    align : str
+    align
         The alignment of the title and subtitle elements in the table header. Options are `"center"`
         (the default), `"left"`, or `"right"`.
 
@@ -680,7 +680,7 @@ def opt_vertical_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
 
     Parameters
     ----------
-    scale : float
+    scale
         The factor by which to scale the vertical padding. The default value is `1.0`. A value
         less than `1.0` will reduce the padding, and a value greater than `1.0` will increase the
         padding. The value must be between `0` and `3`.
@@ -781,7 +781,7 @@ def opt_horizontal_padding(self: GTSelf, scale: float = 1.0) -> GTSelf:
 
     Parameters
     ----------
-    scale : float
+    scale
         The factor by which to scale the horizontal padding. The default value is `1.0`. A value
         less than `1.0` will reduce the padding, and a value greater than `1.0` will increase the
         padding. The value must be between `0` and `3`.
@@ -884,11 +884,11 @@ def opt_all_caps(
 
     Parameters
     ----------
-    all_caps : bool
+    all_caps
         Indicates whether the text transformation to all caps should be performed (`True`, the
         default) or reset to default values (`False`) for the `locations` targeted.
 
-    locations : Union[str, List[str]]
+    locations
         Which locations should undergo this text transformation? By default it includes all of
         the `"column_labels"`, the `"stub"`, and the `"row_group"` locations. However, we could
         just choose one or two of those.

--- a/great_tables/_source_notes.py
+++ b/great_tables/_source_notes.py
@@ -19,7 +19,7 @@ def tab_source_note(data: GTSelf, source_note: Union[str, Text]) -> GTSelf:
 
     Parameters
     ----------
-    source_note : str | Text
+    source_note
         Text to be used in the source note. We can optionally use the [`md()`](`great_tables.md`) or
         [`html()`](`great_tables.html`) helper functions to style the text as Markdown or to retain
         HTML elements in the text.

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -42,23 +42,23 @@ def tab_spanner(
 
     Parameters
     ----------
-    label : str
+    label
         The text to use for the spanner label. We can optionally use the [`md()`](`great_tables.md`)
         and [`html()`](`great_tables.html`) helper functions to style the text as Markdown or to
         retain HTML elements in the text.
-    columns : SelectExpr
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    spanners : str | list[str] | None
+    spanners
         The spanners that should be spanned over, should they already be defined. One or more
         spanner ID values (in quotes) can be supplied here. This argument works in tandem with the
         `columns` argument.
-    level : Optional[int]
+    level
         An explicit level to which the spanner should be placed. If not provided, **Great Tables**
         will choose the level based on the inputs provided within `columns` and `spanners`, placing
         the spanner label where it will fit. The first spanner level (right above the column labels)
         is `0`.
-    id : Optional[str]
+    id
         The ID for the spanner. When accessing a spanner through the `spanners` argument of
         `tab_spanner()` the `id` value is used as the reference (and not the `label`). If an `id`
         is not explicitly provided here, it will be taken from the `label` value. It is advisable to
@@ -66,11 +66,11 @@ def tab_spanner(
         text is complicated (e.g., contains markup, is lengthy, or both). Finally, when providing
         an `id` value you must ensure that it is unique across all ID values set for spanner labels
         (the method will throw an error if `id` isn't unique).
-    gather : bool
+    gather
         An option to move the specified `columns` such that they are unified under the spanner.
         Ordering of the moved-into-place columns will be preserved in all cases. By default, this
         is set to `True`.
-    replace : bool
+    replace
         Should new spanners be allowed to partially or fully replace existing spanners? (This is a
         possibility if setting spanners at an already populated `level`.) By default, this is set to
         `False` and an error will occur if some replacement is attempted.
@@ -215,10 +215,10 @@ def cols_move(data: GTSelf, columns: SelectExpr, after: str) -> GTSelf:
 
     Parameters
     ----------
-    columns : SelectExpr
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    after : str
+    after
         The column after which the `columns` should be placed. This can be any column name that
         exists in the table.
 
@@ -299,7 +299,7 @@ def cols_move_to_start(data: GTSelf, columns: SelectExpr) -> GTSelf:
 
     Parameters
     ----------
-    columns : SelectExpr
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
 
@@ -368,7 +368,7 @@ def cols_move_to_end(data: GTSelf, columns: SelectExpr) -> GTSelf:
 
     Parameters
     ----------
-    columns : SelectExpr
+    columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
 
@@ -436,7 +436,7 @@ def cols_hide(data: GTSelf, columns: SelectExpr) -> GTSelf:
 
     Parameters
     ----------
-    columns : SelectExpr
+    columns
         The columns to hide in the output display table. Can either be a single column name or a
         series of column names provided in a list.
 
@@ -579,7 +579,7 @@ def cols_width(data: GTSelf, cases: Dict[str, str]) -> GTSelf:
 
     Parameters
     ----------
-    cases : Dict[str, str]
+    cases
         A dictionary where the keys are column names and the values are the widths. Widths can be
         specified in pixels (e.g., `"50px"`) or as percentages (e.g., `"20%"`).
 

--- a/great_tables/_stubhead.py
+++ b/great_tables/_stubhead.py
@@ -19,7 +19,7 @@ def tab_stubhead(self: GTSelf, label: Union[str, Text]) -> GTSelf:
 
     Parameters
     ----------
-    label : str | Text
+    label
         The text to be used as the stubhead label. We can optionally use the
         [`md()`](`great_tables.md`) and [`html()`](`great_tables.html`) helper functions to style
         the text as Markdown or to retain HTML elements in the text.

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -135,41 +135,41 @@ class CellStyleText(CellStyle):
 
     Parameters
     ----------
-    color : str | None
+    color
         The text color can be modified through the `color` argument.
-    font : str | None
+    font
         The font or collection of fonts (subsequent font names are) used as fallbacks.
-    size : str | None
+    size
         The size of the font. Can be provided as a number that is assumed to represent `px` values
         (or could be wrapped in the `px()` helper function). We can also use one of the following
         absolute size keywords: `"xx-small"`, `"x-small"`, `"small"`, `"medium"`, `"large"`,
         `"x-large"`, or `"xx-large"`.
-    align : Literal["center", "left", "right", "justify"] | None
+    align
         The text in a cell can be horizontally aligned though one of the following options:
         `"center"`, `"left"`, `"right"`, or `"justify"`.
-    v_align : Literal["middle", "top", "bottom"] | None
+    v_align
         The vertical alignment of the text in the cell can be modified through the options
         `"middle"`, `"top"`, or `"bottom"`.
-    style : Literal["normal", "italic", "oblique"] | None
+    style
         Can be one of either `"normal"`, `"italic"`, or `"oblique"`.
-    weight : Literal["normal", "bold", "bolder", "lighter"] | None)
+    weight
         The weight of the font can be modified thorough a text-based option such as `"normal"`,
         `"bold"`, `"lighter"`, `"bolder"`, or, a numeric value between `1` and `1000`, inclusive.
         Note that only variable fonts may support the numeric mapping of weight.
-    stretch : Literal["normal", "condensed", "ultra-condensed", "extra-condensed", "semi-condensed", "semi-expanded", "expanded", "extra-expanded", "ultra-expanded"] | None
+    stretch
         Allows for text to either be condensed or expanded. We can use one of the following
         text-based keywords to describe the degree of condensation/expansion: `"ultra-condensed"`,
         `"extra-condensed"`, `"condensed"`, `"semi-condensed"`, `"normal"`, `"semi-expanded"`,
         `"expanded"`, `"extra-expanded"`, or `"ultra-expanded"`. Alternatively, we can supply
         percentage values from `0%` to `200%`, inclusive. Negative percentage values are not
         allowed.
-    decorate : Literal["overline", "line-through", "underline", "underline overline"] | None
+    decorate
         Allows for text decoration effect to be applied. Here, we can use `"overline"`,
         `"line-through"`, or `"underline"`.
-    transform : Literal["uppercase", "lowercase", "capitalize"] | None
+    transform
         Allows for the transformation of text. Options are `"uppercase"`, `"lowercase"`, or
         `"capitalize"`.
-    whitespace : Literal["normal", "nowrap", "pre", "pre-wrap", "pre-line", "break-spaces"] | None
+    whitespace
         A white-space preservation option. By default, runs of white-space will be collapsed into
         single spaces but several options exist to govern how white-space is collapsed and how lines
         might wrap at soft-wrap opportunities. The options are `"normal"`, `"nowrap"`, `"pre"`,
@@ -189,24 +189,30 @@ class CellStyleText(CellStyle):
     v_align: Literal["middle", "top", "bottom"] | ColumnExpr | None = None
     style: Literal["normal", "italic", "oblique"] | ColumnExpr | None = None
     weight: Literal["normal", "bold", "bolder", "lighter"] | ColumnExpr | None = None
-    stretch: Literal[
-        "normal",
-        "condensed",
-        "ultra-condensed",
-        "extra-condensed",
-        "semi-condensed",
-        "semi-expanded",
-        "expanded",
-        "extra-expanded",
-        "ultra-expanded",
-    ] | ColumnExpr | None = None
-    decorate: Literal[
-        "overline", "line-through", "underline", "underline overline"
-    ] | ColumnExpr | None = None
+    stretch: (
+        Literal[
+            "normal",
+            "condensed",
+            "ultra-condensed",
+            "extra-condensed",
+            "semi-condensed",
+            "semi-expanded",
+            "expanded",
+            "extra-expanded",
+            "ultra-expanded",
+        ]
+        | ColumnExpr
+        | None
+    ) = None
+    decorate: (
+        Literal["overline", "line-through", "underline", "underline overline"] | ColumnExpr | None
+    ) = None
     transform: Literal["uppercase", "lowercase", "capitalize"] | ColumnExpr | None = None
-    whitespace: Literal[
-        "normal", "nowrap", "pre", "pre-wrap", "pre-line", "break-spaces"
-    ] | ColumnExpr | None = None
+    whitespace: (
+        Literal["normal", "nowrap", "pre", "pre-wrap", "pre-line", "break-spaces"]
+        | ColumnExpr
+        | None
+    ) = None
 
     def _to_html_style(self) -> str:
         rendered = ""
@@ -247,7 +253,7 @@ class CellStyleFill(CellStyle):
 
     Parameters
     ----------
-    color : str
+    color
         The color to use for the cell background fill. This can be any valid CSS color value, such
         as a hex code, a named color, or an RGB value.
 
@@ -276,16 +282,16 @@ class CellStyleBorders(CellStyle):
 
     Parameters
     ----------
-    sides : Literal["all", "top", "bottom", "left", "right"]
+    sides
         The border sides to be modified. Options include `"left"`, `"right"`, `"top"`, and
         `"bottom"`. For all borders surrounding the selected cells, we can use the `"all"` option.
-    color : str
+    color
         The border `color` can be defined with any valid CSS color value, such as a hex code, a
         named color, or an RGB value. The default `color` value is `"#000000"` (black).
-    style : str
+    style
         The border `style` can be one of either `"solid"` (the default), `"dashed"`, `"dotted"`,
         `"hidden"`, or `"double"`.
-    weight : str
+    weight
         The default value for `weight` is `"1px"` and higher values will become more visually
         prominent.
 
@@ -295,9 +301,11 @@ class CellStyleBorders(CellStyle):
         A CellStyleBorders object, which is used for a `styles` argument if specifying cell borders.
     """
 
-    sides: Literal["all", "top", "bottom", "left", "right"] | List[
+    sides: (
         Literal["all", "top", "bottom", "left", "right"]
-    ] | ColumnExpr = "all"
+        | List[Literal["all", "top", "bottom", "left", "right"]]
+        | ColumnExpr
+    ) = "all"
     color: str | ColumnExpr = "#000000"
     style: str | ColumnExpr = "solid"
     weight: str | ColumnExpr = "1px"

--- a/great_tables/_tab_create_modify.py
+++ b/great_tables/_tab_create_modify.py
@@ -32,11 +32,11 @@ def tab_style(
 
     Parameters
     ----------
-    style : CellStyle | list[CellStyle]
+    style
         The styles to use for the cells at the targeted `locations`. The `style.text()`,
         `style.fill()`, and `style.borders()` classes can be used here to more easily generate valid
         styles.
-    location : Loc | list[Loc]
+    location
         The cell or set of cells to be associated with the style. The `loc.body()` class can be used
         here to easily target body cell locations.
 
@@ -130,12 +130,12 @@ def tab_footnote(
 
     Parameters
     ----------
-    footnote:
+    footnote
         The footnote text.
-    locations:
+    locations
         The location to place the footnote. If None, then a footnote is created without
         a correesponding marker on the table (TODO: double check this).
-    placement:
+    placement
         Where to affix the footnote marks to the table content.
 
     """

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -87,18 +87,18 @@ class GT(
 
     Parameters
     ----------
-    data : Any
+    data
         A DataFrame object.
-    rowname_col : str | None
+    rowname_col
         The column name in the input `data=` table to use as row labels to be placed in the table
         stub.
-    groupname_col : str | None
+    groupname_col
         The column name in the input `data=` table to use as group labels for generation of row
         groups.
-    auto_align : bool
+    auto_align
         Optionally have column data be aligned depending on the content contained in each column of
         the input `data=`.
-    locale : str
+    locale
         An optional locale identifier that can be set as the default locale for all functions that
         take a `locale` argument. Examples include `"en"` for English (United States) and `"fr"`
         for French (France).


### PR DESCRIPTION
This removes all type annotations from docstrings. They aren't needed since griffe generates them automatically.