### PR TITLE
Add the `opt_table_outline()` method

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -157,6 +157,7 @@ quartodoc:
         - GT.opt_all_caps
         - GT.opt_vertical_padding
         - GT.opt_horizontal_padding
+        - GT.opt_table_outline
         - GT.opt_stylize
     - title: Value formatting functions
       desc: >

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -974,6 +974,32 @@ def opt_all_caps(
 def opt_table_outline(
     self: GTSelf, style: str = "solid", width: str = "3px", color: str = "#D3D3D3"
 ) -> GTSelf:
+    """
+    Option to wrap an outline around the entire table.
+
+    The `opt_table_outline()` method puts an outline of consistent `style=`, `width=`, and `color=`
+    around the entire table. It'll write over any existing outside lines so long as the `width=`
+    value is larger that of the existing lines. The default value of `style=` (`"solid"`) will draw
+    a solid outline, whereas using `"none"` will remove any present outline.
+
+    Parameters
+    ----------
+    style
+        The style of the table outline. The default value is `"solid"`. The valid values are
+        `"solid"`, `"dashed"`, `"dotted"`, and `"none"`.
+    width
+        The width of the table outline. The default value is `"3px"`. The value must be in pixels
+        and it must be an integer value.
+    color
+        The color of the table outline, where the default is `"#D3D3D3"`. The value must either a
+        hexadecimal color code or a color name.
+
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+    """
 def opt_stylize(self: GTSelf, style: int = 1, color: str = "blue") -> GTSelf:
     """
     Stylize your table with a colorful look.

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1000,6 +1000,10 @@ def opt_table_outline(
         The GT object is returned. This is the same object that the method is called on so that we
         can facilitate method chaining.
     """
+
+    # Validate the `style` argument
+    style = _utils._match_arg(x=style, lst=["solid", "dashed", "dotted", "none"])
+
 def opt_stylize(self: GTSelf, style: int = 1, color: str = "blue") -> GTSelf:
     """
     Stylize your table with a colorful look.

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1019,6 +1019,13 @@ def opt_table_outline(
         "table_border_left_color": color,
         "table_border_right_color": color,
     }
+
+    # Set the table outline options
+    res = tab_options(self=self, **params)
+
+    return res
+
+
 def opt_stylize(self: GTSelf, style: int = 1, color: str = "blue") -> GTSelf:
     """
     Stylize your table with a colorful look.

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -971,6 +971,9 @@ def opt_all_caps(
     return res
 
 
+def opt_table_outline(
+    self: GTSelf, style: str = "solid", width: str = "3px", color: str = "#D3D3D3"
+) -> GTSelf:
 def opt_stylize(self: GTSelf, style: int = 1, color: str = "blue") -> GTSelf:
     """
     Stylize your table with a colorful look.

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1004,6 +1004,21 @@ def opt_table_outline(
     # Validate the `style` argument
     style = _utils._match_arg(x=style, lst=["solid", "dashed", "dotted", "none"])
 
+    # Create a dictionary of parameters to pass to the `tab_options()` method
+    params = {
+        "table_border_top_style": style,
+        "table_border_bottom_style": style,
+        "table_border_left_style": style,
+        "table_border_right_style": style,
+        "table_border_top_width": width,
+        "table_border_bottom_width": width,
+        "table_border_left_width": width,
+        "table_border_right_width": width,
+        "table_border_top_color": color,
+        "table_border_bottom_color": color,
+        "table_border_left_color": color,
+        "table_border_right_color": color,
+    }
 def opt_stylize(self: GTSelf, style: int = 1, color: str = "blue") -> GTSelf:
     """
     Stylize your table with a colorful look.

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -36,6 +36,7 @@ from great_tables._options import (
     opt_row_striping,
     opt_vertical_padding,
     opt_horizontal_padding,
+    opt_table_outline,
     opt_stylize,
 )
 from great_tables._source_notes import tab_source_note
@@ -231,6 +232,7 @@ class GT(
     opt_row_striping = opt_row_striping
     opt_vertical_padding = opt_vertical_padding
     opt_horizontal_padding = opt_horizontal_padding
+    opt_table_outline = opt_table_outline
     opt_stylize = opt_stylize
 
     tab_header = tab_header

--- a/tests/__snapshots__/test_options.ambr
+++ b/tests/__snapshots__/test_options.ambr
@@ -341,3 +341,345 @@
   
   '''
 # ---
+# name: test_scss_from_opt_table_outline
+  '''
+  #abc table {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+          }
+  
+  #abc thead,
+  tbody,
+  tfoot,
+  tr,
+  td,
+  th {
+    border-style: none;
+  }
+  
+  #abc p {
+    margin: 0;
+    padding: 0;
+  }
+  
+  #abc .gt_table {
+    display: table;
+    border-collapse: collapse;
+    line-height: normal;
+    margin-left: auto;
+    margin-right: auto;
+    color: #333333;
+    font-size: 16px;
+    font-weight: normal;
+    font-style: normal;
+    background-color: #FFFFFF;
+    width: auto;
+    border-top-style: dotted;
+    border-top-width: 10px;
+    border-top-color: blue;
+    border-right-style: dotted;
+    border-right-width: 10px;
+    border-right-color: blue;
+    border-bottom-style: dotted;
+    border-bottom-width: 10px;
+    border-bottom-color: blue;
+    border-left-style: dotted;
+    border-left-width: 10px;
+    border-left-color: blue;
+  }
+  
+  #abc .gt_caption {
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+  
+  #abc .gt_title {
+    color: #333333;
+    font-size: 125%;
+    font-weight: initial;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-bottom-color: #FFFFFF;
+    border-bottom-width: 0;
+  }
+  
+  #abc .gt_subtitle {
+    color: #333333;
+    font-size: 85%;
+    font-weight: initial;
+    padding-top: 3px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-top-color: #FFFFFF;
+    border-top-width: 0;
+  }
+  
+  #abc .gt_heading {
+    background-color: #FFFFFF;
+    text-align: center;
+    border-bottom-color: #FFFFFF;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_bottom_border {
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+  }
+  
+  #abc .gt_col_headings {
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_col_heading {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: normal;
+    text-transform: inherit;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+    vertical-align: bottom;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
+    overflow-x: hidden;
+  }
+  
+  #abc .gt_column_spanner_outer {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: normal;
+    text-transform: inherit;
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: 4px;
+    padding-right: 4px;
+  }
+  
+  #abc .gt_column_spanner_outer:first-child {
+    padding-left: 0;
+  }
+  
+  #abc .gt_column_spanner_outer:last-child {
+    padding-right: 0;
+  }
+  
+  #abc .gt_column_spanner {
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    vertical-align: bottom;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    overflow-x: hidden;
+    display: inline-block;
+    width: 100%;
+  }
+  
+  #abc .gt_spanner_row {
+    border-bottom-style: hidden;
+  }
+  
+  #abc .gt_group_heading {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+    vertical-align: middle;
+    text-align: left;
+  }
+  
+  #abc .gt_empty_group_heading {
+    padding: 0.5px;
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    vertical-align: middle;
+  }
+  
+  #abc .gt_from_md> :first-child {
+    margin-top: 0;
+  }
+  
+  #abc .gt_from_md> :last-child {
+    margin-bottom: 0;
+  }
+  
+  #abc .gt_row {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    margin: 10px;
+    border-top-style: solid;
+    border-top-width: 1px;
+    border-top-color: #D3D3D3;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+    vertical-align: middle;
+    overflow-x: hidden;
+  }
+  
+  #abc .gt_stub {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-right-style: solid;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+  
+  #abc .gt_stub_row_group {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-right-style: solid;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    padding-left: 5px;
+    padding-right: 5px;
+    vertical-align: top;
+  }
+  
+  #abc .gt_row_group_first td {
+    border-top-width: 2px;
+  }
+  
+  #abc .gt_row_group_first th {
+    border-top-width: 2px;
+  }
+  
+  #abc .gt_table_body {
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+  }
+  
+  #abc .gt_sourcenotes {
+    color: #333333;
+    background-color: #FFFFFF;
+    border-bottom-style: none;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_sourcenote {
+    font-size: 90%;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+  
+  #abc .gt_left {
+    text-align: left;
+  }
+  
+  #abc .gt_center {
+    text-align: center;
+  }
+  
+  #abc .gt_right {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  
+  #abc .gt_font_normal {
+    font-weight: normal;
+  }
+  
+  #abc .gt_font_bold {
+    font-weight: bold;
+  }
+  
+  #abc .gt_font_italic {
+    font-style: italic;
+  }
+  
+  #abc .gt_super {
+    font-size: 65%;
+  }
+  
+  #abc .gt_footnote_marks {
+    font-size: 75%;
+    vertical-align: 0.4em;
+    position: initial;
+  }
+  
+  #abc .gt_asterisk {
+    font-size: 100%;
+    vertical-align: 0;
+  }
+  
+  '''
+# ---

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -299,3 +299,28 @@ def test_options_all_available(gt_tbl: GT):
 
 def test_scss_default_generated(gt_tbl: GT, snapshot):
     assert snapshot == compile_scss(gt_tbl, id="abc", compress=False)
+
+
+def test_scss_from_opt_table_outline(gt_tbl: GT, snapshot):
+
+    gt_tbl_outline = (
+        GT(
+            exibble[["num", "char", "currency", "row", "group"]],
+            rowname_col="row",
+            groupname_col="group",
+        )
+        .tab_header(
+            title=md("Data listing from **exibble**"),
+            subtitle=md("`exibble` is a **Great Tables** dataset."),
+        )
+        .opt_table_outline(width="10px", style="dotted", color="blue")
+    )
+
+    assert gt_tbl._options.source_notes_border_bottom_color.value == css_color_val
+
+    for part in ["top", "right", "bottom", "left"]:
+        assert getattr(gt_tbl_outline._options, f"table_border_{part}_style").value == "dotted"
+        assert getattr(gt_tbl_outline._options, f"table_border_{part}_width").value == "10px"
+        assert getattr(gt_tbl_outline._options, f"table_border_{part}_color").value == "blue"
+
+    assert snapshot == compile_scss(gt_tbl_outline, id="abc", compress=False)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -302,7 +302,6 @@ def test_scss_default_generated(gt_tbl: GT, snapshot):
 
 
 def test_scss_from_opt_table_outline(gt_tbl: GT, snapshot):
-
     gt_tbl_outline = (
         GT(
             exibble[["num", "char", "currency", "row", "group"]],


### PR DESCRIPTION
This PR adds another `opt_*()` method, this time the `opt_table_outline()` method. It lets you easily draw a line around the entire table, setting several options inside `tab_options()` all at once.