### PR TITLE
Handle `.data_color()` edge cases with single val columns / all missing values

### DIFF
--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -212,6 +212,8 @@ def data_color(
     else:
         columns_resolved = columns
 
+    gt_obj = self
+
     # For each column targeted, get the data values as a new list object
     for col in columns_resolved:
         column_vals = data_table[col].to_list()
@@ -219,7 +221,7 @@ def data_color(
         # If there only a single value in `column_vals`, and it is not missing,
         # then use the first value from the palette
         if len(column_vals) == 1 and not is_na(data_table, column_vals[0]):
-            self = self.tab_style(
+            gt_obj = gt_obj.tab_style(
                 style=fill(color=palette[0]), locations=body(columns=col, rows=[0])
             )
 
@@ -237,7 +239,7 @@ def data_color(
             )
 
             # Apply the first color from the palette to the non-missing value
-            self = self.tab_style(
+            gt_obj = gt_obj.tab_style(
                 style=fill(color=palette[0]), locations=body(columns=col, rows=[non_missing_index])
             )
 
@@ -245,7 +247,7 @@ def data_color(
             missing_indices = [i for i, x in enumerate(column_vals) if is_na(data_table, x)]
 
             # Apply the `na_color=` color to all missing values
-            self = self.tab_style(
+            gt_obj = gt_obj.tab_style(
                 style=fill(color=na_color), locations=body(columns=col, rows=missing_indices)
             )
 
@@ -254,7 +256,7 @@ def data_color(
         # If the entire column contains NA values, then apply the `na_color=` color to the
         # entire column and then move on to the next column
         if all(is_na(data_table, x) for x in column_vals):
-            self = self.tab_style(style=fill(color=na_color), locations=body(columns=col))
+            gt_obj = gt_obj.tab_style(style=fill(color=na_color), locations=body(columns=col))
             continue
 
         # Filter out NA values from `column_vals`
@@ -264,7 +266,9 @@ def data_color(
         # `column_vals`, then apply the `na_color=` color to the entire column and
         # then move on to the next column
         if all(is_na(data_table, x) for x in filtered_column_vals):
-            self = self.tab_style(style=fill(color=na_color), locations=body(columns=col, rows=[0]))
+            gt_obj = gt_obj.tab_style(
+                style=fill(color=na_color), locations=body(columns=col, rows=[0])
+            )
             continue
 
         # The methodology for domain calculation and rescaling depends on column values being:
@@ -311,17 +315,16 @@ def data_color(
             if autocolor_text:
                 fgnd_color = _ideal_fgnd_color(bgnd_color=color_vals[i])
 
-                self = self.tab_style(
+                gt_obj = gt_obj.tab_style(
                     style=[text(color=fgnd_color), fill(color=color_vals[i])],
                     locations=body(columns=col, rows=[i]),
                 )
 
             else:
-                self = self.tab_style(
+                gt_obj = gt_obj.tab_style(
                     style=fill(color=color_vals[i]), locations=body(columns=col, rows=[i])
                 )
-
-    return self
+    return gt_obj
 
 
 def _ideal_fgnd_color(bgnd_color: str, light: str = "#FFFFFF", dark: str = "#000000") -> str:

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -218,15 +218,6 @@ def data_color(
     for col in columns_resolved:
         column_vals = data_table[col].to_list()
 
-        # If there only a single value in `column_vals`, and it is not missing,
-        # then use the first value from the palette
-        if len(column_vals) == 1 and not is_na(data_table, column_vals[0]):
-            gt_obj = gt_obj.tab_style(
-                style=fill(color=palette[0]), locations=body(columns=col, rows=[0])
-            )
-
-            continue
-
         # Obtain a count of non-missing values in `column_vals`
         non_missing_count = sum(1 for x in column_vals if not is_na(data_table, x))
 
@@ -261,15 +252,6 @@ def data_color(
 
         # Filter out NA values from `column_vals`
         filtered_column_vals = [x for x in column_vals if not is_na(data_table, x)]
-
-        # If there are only NA values in `column_vals`, regardless of the length of
-        # `column_vals`, then apply the `na_color=` color to the entire column and
-        # then move on to the next column
-        if all(is_na(data_table, x) for x in filtered_column_vals):
-            gt_obj = gt_obj.tab_style(
-                style=fill(color=na_color), locations=body(columns=col, rows=[0])
-            )
-            continue
 
         # The methodology for domain calculation and rescaling depends on column values being:
         # (1) numeric (integers or floats), then the method should be 'numeric'

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -216,8 +216,57 @@ def data_color(
     for col in columns_resolved:
         column_vals = data_table[col].to_list()
 
+        # If there only a single value in `column_vals`, and it is not missing,
+        # then use the first value from the palette
+        if len(column_vals) == 1 and not is_na(data_table, column_vals[0]):
+            self = self.tab_style(
+                style=fill(color=palette[0]), locations=body(columns=col, rows=[0])
+            )
+
+            continue
+
+        # Obtain a count of non-missing values in `column_vals`
+        non_missing_count = sum(1 for x in column_vals if not is_na(data_table, x))
+
+        # If `non_missing_count` is 1, then identify the index of the non-missing value
+        # and use the first color from the palette
+        if non_missing_count == 1:
+
+            # Find the index of the non-missing value in `column_vals`
+            non_missing_index = column_vals.index(
+                next(x for x in column_vals if not is_na(data_table, x))
+            )
+
+            # Apply the first color from the palette to the non-missing value
+            self = self.tab_style(
+                style=fill(color=palette[0]), locations=body(columns=col, rows=[non_missing_index])
+            )
+
+            # Find the indices of all missing values in `column_vals`
+            missing_indices = [i for i, x in enumerate(column_vals) if is_na(data_table, x)]
+
+            # Apply the `na_color=` color to all missing values
+            self = self.tab_style(
+                style=fill(color=na_color), locations=body(columns=col, rows=missing_indices)
+            )
+
+            continue
+
+        # If the entire column contains NA values, then apply the `na_color=` color to the
+        # entire column and then move on to the next column
+        if all(is_na(data_table, x) for x in column_vals):
+            self = self.tab_style(style=fill(color=na_color), locations=body(columns=col))
+            continue
+
         # Filter out NA values from `column_vals`
         filtered_column_vals = [x for x in column_vals if not is_na(data_table, x)]
+
+        # If there are only NA values in `column_vals`, regardless of the length of
+        # `column_vals`, then apply the `na_color=` color to the entire column and
+        # then move on to the next column
+        if all(is_na(data_table, x) for x in filtered_column_vals):
+            self = self.tab_style(style=fill(color=na_color), locations=body(columns=col, rows=[0]))
+            continue
 
         # The methodology for domain calculation and rescaling depends on column values being:
         # (1) numeric (integers or floats), then the method should be 'numeric'

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -648,8 +648,12 @@ def _rescale_numeric(
     # Get the range of values in `domain`
     domain_range = domain_max - domain_min
 
-    # Rescale the values in `vals` to the range [0, 1], pass through NA values
-    scaled_vals = [(x - domain_min) / domain_range if not is_na(df, x) else x for x in vals]
+    if domain_range == 0:
+        # In the case where the domain range is 0, all scaled values in `vals` will be `0`
+        scaled_vals = [0.0 if not is_na(df, x) else x for x in vals]
+    else:
+        # Rescale the values in `vals` to the range [0, 1], pass through NA values
+        scaled_vals = [(x - domain_min) / domain_range if not is_na(df, x) else x for x in vals]
 
     # Add NA values to any values in `scaled_vals` that are not in the [0, 1] range
     scaled_vals = [x if not is_na(df, x) and (x >= 0 and x <= 1) else np.nan for x in scaled_vals]

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -218,38 +218,6 @@ def data_color(
     for col in columns_resolved:
         column_vals = data_table[col].to_list()
 
-        # Obtain a count of non-missing values in `column_vals`
-        non_missing_count = sum(1 for x in column_vals if not is_na(data_table, x))
-
-        # If `non_missing_count` is 1, then identify the index of the non-missing value
-        # and use the first color from the palette
-        if non_missing_count == 1:
-            # Find the index of the non-missing value in `column_vals`
-            non_missing_index = column_vals.index(
-                next(x for x in column_vals if not is_na(data_table, x))
-            )
-
-            # Apply the first color from the palette to the non-missing value
-            gt_obj = gt_obj.tab_style(
-                style=fill(color=palette[0]), locations=body(columns=col, rows=[non_missing_index])
-            )
-
-            # Find the indices of all missing values in `column_vals`
-            missing_indices = [i for i, x in enumerate(column_vals) if is_na(data_table, x)]
-
-            # Apply the `na_color=` color to all missing values
-            gt_obj = gt_obj.tab_style(
-                style=fill(color=na_color), locations=body(columns=col, rows=missing_indices)
-            )
-
-            continue
-
-        # If the entire column contains NA values, then apply the `na_color=` color to the
-        # entire column and then move on to the next column
-        if all(is_na(data_table, x) for x in column_vals):
-            gt_obj = gt_obj.tab_style(style=fill(color=na_color), locations=body(columns=col))
-            continue
-
         # Filter out NA values from `column_vals`
         filtered_column_vals = [x for x in column_vals if not is_na(data_table, x)]
 

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -231,7 +231,6 @@ def data_color(
         # If `non_missing_count` is 1, then identify the index of the non-missing value
         # and use the first color from the palette
         if non_missing_count == 1:
-
             # Find the index of the non-missing value in `column_vals`
             non_missing_index = column_vals.index(
                 next(x for x in column_vals if not is_na(data_table, x))

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -274,7 +274,9 @@ def data_color(
         # The methodology for domain calculation and rescaling depends on column values being:
         # (1) numeric (integers or floats), then the method should be 'numeric'
         # (2) strings, then the method should be 'factor'
-        if all(isinstance(x, (int, float)) for x in filtered_column_vals):
+        if len(filtered_column_vals) and all(
+            isinstance(x, (int, float)) for x in filtered_column_vals
+        ):
             # If `domain` is not provided, then infer it from the data values
             if autocalc_domain:
                 domain = _get_domain_numeric(df=data_table, vals=column_vals)

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -488,8 +488,11 @@ def _(df: PdDataFrame, x: Any) -> bool:
 @is_na.register
 def _(df: PlDataFrame, x: Any) -> bool:
     import polars as pl
+    import numpy as np
 
-    return isinstance(x, (pl.Null, type(None)))
+    from math import nan
+
+    return isinstance(x, (pl.Null, type(None))) or x is np.nan or x is nan
 
 
 @singledispatch

--- a/tests/data_color/__snapshots__/test_data_color.ambr
+++ b/tests/data_color/__snapshots__/test_data_color.ambr
@@ -27,6 +27,28 @@
   </tbody>
   '''
 # ---
+# name: test_all_values_have_zero_range_domain
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2</td>
+    <td class="gt_row gt_right">4</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #808080;" class="gt_row gt_right">None</td>
+    <td class="gt_row gt_right">5</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #808080;" class="gt_row gt_right">None</td>
+    <td class="gt_row gt_right">6</td>
+  </tr>
+  </tbody>
+  '''
+# ---
 # name: test_data_color_autocolor_text_false[pandas]
   '''
   <tbody class="gt_table_body">

--- a/tests/data_color/__snapshots__/test_data_color.ambr
+++ b/tests/data_color/__snapshots__/test_data_color.ambr
@@ -3,11 +3,11 @@
   '''
   <tbody class="gt_table_body">
   <tr>
-    <td style="background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
     <td class="gt_row gt_right">3</td>
   </tr>
   <tr>
-    <td style="background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
     <td class="gt_row gt_right">6</td>
   </tr>
   </tbody>
@@ -17,11 +17,11 @@
   '''
   <tbody class="gt_table_body">
   <tr>
-    <td style="background-color: #FF0000;" class="gt_row gt_center">None</td>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_center">None</td>
     <td class="gt_row gt_right">3</td>
   </tr>
   <tr>
-    <td style="background-color: #FF0000;" class="gt_row gt_center">None</td>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_center">None</td>
     <td class="gt_row gt_right">6</td>
   </tr>
   </tbody>
@@ -522,7 +522,7 @@
   '''
   <tbody class="gt_table_body">
   <tr>
-    <td style="background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
     <td class="gt_row gt_right">3</td>
   </tr>
   </tbody>
@@ -532,7 +532,7 @@
   '''
   <tbody class="gt_table_body">
   <tr>
-    <td style="background-color: #FF0000;" class="gt_row gt_center">None</td>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_center">None</td>
     <td class="gt_row gt_right">3</td>
   </tr>
   </tbody>
@@ -542,11 +542,11 @@
   '''
   <tbody class="gt_table_body">
   <tr>
-    <td style="background-color: #008000;" class="gt_row gt_right">1.0</td>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1.0</td>
     <td class="gt_row gt_right">3</td>
   </tr>
   <tr>
-    <td style="background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
     <td class="gt_row gt_right">4</td>
   </tr>
   </tbody>
@@ -556,11 +556,11 @@
   '''
   <tbody class="gt_table_body">
   <tr>
-    <td style="background-color: #008000;" class="gt_row gt_right">1</td>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
     <td class="gt_row gt_right">3</td>
   </tr>
   <tr>
-    <td style="background-color: #FF0000;" class="gt_row gt_right">None</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">None</td>
     <td class="gt_row gt_right">4</td>
   </tr>
   </tbody>
@@ -570,7 +570,7 @@
   '''
   <tbody class="gt_table_body">
   <tr>
-    <td style="background-color: #008000;" class="gt_row gt_right">1</td>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
     <td class="gt_row gt_right">3</td>
   </tr>
   </tbody>
@@ -580,7 +580,7 @@
   '''
   <tbody class="gt_table_body">
   <tr>
-    <td style="background-color: #008000;" class="gt_row gt_right">1</td>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
     <td class="gt_row gt_right">3</td>
   </tr>
   </tbody>

--- a/tests/data_color/__snapshots__/test_data_color.ambr
+++ b/tests/data_color/__snapshots__/test_data_color.ambr
@@ -1,4 +1,32 @@
 # serializer version: 1
+# name: test_all_missing_from_multiple_rows_pd
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td style="background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  <tr>
+    <td style="background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">6</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_all_missing_from_multiple_rows_pl
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td style="background-color: #FF0000;" class="gt_row gt_center">None</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  <tr>
+    <td style="background-color: #FF0000;" class="gt_row gt_center">None</td>
+    <td class="gt_row gt_right">6</td>
+  </tr>
+  </tbody>
+  '''
+# ---
 # name: test_data_color_autocolor_text_false[pandas]
   '''
   <tbody class="gt_table_body">
@@ -442,6 +470,74 @@
     <td style="color: #000000; background-color: #fde725;" class="gt_row gt_right">5</td>
     <td style="color: #FFFFFF; background-color: #440154;" class="gt_row gt_right">6</td>
     <td class="gt_row gt_left">five</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_single_value_and_missing_pd
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td style="background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_single_value_and_missing_pl
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td style="background-color: #FF0000;" class="gt_row gt_center">None</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_single_value_from_multiple_rows_pd
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td style="background-color: #008000;" class="gt_row gt_right">1.0</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  <tr>
+    <td style="background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">4</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_single_value_from_multiple_rows_pl
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td style="background-color: #008000;" class="gt_row gt_right">1</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  <tr>
+    <td style="background-color: #FF0000;" class="gt_row gt_right">None</td>
+    <td class="gt_row gt_right">4</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_single_value_pd
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td style="background-color: #008000;" class="gt_row gt_right">1</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_single_value_pl
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td style="background-color: #008000;" class="gt_row gt_right">1</td>
+    <td class="gt_row gt_right">3</td>
   </tr>
   </tbody>
   '''

--- a/tests/data_color/__snapshots__/test_data_color.ambr
+++ b/tests/data_color/__snapshots__/test_data_color.ambr
@@ -27,7 +27,29 @@
   </tbody>
   '''
 # ---
-# name: test_all_values_have_zero_range_domain
+# name: test_all_values_have_zero_range_domain_pd
+  '''
+  <tbody class="gt_table_body">
+  <tr>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2.0</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2.0</td>
+    <td class="gt_row gt_right">4</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #808080;" class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">5</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #808080;" class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">6</td>
+  </tr>
+  </tbody>
+  '''
+# ---
+# name: test_all_values_have_zero_range_domain_pl
   '''
   <tbody class="gt_table_body">
   <tr>

--- a/tests/data_color/__snapshots__/test_data_color.ambr
+++ b/tests/data_color/__snapshots__/test_data_color.ambr
@@ -17,11 +17,11 @@
   '''
   <tbody class="gt_table_body">
   <tr>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_center">None</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
     <td class="gt_row gt_right">3</td>
   </tr>
   <tr>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_center">None</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
     <td class="gt_row gt_right">6</td>
   </tr>
   </tbody>
@@ -532,7 +532,7 @@
   '''
   <tbody class="gt_table_body">
   <tr>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_center">None</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
     <td class="gt_row gt_right">3</td>
   </tr>
   </tbody>

--- a/tests/data_color/test_data_color.py
+++ b/tests/data_color/test_data_color.py
@@ -223,6 +223,14 @@ def test_single_value_and_missing_pd(snapshot: str):
     assert_rendered_body(snapshot, new_gt)
 
 
+# Pandas: Non-missing values have a domain range of 0; applies `na_color=` to the missing values
+def test_all_values_have_zero_range_domain(snapshot: str):
+    df = pd.DataFrame({"x": [2, 2, None, None], "y": [3, 4, 5, 6]})
+    new_gt = GT(df).data_color("x", palette=["green", "blue"], domain=[0, 0])
+
+    assert_rendered_body(snapshot, new_gt)
+
+
 # Polars: Single value -- single color; uses first color from palette
 def test_single_value_pl(snapshot: str):
     df = pl.DataFrame({"x": [1], "y": [3]})
@@ -252,5 +260,13 @@ def test_all_missing_from_multiple_rows_pl(snapshot: str):
 def test_single_value_and_missing_pl(snapshot: str):
     df = pl.DataFrame({"x": [None], "y": [3]})
     new_gt = GT(df).data_color("x", palette=["green", "blue"], na_color="red")
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+# Polars: Non-missing values have a domain range of 0; applies `na_color=` to the missing values
+def test_all_values_have_zero_range_domain(snapshot: str):
+    df = pl.DataFrame({"x": [2, 2, None, None], "y": [3, 4, 5, 6]})
+    new_gt = GT(df).data_color("x", palette=["green", "blue"], domain=[0, 0])
 
     assert_rendered_body(snapshot, new_gt)

--- a/tests/data_color/test_data_color.py
+++ b/tests/data_color/test_data_color.py
@@ -73,7 +73,6 @@ def test_data_color_missing_value(df_cls, none_val):
 
 
 def test_data_color_palette_snap(snapshot, df: DataFrameLike):
-
     gt = GT(df).data_color(columns=["num", "currency"], palette=["red", "green"])
 
     assert_rendered_body(snapshot, gt)

--- a/tests/data_color/test_data_color.py
+++ b/tests/data_color/test_data_color.py
@@ -22,7 +22,7 @@ def assert_rendered_body(snapshot, gt):
     assert snapshot == body
 
 
-def test_data_color_simple_df_snap(snapshot):
+def test_data_color_simple_df_snap(snapshot: str):
     df = pd.DataFrame(
         {
             "A": [1, 2, 3],
@@ -36,19 +36,19 @@ def test_data_color_simple_df_snap(snapshot):
     assert_rendered_body(snapshot, new_gt)
 
 
-def test_data_color_simple_exibble_snap(snapshot, df: DataFrameLike):
+def test_data_color_simple_exibble_snap(snapshot: str, df: DataFrameLike):
     gt = GT(df).data_color()
 
     assert_rendered_body(snapshot, gt)
 
 
-def test_data_color_palette_snap(snapshot, df: DataFrameLike):
+def test_data_color_palette_snap(snapshot: str, df: DataFrameLike):
     gt = GT(df).data_color(columns=["num", "currency"], palette=["red", "green"])
 
     assert_rendered_body(snapshot, gt)
 
 
-def test_data_color_domain_na_color_snap(snapshot, df: DataFrameLike):
+def test_data_color_domain_na_color_snap(snapshot: str, df: DataFrameLike):
     """`data_color` works with `domain` and `na_color`."""
     gt = GT(df).data_color(
         columns="currency", palette=["red", "green"], domain=[0, 50], na_color="blue"
@@ -57,7 +57,7 @@ def test_data_color_domain_na_color_snap(snapshot, df: DataFrameLike):
     assert_rendered_body(snapshot, gt)
 
 
-def test_data_color_domain_na_color_reverse_snap(snapshot, df: DataFrameLike):
+def test_data_color_domain_na_color_reverse_snap(snapshot: str, df: DataFrameLike):
     """`data_color` works with `domain`, `na_color`, and `reverse`."""
     gt = GT(df).data_color(
         columns="currency", palette=["red", "green"], domain=[0, 50], na_color="blue", reverse=True
@@ -66,7 +66,7 @@ def test_data_color_domain_na_color_reverse_snap(snapshot, df: DataFrameLike):
     assert_rendered_body(snapshot, gt)
 
 
-def test_data_color_overlapping_domain(snapshot, df: DataFrameLike):
+def test_data_color_overlapping_domain(snapshot: str, df: DataFrameLike):
     """`data_color` works with overlapping `domain` (RHS domain extends outside the data range)."""
     gt = GT(df).data_color(
         columns="currency",
@@ -78,7 +78,7 @@ def test_data_color_overlapping_domain(snapshot, df: DataFrameLike):
     assert_rendered_body(snapshot, gt)
 
 
-def test_data_color_subset_domain(snapshot, df: DataFrameLike):
+def test_data_color_subset_domain(snapshot: str, df: DataFrameLike):
     """`data_color` works with subset `domain`."""
     gt = GT(df).data_color(
         columns="currency",
@@ -90,7 +90,7 @@ def test_data_color_subset_domain(snapshot, df: DataFrameLike):
     assert_rendered_body(snapshot, gt)
 
 
-def test_data_color_autocolor_text_false(snapshot, df: DataFrameLike):
+def test_data_color_autocolor_text_false(snapshot: str, df: DataFrameLike):
     """`data_color` works with `autocolor_text=False`."""
     gt = GT(df).data_color(
         columns="currency",
@@ -162,7 +162,7 @@ def test_data_color_viridis_palettes(df: DataFrameLike):
         assert isinstance(gt, GT)
 
 
-def test_data_color_colorbrewer_snap(snapshot):
+def test_data_color_colorbrewer_snap(snapshot: str):
     df = pd.DataFrame(
         {
             "A": [1, 2, 3, 4, 5],
@@ -176,7 +176,7 @@ def test_data_color_colorbrewer_snap(snapshot):
     assert_rendered_body(snapshot, new_gt)
 
 
-def test_data_color_viridis_snap(snapshot):
+def test_data_color_viridis_snap(snapshot: str):
     df = pd.DataFrame(
         {
             "A": [1, 2, 3, 4, 5],
@@ -186,5 +186,71 @@ def test_data_color_viridis_snap(snapshot):
     )
 
     new_gt = GT(df).data_color(columns=["A", "B"], palette="viridis")
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+# Pandas: Single value -- single color; uses first color from palette
+def test_single_value_pd(snapshot: str):
+    df = pd.DataFrame({"x": [1], "y": [3]})
+    new_gt = GT(df).data_color("x", palette=["green", "blue"], na_color="red")
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+# Pandas: Single value -- multiple rows (rest of the rows are missing); uses first color
+# from palette and applies `na_color=` to the missing rows
+def test_single_value_from_multiple_rows_pd(snapshot: str):
+    df = pd.DataFrame({"x": [1, None], "y": [3, 4]})
+    new_gt = GT(df).data_color("x", palette=["green", "blue"], na_color="red")
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+# Pandas: Multiple rows in a column but all are missing; applies `na_color=` to all rows
+def test_all_missing_from_multiple_rows_pd(snapshot: str):
+    df = pd.DataFrame({"x": [None, None], "y": [3, 6]})
+    new_gt = GT(df).data_color("x", palette=["green", "blue"], na_color="red")
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+# Pandas: Single missing value from a single row; applies `na_color=` to the missing value
+def test_single_value_and_missing_pd(snapshot: str):
+    df = pd.DataFrame({"x": [None], "y": [3]})
+    new_gt = GT(df).data_color("x", palette=["green", "blue"], na_color="red")
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+# Polars: Single value -- single color; uses first color from palette
+def test_single_value_pl(snapshot: str):
+    df = pl.DataFrame({"x": [1], "y": [3]})
+    new_gt = GT(df).data_color("x", palette=["green", "blue"], na_color="red")
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+# Polars: Single value -- multiple rows (rest of the rows are missing); uses first color
+# from palette and applies `na_color=` to the missing rows
+def test_single_value_from_multiple_rows_pl(snapshot: str):
+    df = pl.DataFrame({"x": [1, None], "y": [3, 4]})
+    new_gt = GT(df).data_color("x", palette=["green", "blue"], na_color="red")
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+# Polars: Multiple rows in a column but all are missing; applies `na_color=` to all rows
+def test_all_missing_from_multiple_rows_pl(snapshot: str):
+    df = pl.DataFrame({"x": [None, None], "y": [3, 6]})
+    new_gt = GT(df).data_color("x", palette=["green", "blue"], na_color="red")
+
+    assert_rendered_body(snapshot, new_gt)
+
+
+# Polars: Single missing value from a single row; applies `na_color=` to the missing value
+def test_single_value_and_missing_pl(snapshot: str):
+    df = pl.DataFrame({"x": [None], "y": [3]})
+    new_gt = GT(df).data_color("x", palette=["green", "blue"], na_color="red")
 
     assert_rendered_body(snapshot, new_gt)

--- a/tests/data_color/test_data_color.py
+++ b/tests/data_color/test_data_color.py
@@ -224,7 +224,7 @@ def test_single_value_and_missing_pd(snapshot: str):
 
 
 # Pandas: Non-missing values have a domain range of 0; applies `na_color=` to the missing values
-def test_all_values_have_zero_range_domain(snapshot: str):
+def test_all_values_have_zero_range_domain_pd(snapshot: str):
     df = pd.DataFrame({"x": [2, 2, None, None], "y": [3, 4, 5, 6]})
     new_gt = GT(df).data_color("x", palette=["green", "blue"], domain=[0, 0])
 
@@ -265,7 +265,7 @@ def test_single_value_and_missing_pl(snapshot: str):
 
 
 # Polars: Non-missing values have a domain range of 0; applies `na_color=` to the missing values
-def test_all_values_have_zero_range_domain(snapshot: str):
+def test_all_values_have_zero_range_domain_pl(snapshot: str):
     df = pl.DataFrame({"x": [2, 2, None, None], "y": [3, 4, 5, 6]})
     new_gt = GT(df).data_color("x", palette=["green", "blue"], domain=[0, 0])
 


### PR DESCRIPTION
As discovered in https://github.com/posit-dev/great-tables/issues/212, there are a few pernicious edge cases of data frame columns being incompatible with the color-scaling methodology of `.data_color()`. We shouldn't error or disallow these types of cases from working with that method, we should handle them with some logic.

Here are the cases and how they will be dealt with.

(1) Single value in column --> use first color from palette for the single row

```python
df = pd.DataFrame({"x": [1], "y": [3]})
GT(df).data_color("x", palette=["green", "blue"], na_color="red")
```

(2) Single value , multiple rows (rest of the rows are missing) --> use first color from palette and apply `na_color=` to the missing rows

```python
df = pd.DataFrame({"x": [1, None], "y": [3, 4]})
GT(df).data_color("x", palette=["green", "blue"], na_color="red")
```

(3) Multiple rows in a column but all are missing --> apply `na_color=` to all rows

```python
df = pd.DataFrame({"x": [None, None], "y": [3, 6]})
GT(df).data_color("x", palette=["green", "blue"], na_color="red")
```

(4) Single missing value from a single row --> apply `na_color=` to the row

```python
df = pd.DataFrame({"x": [None], "y": [3]})
GT(df).data_color("x", palette=["green", "blue"], na_color="red")
```

Fixes: https://github.com/posit-dev/great-tables/issues/212