### PR TITLE
Fix `opt_horizontal_padding()` example

### DIFF
--- a/docs/get-started/table-theme-premade.qmd
+++ b/docs/get-started/table-theme-premade.qmd
@@ -60,7 +60,7 @@ This section shows the different `GT.opt_*()` methods available. They serve as c
 ### Align table header
 
 ```{python}
-gt_ex.opt_align_table_header("left")
+gt_ex.opt_align_table_header(align="left")
 ```
 
 
@@ -73,11 +73,11 @@ gt_ex.opt_all_caps()
 ### Reduce or expand padding
 
 ```{python}
-gt_ex.opt_vertical_padding(.3)
+gt_ex.opt_vertical_padding(scale=0.3)
 ```
 
 ```{python}
-gt_ex.opt_horizontal_padding(2.99)
+gt_ex.opt_horizontal_padding(scale=3)
 ```
 
 ### Set table outline


### PR DESCRIPTION
This slightly modifies the `opt_horizontal_padding()` example in the documentation. This one is a bit odd because during manual testing, `GT.opt_horizontal_padding(scale=3)` did not seem to work (which was chalked up to a bounds issue in an argument check) but the code shows it does accept a `scale` value of 3---and the API docs also has an example of this working in https://posit-dev.github.io/great-tables/reference/GT.opt_horizontal_padding.html#great_tables.GT.opt_horizontal_padding.

Fixes: https://github.com/posit-dev/great-tables/issues/214