### PR TITLE
Set up code coverage workflow with CodeCov

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -1,0 +1,40 @@
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+
+name: test-coverage
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: "3.11"
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+      - name: Install
+        run: |
+          pip install '.[dev]'
+      - name: pytest unit tests
+        run: |
+          pytest --cov .
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: posit-dev/great-tables
+


### PR DESCRIPTION
This adds the `code-coverage.yaml` file for GH Actions. The test coverage report should be uploaded to CodeCov following this change. 