### PR TITLE
Ensure that header component HTML tags pass HTML validation

### DIFF
--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -34,19 +34,23 @@ def create_heading_component_h(data: GTData) -> StringBuilder:
         stub=data._stub, row_groups=data._row_groups, options=data._options
     )
 
-    result.append(
-        f"""  <tr>
-    <th colspan="{n_cols_total}" class="gt_heading gt_title gt_font_normal">{title}
-  </tr>"""
-    )
-
     if has_subtitle:
-        subtitle_row = f"""  <tr>
-    <th colspan="{n_cols_total}" class="gt_heading gt_subtitle gt_font_normal gt_bottom_border">{subtitle}
+        heading = f"""
+  <tr>
+    <th colspan="{n_cols_total}" class="gt_heading gt_title gt_font_normal">{title}</th>
+  </tr>
+  <tr>
+    <th colspan="{n_cols_total}" class="gt_heading gt_subtitle gt_font_normal gt_bottom_border">{subtitle}</th>
   </tr>"""
-        result.append(f"\n{subtitle_row}")
+    else:
+        heading = f"""
+  <tr>
+    <th colspan="{n_cols_total}" class="gt_heading gt_title gt_font_normal">{title}</th>
+  </tr>"""
 
-    return StringBuilder('<thead class="gt_header">', result, "</thead>")
+    result.append(heading)
+
+    return StringBuilder('<thead class="gt_header">', result, "\n</thead>")
 
 
 def create_columns_component_h(data: GTData) -> str:

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -21,6 +21,10 @@ def create_heading_component_h(data: GTData) -> StringBuilder:
     if not has_title and not has_subtitle:
         return result
 
+    # Raise an error if there is a subtitle but no title
+    if not has_title and has_subtitle:
+        raise ValueError("A subtitle was provided without a title.")
+
     title = _process_text(title)
     subtitle = _process_text(subtitle)
 

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -162,8 +162,8 @@ def create_columns_component_h(data: GTData) -> str:
                 )
             )
 
-        # Join the <th> cells into a string and separate each with a newline
-        th_cells = "\n".join([str(tag) for tag in table_col_headings])
+        # Join the <th> cells into a string and begin each with a newline
+        th_cells = "\n" + "\n".join(["  " + str(tag) for tag in table_col_headings]) + "\n"
 
         table_col_headings = tags.tr(HTML(th_cells), class_="gt_col_headings")
 

--- a/tests/__snapshots__/test_export.ambr
+++ b/tests/__snapshots__/test_export.ambr
@@ -48,16 +48,20 @@
    
   </style>
   <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
-  <thead class="gt_header">  <tr>
-      <th colspan="4" class="gt_heading gt_title gt_font_normal">Data listing from <strong>exibble</strong>
+  <thead class="gt_header">
+    <tr>
+      <th colspan="4" class="gt_heading gt_title gt_font_normal">Data listing from <strong>exibble</strong></th>
     </tr>
     <tr>
-      <th colspan="4" class="gt_heading gt_subtitle gt_font_normal gt_bottom_border"><code>exibble</code> is a <strong>Great Tables</strong> dataset.
-    </tr></thead>
-  <tr class="gt_col_headings"><th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id=""></th>
-  <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="num">num</th>
-  <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="char">char</th>
-  <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="currency">currency</th></tr>
+      <th colspan="4" class="gt_heading gt_subtitle gt_font_normal gt_bottom_border"><code>exibble</code> is a <strong>Great Tables</strong> dataset.</th>
+    </tr>
+  </thead>
+  <tr class="gt_col_headings">
+    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id=""></th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="num">num</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="char">char</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="currency">currency</th>
+  </tr>
   <tbody class="gt_table_body">
   <tr>
   <tr class=gt_group_heading_row>  <th class="gt_group_heading" colspan="4">grp_a</th></tr>

--- a/tests/__snapshots__/test_formats.ambr
+++ b/tests/__snapshots__/test_formats.ambr
@@ -3,15 +3,17 @@
   '''
   class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   
-  <tr class="gt_col_headings"><th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="num">num</th>
-  <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="char">char</th>
-  <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="fctr">fctr</th>
-  <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="date">date</th>
-  <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="time">time</th>
-  <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="datetime">datetime</th>
-  <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="currency">currency</th>
-  <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="row">row</th>
-  <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="group">group</th></tr>
+  <tr class="gt_col_headings">
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="num">num</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="char">char</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="fctr">fctr</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="date">date</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="time">time</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="datetime">datetime</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="currency">currency</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="row">row</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="group">group</th>
+  </tr>
   <tbody class="gt_table_body">
   <tr>
     <td class="gt_row gt_right">1.11 × 10<sup style='font-size: 65%;'>−1</sup></td>


### PR DESCRIPTION
There were unclosed tags when generating a header. This generally causes problems when the output HTML is consumed by another process (expectation is that the input HTML should be valid; browsers can handle invalid HTML to great extent, other programs cannot really).

This PR fixes this issue and also performs a few HTML formatting cleanups at the same time. The output HTML was verified in the Nu HTML checker tool (at https://validator.w3.org/nu) to have been improved from the changes here. 

Fixes: https://github.com/posit-dev/great-tables/issues/224

And this should fix a user issue in https://github.com/quarto-dev/quarto-cli/discussions/8971.