### PR TITLE
Allow the 'transparent' color (and others) to be used in tab_options(table_background_color == <color>) (supersedes previous PR)

### DIFF
--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -414,8 +414,6 @@ def _html_color(colors: List[str], alpha: Optional[Union[int, float]] = None) ->
     all_hex_colors = all(_is_hex_col(colors=colors))
 
     if not all_hex_colors:
-        # Ensure that all color names are in the set of X11/R color names or CSS color names
-        _check_named_colors(colors=colors)
 
         # Translate named colors to hexadecimal values
         colors = _color_name_to_hex(colors=colors)
@@ -510,26 +508,14 @@ def _color_name_to_hex(colors: List[str]) -> List[str]:
         if _is_hex_col([color])[0]:
             hex_colors.append(color)
         else:
-            hex_colors.append(COLOR_NAME_TO_HEX[color.lower()])
+            try:
+                hex_colors.append(COLOR_NAME_TO_HEX[color.lower()])
+            except KeyError:
+                raise ValueError(
+                    f"Invalid color name provided ({color}). Please ensure that all colors are valid CSS3 or X11 color names."
+                )
 
     return hex_colors
-
-
-def _check_named_colors(colors: Union[str, List[str]]) -> None:
-    # Ensure that all incoming color names are set in lowercase letters since CSS color names
-    # are often shown with uppercase letters and X11/R color names are always shown with lowercase
-    if isinstance(colors, str):
-        colors = [colors]
-
-    valid_color_names = _color_name_list()
-
-    for color in colors:
-        if not _is_hex_col(colors=[color]) and color not in valid_color_names:
-            raise ValueError(
-                f"Invalid color name provided ({color}). Please ensure that all color names are valid."
-            )
-
-    return
 
 
 def _color_name_list() -> List[str]:

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -502,14 +502,17 @@ def _float_to_hex(x: float) -> str:
 def _color_name_to_hex(colors: List[str]) -> List[str]:
     # If any of the colors are in the color_name_dict, then replace them with the
     # corresponding hexadecimal value
-    i = 0
-    while i < len(colors):
-        color = colors[i]
-        if color.lower() in COLOR_NAME_TO_HEX:
-            colors[i] = COLOR_NAME_TO_HEX[color.lower()]
-        i += 1
 
-    return colors
+    hex_colors: List[str] = []
+
+    for color in colors:
+
+        if _is_hex_col([color])[0]:
+            hex_colors.append(color)
+        else:
+            hex_colors.append(COLOR_NAME_TO_HEX[color.lower()])
+
+    return hex_colors
 
 
 def _check_named_colors(colors: Union[str, List[str]]) -> None:

--- a/tests/__snapshots__/test_options.ambr
+++ b/tests/__snapshots__/test_options.ambr
@@ -31,7 +31,7 @@
     line-height: normal;
     margin-left: 10px;
     margin-right: 10px;
-    color: lightred;
+    color: #000000;
     font-size: 12px;
     font-weight: bold;
     font-style: bold;
@@ -57,7 +57,7 @@
   }
   
   #abc .gt_title {
-    color: lightred;
+    color: #000000;
     font-size: 12px;
     font-weight: bold;
     padding-top: 5px;
@@ -69,7 +69,7 @@
   }
   
   #abc .gt_subtitle {
-    color: lightred;
+    color: #000000;
     font-size: 12px;
     font-weight: bold;
     padding-top: 4px;
@@ -114,7 +114,7 @@
   }
   
   #abc .gt_col_heading {
-    color: lightred;
+    color: #000000;
     background-color: red;
     font-size: 12px;
     font-weight: bold;
@@ -134,7 +134,7 @@
   }
   
   #abc .gt_column_spanner_outer {
-    color: lightred;
+    color: #000000;
     background-color: red;
     font-size: 12px;
     font-weight: bold;
@@ -174,7 +174,7 @@
     padding-bottom: 5px;
     padding-left: 5px;
     padding-right: 5px;
-    color: lightred;
+    color: #000000;
     background-color: red;
     font-size: 12px;
     font-weight: bold;
@@ -197,7 +197,7 @@
   
   #abc .gt_empty_group_heading {
     padding: 0.5px;
-    color: lightred;
+    color: #000000;
     background-color: red;
     font-size: 12px;
     font-weight: bold;
@@ -238,7 +238,7 @@
   }
   
   #abc .gt_stub {
-    color: lightred;
+    color: #000000;
     background-color: red;
     font-size: 12px;
     font-weight: bold;
@@ -251,7 +251,7 @@
   }
   
   #abc .gt_stub_row_group {
-    color: lightred;
+    color: #000000;
     background-color: red;
     font-size: 12px;
     font-weight: bold;
@@ -282,7 +282,7 @@
   }
   
   #abc .gt_sourcenotes {
-    color: lightred;
+    color: #000000;
     background-color: red;
     border-bottom-style: solid;
     border-bottom-width: 5px;

--- a/tests/data_color/test_data_color_utils.py
+++ b/tests/data_color/test_data_color_utils.py
@@ -319,10 +319,10 @@ def test_color_name_to_hex():
 
     # Test case 6: Colors with invalid names
     colors = ["#FF0000", "green", "invalid"]
-    with pytest.raises(KeyError) as e:
+    with pytest.raises(ValueError) as e:
         _color_name_to_hex(colors)
 
-    assert e.value.args[0] == "invalid"
+    assert "Invalid color name provided (invalid)" in e.value.args[0]
 
 
 def test_is_short_hex_valid_short_hex():

--- a/tests/data_color/test_data_color_utils.py
+++ b/tests/data_color/test_data_color_utils.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+import pytest
 from great_tables._data_color.base import (
     _ideal_fgnd_color,
     _get_wcag_contrast_ratio,
@@ -318,10 +319,10 @@ def test_color_name_to_hex():
 
     # Test case 6: Colors with invalid names
     colors = ["#FF0000", "green", "invalid"]
-    try:
+    with pytest.raises(KeyError) as e:
         _color_name_to_hex(colors)
-    except ValueError as e:
-        assert str(e) == "Invalid color name provided (invalid)."
+
+    assert e.value.args[0] == "invalid"
 
 
 def test_is_short_hex_valid_short_hex():

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -30,8 +30,9 @@ css_length_val_large = "100px"
 css_length_val_margin = "10px"
 css_length_val_small = "5px"
 css_font_size_val = "12px"
+css_font_color_val = "#000000"
+css_font_color_val_light = "#FFFFFF"
 css_color_val = "red"
-css_color_val_light = "lightred"
 css_style_val = "solid"
 css_font_family_list = ["Arial", "Helvetica", "sans-serif"]
 css_font_weight_val = "bold"
@@ -62,13 +63,13 @@ def gt_tbl():
             table_layout="auto",
             table_margin_left=css_length_val_margin,
             table_margin_right=css_length_val_margin,
-            table_background_color=css_color_val,
+            table_background_color="red",
             table_font_names=css_font_family_list,
             table_font_size=css_font_size_val,
             table_font_weight=css_font_weight_val,
             table_font_style=css_font_weight_val,
-            table_font_color=css_color_val,
-            table_font_color_light=css_color_val_light,
+            table_font_color=css_font_color_val,
+            table_font_color_light=css_font_color_val_light,
             table_border_top_style=css_style_val,
             table_border_top_width=css_length_val_small,
             table_border_top_color=css_color_val,
@@ -191,8 +192,8 @@ def test_options_all_available(gt_tbl: GT):
     assert gt_tbl._options.table_font_size.value == css_font_size_val
     assert gt_tbl._options.table_font_weight.value == css_font_weight_val
     assert gt_tbl._options.table_font_style.value == css_font_weight_val
-    assert gt_tbl._options.table_font_color.value == css_color_val
-    assert gt_tbl._options.table_font_color_light.value == css_color_val_light
+    assert gt_tbl._options.table_font_color.value == css_font_color_val
+    assert gt_tbl._options.table_font_color_light.value == css_font_color_val_light
     assert gt_tbl._options.table_border_top_style.value == css_style_val
     assert gt_tbl._options.table_border_top_width.value == css_length_val_small
     assert gt_tbl._options.table_border_top_color.value == css_color_val

--- a/tests/test_scss.py
+++ b/tests/test_scss.py
@@ -8,13 +8,18 @@ from great_tables._scss import font_color, css_add, compile_scss
 @pytest.mark.parametrize(
     "src,dst",
     [
-        ("#FFFFFF", "dark"),
-        ("#000000", "light"),
-        ("white", "dark"),
+        ("#FFFFFF", "#000000"),
+        ("#000000", "#FFFFFF"),
+        ("white", "#000000"),
+        ("black", "#FFFFFF"),
+        ("silver", "#000000"),
+        ("transparent", "#000000"),
+        ("currentcolor", "currentcolor"),
+        ("currentColor", "currentcolor"),
     ],
 )
 def test_font_color(src, dst):
-    res = font_color(src, "dark", "light")
+    res = font_color(src, "#000000", "#FFFFFF")
     assert res == dst
 
 


### PR DESCRIPTION
This PR makes it possible for a GT table to have a transparent background by way of using the `"transparent"` color keyword. Previously, there would be an error because color values in `_font_color()` are routed through a **webcolors** function that only accepts CSS color names.

This PR is a more focused version of an earlier version: https://github.com/posit-dev/great-tables/pull/232

Fixes: https://github.com/posit-dev/great-tables/issues/230