### PR TITLE
feat: basic sub_missing and sub_zero

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -113,6 +113,8 @@ quartodoc:
         - GT.fmt_nanoplot
         - GT.fmt
         - GT.data_color
+        - GT.sub_missing
+        - GT.sub_zero
     - title: Modifying columns
       desc: >
         The `cols_*()` methods allow for modifications that act on entire columns. This includes

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -64,6 +64,7 @@ def fmt(
     fns: Union[FormatFn, FormatFns],
     columns: SelectExpr = None,
     rows: Union[int, List[int], None] = None,
+    is_substitution=False,
 ) -> GTSelf:
     """
     Set a column format with a formatter function.
@@ -86,6 +87,8 @@ def fmt(
         In conjunction with `columns`, we can specify which of their rows should undergo
         formatting. The default is all rows, resulting in all rows in `columns` being formatted.
         Alternatively, we can supply a list of row indices.
+    is_substitution
+        Whether the formatter is a substitution. Substitutions are run last, after other formatters.
 
     Returns
     -------
@@ -105,6 +108,10 @@ def fmt(
     col_res = resolve_cols_c(self, columns)
 
     formatter = FormatInfo(fns, col_res, row_pos)
+
+    if is_substitution:
+        return self._replace(_substitutions=[*self._substitutions, formatter])
+
     return self._replace(_formats=[*self._formats, formatter])
 
 

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field, replace
 from ._utils import _str_detect
 from ._tbl_data import create_empty_frame, to_list, validate_frame
 
+# TODO: move this class somewhere else (even gt_data could work)
+
 from ._styles import CellStyle
 
 # Note that we replace with with collections.abc after python 3.8
@@ -155,6 +157,9 @@ class Body:
                 raise Exception("Internal Error")
             for col, row in fmt.cells.resolve():
                 result = eval_func(_get_cell(data_tbl, row, col))
+                if isinstance(result, FormatterSkipElement):
+                    continue
+
                 # TODO: I think that this is very inefficient with polars, so
                 # we could either accumulate results and set them per column, or
                 # could always use a pandas DataFrame inside Body?
@@ -842,7 +847,12 @@ from typing import Any, Callable, TypeVar, Union, List, Optional, Tuple
 
 from ._tbl_data import n_rows
 
-FormatFn = Callable[[Any], str]
+
+class FormatterSkipElement:
+    """Represent that nothing should be saved for a formatted value."""
+
+
+FormatFn = Callable[[Any], "str | FormatterSkipElement"]
 
 
 class FormatFns:

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -7,7 +7,7 @@ from typing import overload, TypeVar, Dict, Optional
 from typing_extensions import Self, TypeAlias
 from dataclasses import dataclass, field, replace
 from ._utils import _str_detect
-from ._tbl_data import create_empty_frame, to_list, validate_frame
+from ._tbl_data import create_empty_frame, to_list, validate_frame, copy_data
 
 # TODO: move this class somewhere else (even gt_data could work)
 
@@ -41,6 +41,7 @@ class GTData:
     _styles: Styles
     _locale: Locale | None
     _formats: Formats
+    _substitutions: Formats
     _options: Options
     _has_built: bool = False
 
@@ -94,6 +95,7 @@ class GTData:
             _styles=[],
             _locale=Locale(locale),
             _formats=[],
+            _substitutions=[],
             _options=options,
         )
 
@@ -145,7 +147,6 @@ from ._tbl_data import DataFrameLike, TblData, _get_cell, _set_cell
 # _tbl_data.py
 class Body:
     body: TblData
-    data: Any
 
     def __init__(self, body: Union[pd.DataFrame, TblData]):
         self.body = body
@@ -166,6 +167,9 @@ class Body:
                 _set_cell(self.body, row, col, result)
 
         return self
+
+    def copy(self):
+        return self.__class__(copy_data(self.body))
 
     @classmethod
     def from_empty(cls, body: DataFrameLike):

--- a/great_tables/_substitution.py
+++ b/great_tables/_substitution.py
@@ -120,10 +120,14 @@ def sub_zero(
         [`md()`](`great_tables.md`) or [`html()`](`great_tables.html`) functions to style the text
         as Markdown or to retain HTML elements in the text.
 
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
 
     Examples
     --------
-
     Let's generate a simple table that contains an assortment of values that could potentially
     undergo some substitution via the `sub_zero()` method (i.e., there are two `0` values). The
     ordering of the [`fmt_scientific()`](`great_tables.GT.fmt_scientific`) and `sub_zero()` calls

--- a/great_tables/_substitution.py
+++ b/great_tables/_substitution.py
@@ -34,7 +34,7 @@ def sub_missing(
     missing_text: str = "---",
 ) -> GTSelf:
     subber = SubMissing(self._tbl_data, missing_text)
-    return fmt(self, fns=subber.to_html, columns=columns, rows=rows)
+    return fmt(self, fns=subber.to_html, columns=columns, rows=rows, is_substitution=True)
 
 
 def sub_zero(
@@ -44,7 +44,7 @@ def sub_zero(
     zero_text: str = "nil",
 ) -> GTSelf:
     subber = SubZero(zero_text)
-    return fmt(self, fns=subber.to_html, columns=columns, rows=rows)
+    return fmt(self, fns=subber.to_html, columns=columns, rows=rows, is_substitution=True)
 
 
 @dataclass

--- a/great_tables/_substitution.py
+++ b/great_tables/_substitution.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from ._tbl_data import DataFrameLike, SelectExpr, is_na
+from ._gt_data import FormatterSkipElement, FormatInfo
+from ._formats import fmt
+
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Type, Union, Literal, List
+
+if TYPE_CHECKING:
+    from ._types import GTSelf
+
+
+def _convert_missing(context: Literal["html"], el: str):
+    """Convert el to a context specific representation."""
+
+    # TODO: how is context passed? Could use a literal string (e.g. "html") for now?
+    # TODO: detect if el has some kind of AsIs feature specified
+    # which indicates it should not be converted
+
+    # If a table row has all empty cells, they collapse. So add a single line break.
+    # See https://stackoverflow.com/q/2789372/1144523
+    if context == "html" and el == "":
+        return "<br />"
+
+    return el
+
+
+def sub_missing(
+    self: GTSelf,
+    columns: SelectExpr = None,
+    rows: Union[int, List[int], None] = None,
+    missing_text: str = "---",
+) -> GTSelf:
+    subber = SubMissing(self._tbl_data, missing_text)
+    return fmt(self, fns=subber.to_html, columns=columns, rows=rows)
+
+
+def sub_zero(
+    self: GTSelf,
+    columns: SelectExpr = None,
+    rows: Union[int, List[int], None] = None,
+    zero_text: str = "nil",
+) -> GTSelf:
+    subber = SubZero(zero_text)
+    return fmt(self, fns=subber.to_html, columns=columns, rows=rows)
+
+
+@dataclass
+class SubMissing:
+    dispatch_frame: DataFrameLike
+    missing_text: str
+
+    def to_html(self, x: Any) -> str | FormatterSkipElement:
+        return self.missing_text if is_na(self.dispatch_frame, x) else FormatterSkipElement()
+
+
+@dataclass
+class SubZero:
+    zero_text: str
+
+    def to_html(self, x: Any) -> str | FormatterSkipElement:
+        return self.zero_text if x == 0 else FormatterSkipElement()

--- a/great_tables/_substitution.py
+++ b/great_tables/_substitution.py
@@ -33,6 +33,63 @@ def sub_missing(
     rows: Union[int, List[int], None] = None,
     missing_text: str = "---",
 ) -> GTSelf:
+    """
+    Substitute missing values in the table body.
+
+    Wherever there is missing data (i.e., `None` values) customizable content may present better
+    than the standard representation of missing values that would otherwise appear. The
+    `sub_missing()` method allows for this replacement through its `missing_text=` argument.
+    And by not supplying anything to `missing_text=`, an em dash will serve as a default indicator
+    of missingness.
+
+    Parameters
+    ----------
+    columns
+        The columns to target. Can either be a single column name or a series of column names
+        provided in a list.
+    rows
+        In conjunction with `columns=`, we can specify which of their rows should be scanned for
+        missing values. The default is all rows, resulting in all rows in all targeted columns being
+        considered for this substitution. Alternatively, we can supply a list of row indices.
+    missing_text
+        The text to be used in place of missing values in the rendered table. We can optionally use
+        the `md()` and `html()` helper functions to style the text as Markdown or to retain HTML
+        elements in the text.
+
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+
+    Examples
+    --------
+    Using a subset of the `exibble` dataset, let's create a new table. The missing values in two
+    selections of columns will be given different variations of replacement text (across two
+    separate calls of `sub_missing()`).
+
+    ```{python}
+    from great_tables import GT, md, html, exibble
+    import polars as pl
+    import polars.selectors as cs
+
+    exibble_mini = pl.from_pandas(exibble).drop("row", "group", "fctr").slice(4, 8)
+
+    (
+        GT(exibble_mini)
+        .sub_missing(
+            columns = ["num", "char"],
+            missing_text = "missing"
+        )
+        .sub_missing(
+            columns = cs.contains(("date", "time")) | cs.by_name("currency"),
+            missing_text = "nothing"
+        )
+    )
+    ```
+
+    """
+
     subber = SubMissing(self._tbl_data, missing_text)
     return fmt(self, fns=subber.to_html, columns=columns, rows=rows, is_substitution=True)
 

--- a/great_tables/_substitution.py
+++ b/great_tables/_substitution.py
@@ -53,8 +53,8 @@ def sub_missing(
         considered for this substitution. Alternatively, we can supply a list of row indices.
     missing_text
         The text to be used in place of missing values in the rendered table. We can optionally use
-        the `md()` and `html()` helper functions to style the text as Markdown or to retain HTML
-        elements in the text.
+        the [`md()`](`great_tables.md`) or [`html()`](`great_tables.html`) helper functions to style
+        the text as Markdown or to retain HTML elements in the text.
 
     Returns
     -------
@@ -78,16 +78,15 @@ def sub_missing(
     (
         GT(exibble_mini)
         .sub_missing(
-            columns = ["num", "char"],
-            missing_text = "missing"
+            columns=["num", "char"],
+            missing_text="missing"
         )
         .sub_missing(
-            columns = cs.contains(("date", "time")) | cs.by_name("currency"),
-            missing_text = "nothing"
+            columns=cs.contains(("date", "time")) | cs.by_name("currency"),
+            missing_text="nothing"
         )
     )
     ```
-
     """
 
     subber = SubMissing(self._tbl_data, missing_text)
@@ -100,6 +99,52 @@ def sub_zero(
     rows: Union[int, List[int], None] = None,
     zero_text: str = "nil",
 ) -> GTSelf:
+    """
+    Substitute zero values in the table body.
+
+    Wherever there is numerical data that are zero in value, replacement text may be better for
+    explanatory purposes. The `sub_zero()` function allows for this replacement through its
+    `zero_text=` argument.
+
+    Parameters
+    ----------
+    columns
+        The columns to target. Can either be a single column name or a series of column names
+        provided in a list.
+    rows
+        In conjunction with `columns=`, we can specify which of their rows should be scanned for
+        zeros. The default is all rows, resulting in all rows in all targeted columns being
+        considered for this substitution. Alternatively, we can supply a list of row indices.
+    zero_text
+        The text to be used in place of zero values in the rendered table. We can optionally use the
+        [`md()`](`great_tables.md`) or [`html()`](`great_tables.html`) functions to style the text
+        as Markdown or to retain HTML elements in the text.
+
+
+    Examples
+    --------
+
+    Let's generate a simple table that contains an assortment of values that could potentially
+    undergo some substitution via the `sub_zero()` method (i.e., there are two `0` values). The
+    ordering of the [`fmt_scientific()`](`great_tables.GT.fmt_scientific`) and `sub_zero()` calls
+    in the example below doesn't affect the final result since any `sub_*()` method won't interfere
+    with the formatting of the table.
+
+    ```{python}
+    from great_tables import GT
+    import polars as pl
+
+    single_vals_df = pl.DataFrame(
+        {
+            "i": range(1, 8),
+            "numbers": [2.75, 0, -3.2, 8, 1e-10, 0, 2.6e9]
+        }
+    )
+
+    GT(single_vals_df).fmt_scientific(columns="numbers").sub_zero()
+    ```
+    """
+
     subber = SubZero(zero_text)
     return fmt(self, fns=subber.to_html, columns=columns, rows=rows, is_substitution=True)
 

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -491,9 +491,9 @@ def _(df: PlDataFrame, x: Any) -> bool:
     import polars as pl
     import numpy as np
 
-    from math import nan
+    from math import isnan, nan
 
-    return isinstance(x, (pl.Null, type(None))) or x is np.nan or x is nan
+    return isinstance(x, (pl.Null, type(None))) or (isinstance(x, float) and isnan(x))
 
 
 @singledispatch

--- a/great_tables/_text.py
+++ b/great_tables/_text.py
@@ -1,14 +1,15 @@
-from typing import Union, List
+from typing import Union, List, Literal
+from dataclasses import dataclass
 import html
 
 import commonmark
 import re
 
 
+@dataclass
 class Text:
-    def __init__(self, text: str, type: str):
-        self.text: str = text
-        self.type: str = type
+    text: str
+    type: Literal["from_markdown", "html"]
 
 
 class StringBuilder:

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -28,7 +28,7 @@ from great_tables._formats import (
     fmt_markdown,
     fmt_image,
 )
-from great_tables._substitution import sub_missing
+from great_tables._substitution import sub_missing, sub_zero
 from great_tables._heading import tab_header
 from great_tables._helpers import random_id
 from great_tables._options import (
@@ -230,6 +230,7 @@ class GT(
     data_color = data_color
 
     sub_missing = sub_missing
+    sub_zero = sub_zero
 
     opt_stylize = opt_stylize
     opt_align_table_header = opt_align_table_header
@@ -264,11 +265,12 @@ class GT(
         return self._has_built
 
     def _render_formats(self, context: str) -> Self:
-        rendered = copy.copy(self)
+        new_body = self._body.copy()
 
         # TODO: this body method performs a mutation. Should we make a copy of body?
-        rendered._body.render_formats(rendered._tbl_data, rendered._formats, context)
-        return rendered
+        new_body.render_formats(self._tbl_data, self._formats, context)
+        new_body.render_formats(self._tbl_data, self._substitutions, context)
+        return self._replace(_body=new_body)
 
     def _build_data(self, context: str) -> Self:
         # Build the body of the table by generating a dictionary

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -192,8 +192,7 @@ class GT(
     """
 
     def _repr_html_(self):
-        html = self.render(context="html")
-        return f"<html>{html}</html>"
+        return self.render(context="html")
 
     def __init__(
         self,

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -28,6 +28,7 @@ from great_tables._formats import (
     fmt_markdown,
     fmt_image,
 )
+from great_tables._substitution import sub_missing
 from great_tables._heading import tab_header
 from great_tables._helpers import random_id
 from great_tables._options import (
@@ -191,7 +192,8 @@ class GT(
     """
 
     def _repr_html_(self):
-        return self.render(context="html")
+        html = self.render(context="html")
+        return f"<html>{html}</html>"
 
     def __init__(
         self,
@@ -226,6 +228,8 @@ class GT(
     fmt_markdown = fmt_markdown
     fmt_image = fmt_image
     data_color = data_color
+
+    sub_missing = sub_missing
 
     opt_stylize = opt_stylize
     opt_align_table_header = opt_align_table_header

--- a/tests/test_substitutions.py
+++ b/tests/test_substitutions.py
@@ -1,0 +1,68 @@
+import pandas as pd
+import polars as pl
+import polars.testing
+import numpy as np
+import pytest
+
+from great_tables import GT
+from great_tables._tbl_data import DataFrameLike, _get_cell, to_list
+from great_tables._substitution import SubMissing, SubZero
+from great_tables._gt_data import FormatterSkipElement
+from math import nan
+
+params_frames = [pytest.param(pd.DataFrame, id="pandas"), pytest.param(pl.DataFrame, id="polars")]
+
+
+@pytest.fixture(params=params_frames, scope="function")
+def df(request) -> DataFrameLike:
+    return request.param({"col1": [None, nan, 0]})
+
+
+@pytest.fixture(params=params_frames, scope="function")
+def df_empty(request) -> DataFrameLike:
+    return request.param()
+
+
+def assert_frame_equal(src: DataFrameLike, target: DataFrameLike):
+    if isinstance(src, pd.DataFrame):
+        pd.testing.assert_frame_equal(src, target)
+    elif isinstance(src, pl.DataFrame):
+        pl.testing.assert_frame_equal(src, target)
+    else:
+        raise NotImplementedError(f"Unsupported data type: {type(src)}")
+
+
+def assert_series_equals(src, target: list):
+    # polars is kind and converts its null type to None, but
+    # pandas needs the NA -> None to be done manually.
+    fixed = [None if x is pd.NA else x for x in to_list(src)]
+    assert fixed == target
+
+
+@pytest.mark.parametrize("el", [None, nan, np.nan])
+def test_sub_missing_el(df_empty: DataFrameLike, el):
+    # df just being used as constructor
+    assert SubMissing(df_empty, "---").to_html(el) == "---"
+
+
+def test_sub_missing_el_skip(df_empty: DataFrameLike):
+    assert isinstance(SubMissing(df_empty, "---").to_html(0), FormatterSkipElement)
+
+
+def test_sub_missing_meth(df):
+    new_gt = GT(df).sub_missing("col1", missing_text="--")._render_formats("html")
+    assert_series_equals(new_gt._body.body["col1"], ["--", "--", None])
+
+
+@pytest.mark.parametrize("el", [0, 0.0])
+def test_sub_zero_el(el):
+    assert SubZero("--").to_html(el) == "--"
+
+
+def test_sub_zero_el_skip():
+    assert isinstance(SubZero("--").to_html(1), FormatterSkipElement)
+
+
+def test_sub_zero_meth(df):
+    new_gt = GT(df).sub_zero("col1", zero_text="no")._render_formats("html")
+    assert_series_equals(new_gt._body.body["col1"], [None, None, "no"])


### PR DESCRIPTION
This PR adds support for substitution functions. It address #182, by adding the following methods:

* `sub_missing`: substitutes any missing values. This includes both null and nan.
  * polars: should be equivalent to polars using `.is_null() | .is_nan()`, since distinguishes between the two.
  * pandas: should be equivalent to `.isna()`, which flags both kinds of missingness.
* `sub_zero`

Currently, it is just using the formatter machinery. As I understand, substitutions should always go after formatters. (e.g. you should be able to `.sub_zero()` right away in a chain, and expect later `fmt_*()` calls to not override that.

Note these important pieces:

* Introduced new class `FormatterSkipElement`, which when returned from a format call, indicates that no change should be made.
* Rich, in his HTML wizardry, had to address this situation: when a row of a table has all empty cells, then its height collapses (because there is no content inside). Recommended practice is to add a single `<br>`. 
* Fixed `is_na` to properly detect float("nan")
* Added the parameter `is_substitution=` to `fmt()`. This deviates from gt. Happy to change to be more similar.