### PR TITLE
Fix error from incorrectly passing nanoplot options to args in `_generate_nanoplot()` 

### DIFF
--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -514,8 +514,8 @@ def _construct_nanoplot_svg(
     show_data_points: bool,
     show_data_line: bool,
     show_data_area: bool,
-    show_ref_line: bool,
-    show_ref_area: bool,
+    show_reference_line: bool,
+    show_reference_area: bool,
     show_vertical_guides: bool,
     show_y_axis_guide: bool,
     ref_area_tags: Optional[str] = None,
@@ -533,12 +533,12 @@ def _construct_nanoplot_svg(
     """
 
     # For the optional strings, transform None to an empty string
-    ref_area_tags = "" if ref_area_tags is None or show_ref_area is False else ref_area_tags
+    ref_area_tags = "" if ref_area_tags is None or show_reference_area is False else ref_area_tags
     area_path_tags = "" if area_path_tags is None or show_data_area is False else area_path_tags
     data_path_tags = "" if data_path_tags is None or show_data_line is False else data_path_tags
     zero_line_tags = "" if zero_line_tags is None else zero_line_tags
     bar_tags = "" if bar_tags is None else bar_tags
-    ref_line_tags = "" if ref_line_tags is None or show_ref_line is False else ref_line_tags
+    ref_line_tags = "" if ref_line_tags is None or show_reference_line is False else ref_line_tags
     circle_tags = "" if circle_tags is None or show_data_points is False else circle_tags
     g_y_axis_tags = "" if g_y_axis_tags is None or show_y_axis_guide is False else g_y_axis_tags
     g_guide_tags = "" if g_guide_tags is None or show_vertical_guides is False else g_guide_tags
@@ -557,7 +557,7 @@ def _generate_nanoplot(
     all_y_vals: Optional[Union[List[Union[int, float]], List[int], List[float]]] = None,
     all_single_y_vals: Optional[Union[List[Union[int, float]], List[int], List[float]]] = None,
     plot_type: str = "line",
-    line_type: str = "curved",
+    data_line_type: str = "curved",
     currency: Optional[str] = None,
     y_val_fmt_fn: Optional[Callable[..., str]] = None,
     y_axis_fmt_fn: Optional[Callable[..., str]] = None,
@@ -582,8 +582,8 @@ def _generate_nanoplot(
     show_data_points: bool = True,
     show_data_line: bool = True,
     show_data_area: bool = True,
-    show_ref_line: bool = True,
-    show_ref_area: bool = True,
+    show_reference_line: bool = True,
+    show_reference_area: bool = True,
     show_vertical_guides: bool = True,
     show_y_axis_guide: bool = True,
     interactive_data_values: bool = True,
@@ -599,7 +599,7 @@ def _generate_nanoplot(
         lst=["marker", "gap", "zero", "remove"],
     )
     _match_arg(
-        x=line_type,
+        x=data_line_type,
         lst=["curved", "straight"],
     )
 
@@ -681,7 +681,7 @@ def _generate_nanoplot(
         # we'll force the use of the 'straight' line type
         # TODO: if someone specifies the options curved, and we can't do it
         # then we should raise an error.
-        line_type = "straight"
+        data_line_type = "straight"
 
     # If `missing_vals` is set to 'gap' raise an error
     # TODO: Implement the 'gap' option for missing values
@@ -715,8 +715,8 @@ def _generate_nanoplot(
         show_data_points = True
         show_data_line = True
         show_data_area = False
-        show_ref_line = False
-        show_ref_area = False
+        show_reference_line = False
+        show_reference_area = False
         show_vertical_guides = False
         show_y_axis_guide = False
 
@@ -728,8 +728,8 @@ def _generate_nanoplot(
         show_data_points = False
         show_data_line = False
         show_data_area = False
-        show_ref_line = False
-        show_ref_area = False
+        show_reference_line = False
+        show_reference_area = False
         show_vertical_guides = False
         show_y_axis_guide = False
 
@@ -754,13 +754,13 @@ def _generate_nanoplot(
     # Ensure that a reference line or reference area isn't shown if None or
     # any of its directives is missing
     if y_ref_line is None or (y_ref_line is not None and pd.isna(y_ref_line)):
-        show_ref_line = False
+        show_reference_line = False
 
     if y_ref_area is None:
-        show_ref_area = False
+        show_reference_area = False
 
     if y_ref_area is not None and (pd.isna(y_ref_area[0]) or pd.isna(y_ref_area[1])):
-        show_ref_area = False
+        show_reference_area = False
 
     # Determine the width of the data plot area; for plots where `x_vals`
     # are available, we'll use a fixed width of `500` (px), and for plots
@@ -808,7 +808,7 @@ def _generate_nanoplot(
     # so that there are normalized values in relation to the data points
     #
 
-    if show_ref_line and show_ref_area:
+    if show_reference_line and show_reference_area:
 
         # Case where there is both a reference line and a reference area
 
@@ -861,7 +861,7 @@ def _generate_nanoplot(
         data_y_ref_area_l = safe_y_d + ((1 - y_proportions_ref_area_l) * data_y_height)
         data_y_ref_area_u = safe_y_d + ((1 - y_proportions_ref_area_u) * data_y_height)
 
-    elif show_ref_line:
+    elif show_reference_line:
 
         # Case where there is a reference line
 
@@ -891,7 +891,7 @@ def _generate_nanoplot(
         # Scale reference line
         data_y_ref_line = safe_y_d + ((1 - y_proportion_ref_line) * data_y_height)
 
-    elif show_ref_area:
+    elif show_reference_area:
 
         # Case where there is a reference area
 
@@ -1029,7 +1029,7 @@ def _generate_nanoplot(
     # Generate a curved data line
     #
 
-    if plot_type == "line" and show_data_line and line_type == "curved":
+    if plot_type == "line" and show_data_line and data_line_type == "curved":
 
         data_path_tags = []
 
@@ -1058,7 +1058,7 @@ def _generate_nanoplot(
 
         data_path_tags = "\n".join(data_path_tags)
 
-    if plot_type == "line" and show_data_line and line_type == "straight":
+    if plot_type == "line" and show_data_line and data_line_type == "straight":
 
         data_path_tags = []
 
@@ -1382,7 +1382,7 @@ def _generate_nanoplot(
     # Generate reference line
     #
 
-    if show_ref_line:
+    if show_reference_line:
 
         stroke = reference_line_color
         stroke_width = 1
@@ -1402,7 +1402,7 @@ def _generate_nanoplot(
     # Generate reference area
     #
 
-    if show_ref_area:
+    if show_reference_area:
 
         fill = reference_area_fill_color
 
@@ -1545,8 +1545,8 @@ def _generate_nanoplot(
         show_data_points=show_data_points,
         show_data_line=show_data_line,
         show_data_area=show_data_area,
-        show_ref_line=show_ref_line,
-        show_ref_area=show_ref_area,
+        show_reference_line=show_reference_line,
+        show_reference_area=show_reference_area,
         show_vertical_guides=show_vertical_guides,
         show_y_axis_guide=show_y_axis_guide,
         ref_area_tags=ref_area_tags,


### PR DESCRIPTION
In a previous PR, a call to `_generate_nanoplot()` was simplified to use `**` to pass through args: 

https://github.com/posit-dev/great-tables/blob/cd618a4111b0f5206e412b522e2c50c06b2c9e8d/great_tables/_formats.py#L3832

However, the argument names in three cases don't match. These are:

- `line_type` != `data_line_type`
- `show_ref_line` != `show_reference_line`
- `show_ref_area` != `show_reference_area`

The solution here is to expand the shorter arg names to their longer counterparts. This doesn't break the GT API since the longer names are what the user has access to within `nanoplot_options()`.

With this change, examples in https://posit-dev.github.io/great-tables/blog/introduction-0.4.0/ should no longer be broken.