### PR TITLE
Update list of supported Python versions to match those tested

### DIFF
--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -148,9 +148,10 @@ def save(
     # is visible in the screenshot; this is settable via the `window_size=` argument
     options.add_argument(f"--window-size={window_size[0]},{window_size[1]}")
 
-    with tempfile.NamedTemporaryFile(suffix=".html", dir=temp_dir) as temp_file, webdriver.Chrome(
-        options=options
-    ) as chrome:
+    with (
+        tempfile.NamedTemporaryFile(suffix=".html", dir=temp_dir) as temp_file,
+        webdriver.Chrome(options=options) as chrome,
+    ):
 
         # Write the HTML content to the temp file
         with open(temp_file.name, "w") as fp:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,10 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -47,7 +48,7 @@ dependencies = [
     "mizani>=0.9.3",
     "webcolors>=1.13",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 all = [


### PR DESCRIPTION
# Summary

Existing README screenshot:
<img width="237" alt="Screenshot 2024-04-05 at 8 40 52 AM" src="https://github.com/posit-dev/great-tables/assets/7703961/eb9746c5-8fff-49a9-83d7-0e95ad0f3733">

Shows support for Python 3.7, 3.8, and 3.9. The GitHub Actions test matrix shows `python-version: ["3.9", "3.10", "3.11", "3.12"]`.

This PR updates the supported Python version list to match what's tested.

# Checklist

- [X] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [n/a] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [n/a] I have added **pytest** unit tests for any new functionality.


Fixes: https://github.com/posit-dev/great-tables/issues/220
