### PR TITLE
feat: remove mizani as dependency, re-implement logic internally

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -50,7 +50,7 @@ jobs:
           python-version: "3.12"
       - name: Install dependencies
         run: |
-          pip install -e '.[dev]'
+          pip install -e '.[dev-no-pandas]'
       - name: pytest unit tests
         run: |
           make test-no-pandas

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -6,7 +6,10 @@ from typing import (
     Optional,
     Tuple,
 )
+from typing_extensions import TypeAlias
+
 from .constants import DEFAULT_PALETTE, COLOR_NAME_TO_HEX, ALL_PALETTES
+
 from great_tables._tbl_data import is_na, DataFrameLike
 from great_tables.style import fill, text
 from great_tables.loc import body
@@ -166,12 +169,8 @@ def data_color(
     ```
     """
 
-    try:
-        from mizani.palettes import gradient_n_pal
-    except ModuleNotFoundError:
-        raise ModuleNotFoundError(
-            "The `mizani` package is required to use the `data_color()` method."
-        )
+    # TODO: there is a circular import in palettes (which imports functions from this module)
+    from great_tables._data_color.palettes import GradientPalette
 
     # If no color is provided to `na_color`, use a light gray color as a default
     if na_color is None:
@@ -259,7 +258,7 @@ def data_color(
         scaled_vals = [np.nan if is_na(data_table, x) else x for x in scaled_vals]
 
         # Create a color scale function from the palette
-        color_scale_fn = gradient_n_pal(colors=palette)
+        color_scale_fn = GradientPalette(colors=palette)
 
         # Call the color scale function on the scaled values to get a list of colors
         color_vals = color_scale_fn(scaled_vals)

--- a/great_tables/_data_color/palettes.py
+++ b/great_tables/_data_color/palettes.py
@@ -1,0 +1,171 @@
+from bisect import bisect
+from math import isnan, isinf
+from typing import TypedDict, Tuple
+from typing_extensions import TypeAlias
+
+from .base import _html_color, _hex_to_rgb
+
+RGBColor: TypeAlias = Tuple[int, int, int]
+
+
+def rgb_to_hex(rgb: RGBColor) -> str:
+    return f"#{rgb[0]:02x}{rgb[1]:02x}{rgb[2]:02x}"
+
+
+# data ---------------------------------------------------------------------------------------------
+
+
+class GradientCoefficients(TypedDict):
+    """Coefficients for a gradient color map.
+
+    Parameters
+    ----------
+    starting:
+        The value at which these coefficients start to apply.
+    intercept:
+        The outcome when the value is equal to starting.
+    scalar:
+        The rate at which the outcome changes as the value increases.
+    """
+
+    starting: float
+    intercept: int
+    scalar: float
+
+
+# coefficient lookup classes -----------------------------------------------------------------------
+
+
+class CoeffSequence:
+    """Return the coefficients for transforming an input to RGB."""
+
+    coeffs: list[GradientCoefficients]
+
+    def __init__(self, coeffs: list[GradientCoefficients]):
+        self.coeffs = coeffs
+
+    def lookup(self, x: float) -> GradientCoefficients:
+        for coeff in reversed(self.coeffs):
+            if x >= coeff["starting"]:
+                return coeff
+
+        raise ValueError("No coefficients found for this value.")
+
+
+class CoeffSequenceBisector(CoeffSequence):
+    """Use a bisect search to find coefficients."""
+
+    starting: list[float]
+    coeffs: list[GradientCoefficients]
+
+    def __init__(self, coeffs: list[GradientCoefficients]):
+        self.starting = [coeff["starting"] for coeff in coeffs]
+        self.coeffs = coeffs
+
+    def lookup(self, x: float) -> GradientCoefficients:
+        idx = bisect(self.starting, x) - 1
+        return self.coeffs[idx]
+
+
+# palettes -----------------------------------------------------------------------------------------
+
+
+class GradientPalette:
+    """A palette that interpolates between colors using a linear gradient on RBG channels.
+
+    Parameters
+    ----------
+    colors:
+        The colors to interpolate between, as hex strings.
+    values:
+        The value cutoffs for switching between colors. By default these are evenly spaced.
+    """
+
+    colors: list[RGBColor]
+    values: list[float]
+
+    def __init__(
+        self,
+        colors: list[str],
+        values: "list[float] | None" = None,
+        cls_coeff_sequence: "type[CoeffSequence]" = CoeffSequenceBisector,
+    ):
+        if len(colors) < 2:
+            raise ValueError(
+                f"Palette requires at least 2 colors, but only {len(colors)} were provided."
+            )
+
+        if values is None:
+            values = self._linspace_to_one(len(colors))
+        elif len(values) < 2 or values[0] != 0 or values[-1] != 1:
+            raise ValueError("Values must be at least length 2, start with 0, and end with 1.")
+
+        if len(values) != len(colors):
+            raise ValueError(
+                "Values and colors must be the same length. "
+                f"Receieved {len(values)} and {len(colors)}."
+            )
+
+        # colors can be rgb tuples or hex strings
+        if isinstance(colors[0], str):
+            rgb_colors: "list[RGBColor]" = [_hex_to_rgb(color) for color in _html_color(colors)]
+        else:
+            raise NotImplementedError("Currently, rgb tuples can't be passed directly.")
+
+        self.colors = rgb_colors
+        self.values = values
+        self.cls_coeff_sequence = cls_coeff_sequence
+        self._r_coeffs = self._create_coefficients(values, [x[0] for x in rgb_colors])
+        self._g_coeffs = self._create_coefficients(values, [x[1] for x in rgb_colors])
+        self._b_coeffs = self._create_coefficients(values, [x[2] for x in rgb_colors])
+
+    def __call__(self, data: list[float]) -> "list[str | None]":
+        """Return data transformed to hex color values."""
+
+        rgb = self.vals_to_rgb(data)
+        return [rgb_to_hex(x) if x is not None else None for x in rgb]
+
+    def vals_to_rgb(self, data: list[float]) -> "list[RGBColor | None]":
+        """Return data transformed to RGB values."""
+
+        out: "list[RGBColor | None]" = []
+        for ii, x in enumerate(data):
+            if isinf(x) or isnan(x):
+                out.append(None)
+            elif x < 0 or x > 1:
+                raise ValueError(f"Element {ii} is outside the range [0, 1]. Value: {x}.")
+            else:
+                r = self._interpolate(x, self._r_coeffs)
+                g = self._interpolate(x, self._g_coeffs)
+                b = self._interpolate(x, self._b_coeffs)
+                out.append((round(r), round(g), round(b)))
+
+        return out
+
+    @staticmethod
+    def _linspace_to_one(n_steps: int) -> list[float]:
+        # equivalent to np.linspace(0, 1, n_steps)
+        increment = 1 / (n_steps - 1)
+        return [x * increment for x in range(n_steps)]
+
+    def _create_coefficients(self, cutoffs: list[float], channel: list[int]) -> CoeffSequence:
+        """Return coefficients for interpolating between cutoffs on a color channel."""
+
+        p_cutoffs = list(zip(cutoffs[:-1], cutoffs[1:]))
+        p_colors = list(zip(channel[:-1], channel[1:]))
+
+        coeffs: list[GradientCoefficients] = []
+        for (prev_cutoff, crnt_cutoff), (prev_color, crnt_color) in zip(p_cutoffs, p_colors):
+            cutoff_diff = crnt_cutoff - prev_cutoff
+            color_scalar = (crnt_color - prev_color) / cutoff_diff
+
+            coeffs.append(
+                {"scalar": color_scalar, "intercept": prev_color, "starting": prev_cutoff}
+            )
+
+        return self.cls_coeff_sequence(coeffs)
+
+    @staticmethod
+    def _interpolate(x: float, coeffs: CoeffSequence) -> float:
+        coeff = coeffs.lookup(x)
+        return coeff["scalar"] * (x - coeff["starting"]) + coeff["intercept"]

--- a/great_tables/_data_color/palettes.py
+++ b/great_tables/_data_color/palettes.py
@@ -1,3 +1,8 @@
+"""Palette classes for translating data to color values.
+
+Note that this code is largely a pure python port of the mizani gradient_n_pal code.
+"""
+
 from bisect import bisect
 from math import isnan, isinf
 from typing import TypedDict, Tuple

--- a/great_tables/_data_color/palettes.py
+++ b/great_tables/_data_color/palettes.py
@@ -92,7 +92,7 @@ class GradientPalette:
     ):
         if len(colors) < 2:
             raise ValueError(
-                f"Palette requires at least 2 colors, but only {len(colors)} were provided."
+                f"Palette requires at least 2 colors, but only {len(colors)} provided."
             )
 
         if values is None:
@@ -103,7 +103,7 @@ class GradientPalette:
         if len(values) != len(colors):
             raise ValueError(
                 "Values and colors must be the same length. "
-                f"Receieved {len(values)} and {len(colors)}."
+                f"Received {len(values)} values and {len(colors)} colors."
             )
 
         # colors can be rgb tuples or hex strings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ all = [
 extra = [
     "selenium>=4.18.1",
     "Pillow>=10.2.0",
-    "mizani>=0.9.3",
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
     "jupyter",
     "quartodoc>=0.7.1; python_version >= '3.9'",
     "griffe==0.38.1",
+    "pandas",
     "polars",
     "pre-commit==2.15.0",
     "pyarrow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,11 +59,15 @@ extra = [
 ]
 
 dev = [
+    "great_tables[dev-no-pandas]",
+    "pandas"
+]
+
+dev-no-pandas = [
     "black",
     "jupyter",
     "quartodoc>=0.7.1; python_version >= '3.9'",
     "griffe==0.38.1",
-    "pandas",
     "polars",
     "pre-commit==2.15.0",
     "pyarrow",

--- a/tests/data_color/__snapshots__/test_data_color.ambr
+++ b/tests/data_color/__snapshots__/test_data_color.ambr
@@ -137,8 +137,8 @@
     <td class="gt_row gt_left">two</td>
   </tr>
   <tr>
-    <td style="color: #000000; background-color: #73c476;" class="gt_row gt_right">3</td>
-    <td style="color: #000000; background-color: #73c476;" class="gt_row gt_right">8</td>
+    <td style="color: #000000; background-color: #74c476;" class="gt_row gt_right">3</td>
+    <td style="color: #000000; background-color: #74c476;" class="gt_row gt_right">8</td>
     <td class="gt_row gt_left">three</td>
   </tr>
   <tr>
@@ -279,7 +279,7 @@
   <tr>
     <td class="gt_row gt_right">444.4</td>
     <td class="gt_row gt_left">durian</td>
-    <td style="color: #FFFFFF; background-color: #673598;" class="gt_row gt_right">65100.0</td>
+    <td style="color: #FFFFFF; background-color: #673498;" class="gt_row gt_right">65100.0</td>
   </tr>
   </tbody>
   '''
@@ -305,7 +305,7 @@
   <tr>
     <td class="gt_row gt_right">444.4</td>
     <td class="gt_row gt_left">durian</td>
-    <td style="color: #FFFFFF; background-color: #673598;" class="gt_row gt_right">65100.0</td>
+    <td style="color: #FFFFFF; background-color: #673498;" class="gt_row gt_right">65100.0</td>
   </tr>
   </tbody>
   '''
@@ -371,8 +371,8 @@
     <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">one</td>
   </tr>
   <tr>
-    <td style="color: #000000; background-color: #25bee5;" class="gt_row gt_right">2</td>
-    <td style="color: #000000; background-color: #25bee5;" class="gt_row gt_right">9</td>
+    <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_right">2</td>
+    <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_right">9</td>
     <td style="color: #000000; background-color: #4cbd81;" class="gt_row gt_left">two</td>
   </tr>
   <tr>
@@ -389,21 +389,21 @@
   <tr>
     <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">0.1111</td>
     <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">apricot</td>
-    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">49.95</td>
+    <td style="color: #FFFFFF; background-color: #010001;" class="gt_row gt_right">49.95</td>
   </tr>
   <tr>
-    <td style="color: #FFFFFF; background-color: #060203;" class="gt_row gt_right">2.222</td>
-    <td style="color: #000000; background-color: #80b256;" class="gt_row gt_left">banana</td>
+    <td style="color: #FFFFFF; background-color: #070304;" class="gt_row gt_right">2.222</td>
+    <td style="color: #000000; background-color: #80b156;" class="gt_row gt_left">banana</td>
     <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">17.95</td>
   </tr>
   <tr>
-    <td style="color: #FFFFFF; background-color: #742b38;" class="gt_row gt_right">33.33</td>
-    <td style="color: #000000; background-color: #25bee5;" class="gt_row gt_left">coconut</td>
+    <td style="color: #FFFFFF; background-color: #752b38;" class="gt_row gt_right">33.33</td>
+    <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_left">coconut</td>
     <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1.39</td>
   </tr>
   <tr>
     <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">444.4</td>
-    <td style="color: #000000; background-color: #d73992;" class="gt_row gt_left">durian</td>
+    <td style="color: #000000; background-color: #d73a91;" class="gt_row gt_left">durian</td>
     <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">65100.0</td>
   </tr>
   </tbody>
@@ -415,21 +415,21 @@
   <tr>
     <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">0.1111</td>
     <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">apricot</td>
-    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">49.95</td>
+    <td style="color: #FFFFFF; background-color: #010001;" class="gt_row gt_right">49.95</td>
   </tr>
   <tr>
-    <td style="color: #FFFFFF; background-color: #060203;" class="gt_row gt_right">2.222</td>
-    <td style="color: #000000; background-color: #80b256;" class="gt_row gt_left">banana</td>
+    <td style="color: #FFFFFF; background-color: #070304;" class="gt_row gt_right">2.222</td>
+    <td style="color: #000000; background-color: #80b156;" class="gt_row gt_left">banana</td>
     <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">17.95</td>
   </tr>
   <tr>
-    <td style="color: #FFFFFF; background-color: #742b38;" class="gt_row gt_right">33.33</td>
-    <td style="color: #000000; background-color: #25bee5;" class="gt_row gt_left">coconut</td>
+    <td style="color: #FFFFFF; background-color: #752b38;" class="gt_row gt_right">33.33</td>
+    <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_left">coconut</td>
     <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1.39</td>
   </tr>
   <tr>
     <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">444.4</td>
-    <td style="color: #000000; background-color: #d73992;" class="gt_row gt_left">durian</td>
+    <td style="color: #000000; background-color: #d73a91;" class="gt_row gt_left">durian</td>
     <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">65100.0</td>
   </tr>
   </tbody>
@@ -497,16 +497,16 @@
   </tr>
   <tr>
     <td style="color: #FFFFFF; background-color: #3b518a;" class="gt_row gt_right">2</td>
-    <td style="color: #000000; background-color: #5fc761;" class="gt_row gt_right">9</td>
+    <td style="color: #000000; background-color: #5fc861;" class="gt_row gt_right">9</td>
     <td class="gt_row gt_left">two</td>
   </tr>
   <tr>
-    <td style="color: #000000; background-color: #22908b;" class="gt_row gt_right">3</td>
-    <td style="color: #000000; background-color: #22908b;" class="gt_row gt_right">8</td>
+    <td style="color: #000000; background-color: #22908c;" class="gt_row gt_right">3</td>
+    <td style="color: #000000; background-color: #22908c;" class="gt_row gt_right">8</td>
     <td class="gt_row gt_left">three</td>
   </tr>
   <tr>
-    <td style="color: #000000; background-color: #5fc761;" class="gt_row gt_right">4</td>
+    <td style="color: #000000; background-color: #5fc861;" class="gt_row gt_right">4</td>
     <td style="color: #FFFFFF; background-color: #3b518a;" class="gt_row gt_right">7</td>
     <td class="gt_row gt_left">four</td>
   </tr>

--- a/tests/data_color/test_data_color_utils.py
+++ b/tests/data_color/test_data_color_utils.py
@@ -1,3 +1,4 @@
+import math
 import pandas as pd
 import numpy as np
 import pytest
@@ -20,6 +21,7 @@ from great_tables._data_color.base import (
     _get_domain_numeric,
     _get_domain_factor,
 )
+from great_tables._data_color.palettes import GradientPalette
 
 
 def test_ideal_fgnd_color_dark_contrast():
@@ -523,3 +525,21 @@ def test_get_domain_factor():
     vals = ["A", "B", "B", "C"]
     result = _get_domain_factor(df, vals)
     assert result == ["A", "B", "C"]
+
+
+def test_gradient_n_pal():
+    palette = GradientPalette(["red", "blue"])
+
+    res = palette([0, 0.25, 0.5, 0.75, 1])
+    assert res == ["#ff0000", "#bf0040", "#800080", "#4000bf", "#0000ff"]
+
+
+def test_gradient_n_pal_inf():
+    palette = GradientPalette(["red", "blue"])
+
+    res = palette([-math.inf, 0, math.nan, 1, math.inf])
+    assert res == [None, "#ff0000", None, "#0000ff", None]
+
+    # same but with numpy
+    res = palette([-np.inf, 0, np.nan, 1, np.inf])
+    assert res == [None, "#ff0000", None, "#0000ff", None]

--- a/tests/data_color/test_data_color_utils.py
+++ b/tests/data_color/test_data_color_utils.py
@@ -534,6 +534,16 @@ def test_gradient_n_pal():
     assert res == ["#ff0000", "#bf0040", "#800080", "#4000bf", "#0000ff"]
 
 
+@pytest.mark.parametrize(
+    "src,dst", [(0.001, "#ff0000"), (0.004, "#fe0001"), (0.999, "#0000ff"), (0.996, "#0100fe")]
+)
+def test_gradient_n_pal_rounds(src, dst):
+    palette = GradientPalette(["red", "blue"])
+
+    res = palette([src])
+    assert res == [dst]
+
+
 def test_gradient_n_pal_inf():
     palette = GradientPalette(["red", "blue"])
 

--- a/tests/data_color/test_data_color_utils.py
+++ b/tests/data_color/test_data_color_utils.py
@@ -543,3 +543,25 @@ def test_gradient_n_pal_inf():
     # same but with numpy
     res = palette([-np.inf, 0, np.nan, 1, np.inf])
     assert res == [None, "#ff0000", None, "#0000ff", None]
+
+
+def test_gradient_n_pal_symmetric():
+    # based on mizani unit tests
+    palette = GradientPalette(["red", "blue", "red"], values=[0, 0.5, 1])
+
+    res = palette([0.2, 0.5, 0.8])
+    assert res == ["#990066", "#0000ff", "#990066"]
+
+
+def test_gradient_n_pal_out_of_bounds_raises():
+    palette = GradientPalette(["red", "blue"])
+
+    with pytest.raises(ValueError) as exc_info:
+        palette([0, 1.1])
+
+    assert "Value: 1.1" in exc_info.value.args[0]
+
+    with pytest.raises(ValueError) as exc_info:
+        palette([0, -0.1])
+
+    assert "Value: -0.1" in exc_info.value.args[0]

--- a/tests/data_color/test_data_color_utils.py
+++ b/tests/data_color/test_data_color_utils.py
@@ -563,6 +563,31 @@ def test_gradient_n_pal_symmetric():
     assert res == ["#990066", "#0000ff", "#990066"]
 
 
+def test_gradient_n_pal_guard_raises():
+    with pytest.raises(ValueError) as exc_info:
+        GradientPalette(["red"])
+
+    assert "only 1 provided" in exc_info.value.args[0]
+
+    # values must start with 0
+    with pytest.raises(ValueError) as exc_info:
+        GradientPalette(["red", "blue"], values=[0.1, 1])
+
+    assert "start with 0" in exc_info.value.args[0]
+
+    # values must end with 1
+    with pytest.raises(ValueError) as exc_info:
+        GradientPalette(["red", "blue"], values=[0, 0.1])
+
+    assert "end with 1" in exc_info.value.args[0]
+
+    # len(color) != len(values)
+    with pytest.raises(ValueError) as exc_info:
+        GradientPalette(["red", "blue"], values=[0, 1.1, 1])
+
+    assert "Received 3 values and 2 colors" in exc_info.value.args[0]
+
+
 def test_gradient_n_pal_out_of_bounds_raises():
     palette = GradientPalette(["red", "blue"])
 

--- a/tests/data_color/test_data_color_utils.py
+++ b/tests/data_color/test_data_color_utils.py
@@ -563,6 +563,14 @@ def test_gradient_n_pal_symmetric():
     assert res == ["#990066", "#0000ff", "#990066"]
 
 
+def test_gradient_n_pal_manual_values():
+    # note that green1 is #0000ff (and green is not!)
+    palette = GradientPalette(["red", "blue", "green1"], values=[0, 0.8, 1])
+
+    res = palette([0, 0.8, 0.9, 1])
+    assert res == ["#ff0000", "#0000ff", "#008080", "#00ff00"]
+
+
 def test_gradient_n_pal_guard_raises():
     with pytest.raises(ValueError) as exc_info:
         GradientPalette(["red"])


### PR DESCRIPTION
This PR removes mizani as a dependency, so that we don't transitively depend on scipy and pandas. Note that our internal implementation does not depend on numpy, so that we can drop it as a dependency in a later PR.

This implementation is not as elegant as mizani's, or quite as optimized, but should do well for our purposes.

## Speed

Our default implementation was about 50% slower than mizani in a simple test. But both are very fast for simple table displays (1.52 ms for 1,000 points for ours, 1ms for mizani.)

```python
from great_tables._data_color.palettes import GradientPalette, CoeffSequence
from mizani.palettes import gradient_n_pal

palette = GradientPalette(["red", "orange", "blue", "grey", "yellow", "red", "orange"])
palette2 = GradientPalette(["red", "orange", "blue", "grey", "yellow", "red", "orange"], cls_coeff_sequence=CoeffSequence)
palette3 = gradient_n_pal(["red", "orange", "blue", "grey", "yellow", "red", "orange"])


%%timeit
# internal + bisect lookup: 1.52 ms ± 5.85 µs per loop
palette([x / 1000. for x in range(1000)])

%%timeit
# 1.76 ms ± 6.27 µs per loop
palette2([x / 1000. for x in range(1000)])

%%timeit
# mizani: 1.03 ms ± 9.82 µs per loop
palette3([x / 1000. for x in range(1000)])
```

The main difference is that we're using a simple bisect lookup to find cutoff corresponding to a value (in order to get coefficients for transforming within a cutoff band). Mizani uses a table lookup, which cuts the input/response space into 256 bins.

Fixes: https://github.com/posit-dev/great-tables/issues/7