### PR TITLE
Resolve issue with `table_font_color` not accepting named colors

### DIFF
--- a/great_tables/_scss.py
+++ b/great_tables/_scss.py
@@ -39,13 +39,20 @@ FONT_COLOR_VARS = (
 )
 
 
-def font_color(color: str, table_font_color: str, table_font_color_light: str) -> str:
-    """Return either table_font_color or table_font_color_light, whichever is higher contrast."""
+def font_color(color: str, dark_option: str, light_option: str) -> str:
+    """Return either dark_option or light_option, whichever is higher contrast with color.
+
+    Handles common html color kinds (like transparent), and always returns a hex color.
+    """
+
+    # Normalize return options to hex colors
+    dark_normalized = _html_color(colors=[dark_option])[0]
+    light_normalized = _html_color(colors=[light_option])[0]
 
     if color == "transparent":
         # With the `transparent` color, the font color should have the same value
-        # as the `table_font_color` option since the background will be transparent
-        return table_font_color
+        # as the `dark_option` option since the background will be transparent
+        return dark_normalized
     if color in ["currentcolor", "currentColor"]:
         # With two variations of `currentColor` value, normalize to `currentcolor`
         return "currentcolor"
@@ -55,14 +62,12 @@ def font_color(color: str, table_font_color: str, table_font_color_light: str) -
 
     # Normalize the color to a hexadecimal value
     color_normalized = _html_color(colors=[color])
-    table_font_color_normalized = _html_color(colors=[table_font_color])
-    table_font_color_light_normalized = _html_color(colors=[table_font_color_light])
 
     # Determine the ideal font color given the different background colors
     ideal_font_color = _ideal_fgnd_color(
         bgnd_color=color_normalized[0],
-        light=table_font_color_normalized[0],
-        dark=table_font_color_light_normalized[0],
+        light=light_normalized,
+        dark=dark_normalized,
     )
 
     return ideal_font_color

--- a/great_tables/_scss.py
+++ b/great_tables/_scss.py
@@ -54,12 +54,15 @@ def font_color(color: str, table_font_color: str, table_font_color_light: str) -
 
     # Normalize the color to a hexadecimal value
     color_normalized = _html_color(colors=[color])
+    table_font_color_normalized = _html_color(colors=[table_font_color])
+    table_font_color_light_normalized = _html_color(
+        colors=[table_font_color_light])
 
     # Determine the ideal font color given the different background colors
     ideal_font_color = _ideal_fgnd_color(
         bgnd_color=color_normalized[0],
-        light=table_font_color,
-        dark=table_font_color_light,
+        light=table_font_color_normalized[0],
+        dark=table_font_color_light_normalized[0],
     )
 
     return ideal_font_color

--- a/great_tables/_scss.py
+++ b/great_tables/_scss.py
@@ -55,8 +55,7 @@ def font_color(color: str, table_font_color: str, table_font_color_light: str) -
     # Normalize the color to a hexadecimal value
     color_normalized = _html_color(colors=[color])
     table_font_color_normalized = _html_color(colors=[table_font_color])
-    table_font_color_light_normalized = _html_color(
-        colors=[table_font_color_light])
+    table_font_color_light_normalized = _html_color(colors=[table_font_color_light])
 
     # Determine the ideal font color given the different background colors
     ideal_font_color = _ideal_fgnd_color(

--- a/great_tables/_scss.py
+++ b/great_tables/_scss.py
@@ -40,6 +40,7 @@ FONT_COLOR_VARS = (
 
 
 def font_color(color: str, table_font_color: str, table_font_color_light: str) -> str:
+    """Return either table_font_color or table_font_color_light, whichever is higher contrast."""
 
     if color == "transparent":
         # With the `transparent` color, the font color should have the same value

--- a/great_tables/_scss.py
+++ b/great_tables/_scss.py
@@ -101,8 +101,8 @@ def compile_scss(
     # TODO: at this stage, the params below (e.g. table_font_color) have to exist, right?
     p_font_color = partial(
         font_color,
-        table_font_color=params["table_font_color"],
-        table_font_color_light=params["table_font_color_light"],
+        dark_option=params["table_font_color"],
+        light_option=params["table_font_color_light"],
     )
 
     font_params = {f"font_color_{k}": p_font_color(scss_params[k]) for k in FONT_COLOR_VARS}

--- a/tests/test_scss.py
+++ b/tests/test_scss.py
@@ -6,21 +6,23 @@ from great_tables._scss import font_color, css_add, compile_scss
 
 
 @pytest.mark.parametrize(
-    "src,dst",
+    "src,dst,table_font_color,table_font_color_light",
     [
-        ("#FFFFFF", "#000000"),
-        ("#000000", "#FFFFFF"),
-        ("white", "#000000"),
-        ("black", "#FFFFFF"),
-        ("silver", "#000000"),
-        ("transparent", "#000000"),
-        ("currentcolor", "currentcolor"),
-        ("currentColor", "currentcolor"),
+        ("#FFFFFF", "#000000", "#000000", "#FFFFFF"),
+        ("#000000", "#FFFFFF", "black", "white"),
+        ("white", "#000000", "#000000", "#FFFFFF"),
+        ("black", "#FFFFFF", "black", "white"),
+        ("silver", "#000000", "#000000", "#FFFFFF"),
+        ("transparent", "#000000", "#000000", "#FFFFFF"),
+        ("transparent", "black", "black", "white"),
+        ("currentcolor", "currentcolor", "#000000", "#FFFFFF"),
+        ("currentColor", "currentcolor", "black", "white"),
     ],
 )
-def test_font_color(src, dst):
-    res = font_color(src, "#000000", "#FFFFFF")
+def test_font_color(src, dst, table_font_color, table_font_color_light):
+    res = font_color(src, table_font_color, table_font_color_light)
     assert res == dst
+
 
 
 @pytest.mark.parametrize(

--- a/tests/test_scss.py
+++ b/tests/test_scss.py
@@ -26,7 +26,7 @@ def test_font_color(src, dst):
 @pytest.mark.parametrize(
     "src, dst",
     [
-        ("transparent", "#FFFFFF"),
+        ("transparent", "#000000"),
         ("currentColor", "currentcolor"),
         ("black", "#FFFFFF"),
     ],

--- a/tests/test_scss.py
+++ b/tests/test_scss.py
@@ -6,22 +6,33 @@ from great_tables._scss import font_color, css_add, compile_scss
 
 
 @pytest.mark.parametrize(
-    "src,dst,table_font_color,table_font_color_light",
+    "src,dst",
     [
-        ("#FFFFFF", "#000000", "#000000", "#FFFFFF"),
-        ("#000000", "#FFFFFF", "black", "white"),
-        ("white", "#000000", "#000000", "#FFFFFF"),
-        ("black", "#FFFFFF", "black", "white"),
-        ("silver", "#000000", "#000000", "#FFFFFF"),
-        ("transparent", "#000000", "#000000", "#FFFFFF"),
-        ("transparent", "black", "black", "white"),
-        ("currentcolor", "currentcolor", "#000000", "#FFFFFF"),
-        ("currentColor", "currentcolor", "black", "white"),
+        ("#FFFFFF", "#000000"),
+        ("#000000", "#FFFFFF"),
+        ("white", "#000000"),
+        ("black", "#FFFFFF"),
+        ("silver", "#000000"),
+        ("transparent", "#000000"),
+        ("currentcolor", "currentcolor"),
+        ("currentColor", "currentcolor"),
     ],
 )
-def test_font_color(src, dst, table_font_color, table_font_color_light):
-    res = font_color(src, table_font_color, table_font_color_light)
+def test_font_color(src, dst):
+    res = font_color(src, "#000000", "#FFFFFF")
     assert res == dst
+
+
+@pytest.mark.parametrize(
+    "src, dst",
+    [
+        ("transparent", "#FFFFFF"),
+        ("currentColor", "currentcolor"),
+        ("black", "#FFFFFF"),
+    ],
+)
+def test_font_color_normalizes_table_color_names(src, dst):
+    assert font_color(src, "black", "white") == dst
 
 
 @pytest.mark.parametrize(

--- a/tests/test_scss.py
+++ b/tests/test_scss.py
@@ -24,7 +24,6 @@ def test_font_color(src, dst, table_font_color, table_font_color_light):
     assert res == dst
 
 
-
 @pytest.mark.parametrize(
     "src,dst",
     [


### PR DESCRIPTION
It appears we're having an issue with the [Table Theme Options -> Set options across table parts](https://posit-dev.github.io/great-tables/get-started/table-theme-options.html#set-options-across-table-parts) section. 

![image](https://github.com/posit-dev/great-tables/assets/67060418/52ab0a06-508c-4fd9-8970-eed706681b3e)

The problem seems to arise when color values are input using common names like `yellow` or `white`, causing the `font_color` not to transform them into the appropriate hexadecimal format.

To address this issue, I've implemented a conversion pattern similar to the one used in `font_color`, which should hopefully resolve the issue.

Additionally, I noticed quick returns in the first few lines of `font_color`. I'm uncertain whether these also need conversion. Could the team please review this aspect?