### PR TITLE
ci: test on a windows runner

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -40,6 +40,21 @@ jobs:
           name: "py${{ matrix.python-version }}"
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          pip install -e '.[all]'
+      - name: pytest unit tests
+        run: |
+          make test
+
   test-pandas:
     runs-on: ubuntu-latest
     steps:

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -151,9 +151,6 @@ def save(
     # Get the HTML content from the displayed output
     html_content = as_raw_html(self)
 
-    # Create a temp directory to store the HTML file
-    temp_dir = tempfile.mkdtemp()
-
     # Set the webdriver and options based on the chosen browser (`web_driver=` argument)
     if web_driver == "chrome":
         wdriver = webdriver.Chrome
@@ -177,7 +174,7 @@ def save(
     wd_options.add_argument(f"--height={window_size[1]}")
 
     with (
-        tempfile.NamedTemporaryFile(suffix=".html", dir=temp_dir) as temp_file,
+        tempfile.NamedTemporaryFile(suffix=".html") as temp_file,
         wdriver(options=wd_options) as headless_browser,
     ):
 

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -180,7 +180,7 @@ def save(
 
         # Write the HTML content to the temp file
         temp_file.write(html_content)
-        temp_file.flush()
+        temp_file.close()
 
         # Convert the scale value to a percentage string used by the
         # Chrome browser for zooming

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -174,13 +174,13 @@ def save(
     wd_options.add_argument(f"--height={window_size[1]}")
 
     with (
-        tempfile.NamedTemporaryFile(mode="w", suffix=".html") as temp_file,
+        tempfile.TemporaryDirectory() as tmp_dir,
         wdriver(options=wd_options) as headless_browser,
     ):
 
         # Write the HTML content to the temp file
-        temp_file.write(html_content)
-        temp_file.close()
+        with open(f"{tmp_dir}/table.html", "w") as temp_file:
+            temp_file.write(html_content)
 
         # Convert the scale value to a percentage string used by the
         # Chrome browser for zooming

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -180,6 +180,7 @@ def save(
 
         # Write the HTML content to the temp file
         temp_file.write(html_content)
+        temp_file.flush()
 
         # Convert the scale value to a percentage string used by the
         # Chrome browser for zooming

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -174,13 +174,12 @@ def save(
     wd_options.add_argument(f"--height={window_size[1]}")
 
     with (
-        tempfile.NamedTemporaryFile(suffix=".html") as temp_file,
+        tempfile.NamedTemporaryFile(mode="w", suffix=".html") as temp_file,
         wdriver(options=wd_options) as headless_browser,
     ):
 
         # Write the HTML content to the temp file
-        with open(temp_file.name, "w") as fp:
-            fp.write(html_content)
+        temp_file.write(html_content)
 
         # Convert the scale value to a percentage string used by the
         # Chrome browser for zooming

--- a/great_tables/_locale.py
+++ b/great_tables/_locale.py
@@ -8,7 +8,7 @@ DATA_MOD = files("great_tables") / "data"
 
 
 def read_csv(fname: str) -> list[dict[str, Any]]:
-    with open(fname) as f:
+    with open(fname, encoding="utf8") as f:
         return list(DictReader(f))
 
 


### PR DESCRIPTION
This PR addresses potential issues when using `GT.save()` on a windows machine. It removes an unnecessary tmp dir being used when initiating NamedTemporaryFile (which could cause bizarreness), and adds a windows runner to our CI.

Edit: let's push fine-tuning to https://github.com/posit-dev/great-tables/pull/276, which uploads saved table images as artifacts in our CI.