### PR TITLE
Ensure that group label rows have valid HTML

### DIFF
--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -463,7 +463,7 @@ def create_body_component_h(data: GTData) -> str:
                     "gt_empty_group_heading" if group_label == "" else "gt_group_heading_row"
                 )
 
-                group_row = f"""  <tr class="{group_class}">
+                group_row = f"""<tr class="{group_class}">
     <th class="gt_group_heading" colspan="{colspan_value}">{group_label}</th>
   </tr>"""
 
@@ -500,14 +500,14 @@ def create_body_component_h(data: GTData) -> str:
                 cell_styles = ""
 
             if is_stub_cell:
-                body_cells.append(f"""    <th class="gt_row gt_left gt_stub">{cell_str}</th>""")
+                body_cells.append(f"""  <th class="gt_row gt_left gt_stub">{cell_str}</th>""")
             else:
                 body_cells.append(
-                    f"""    <td {cell_styles}class="gt_row gt_{cell_alignment}">{cell_str}</td>"""
+                    f"""  <td {cell_styles}class="gt_row gt_{cell_alignment}">{cell_str}</td>"""
                 )
 
         prev_group_label = group_label
-        body_rows.append("  <tr>\n" + "\n".join(body_cells) + "\n  </tr>")
+        body_rows.append("<tr>\n" + "\n".join(body_cells) + "\n</tr>")
 
     all_body_rows = "\n".join(body_rows)
 

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -463,7 +463,7 @@ def create_body_component_h(data: GTData) -> str:
                     "gt_empty_group_heading" if group_label == "" else "gt_group_heading_row"
                 )
 
-                group_row = f"""<tr class="{group_class}">
+                group_row = f"""  <tr class="{group_class}">
     <th class="gt_group_heading" colspan="{colspan_value}">{group_label}</th>
   </tr>"""
 
@@ -500,14 +500,14 @@ def create_body_component_h(data: GTData) -> str:
                 cell_styles = ""
 
             if is_stub_cell:
-                body_cells.append(f"""  <th class="gt_row gt_left gt_stub">{cell_str}</th>""")
+                body_cells.append(f"""    <th class="gt_row gt_left gt_stub">{cell_str}</th>""")
             else:
                 body_cells.append(
-                    f"""  <td {cell_styles}class="gt_row gt_{cell_alignment}">{cell_str}</td>"""
+                    f"""    <td {cell_styles}class="gt_row gt_{cell_alignment}">{cell_str}</td>"""
                 )
 
         prev_group_label = group_label
-        body_rows.append("<tr>\n" + "\n".join(body_cells) + "\n</tr>")
+        body_rows.append("  <tr>\n" + "\n".join(body_cells) + "\n  </tr>")
 
     all_body_rows = "\n".join(body_rows)
 

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -471,8 +471,6 @@ def create_body_component_h(data: GTData) -> str:
 
                 body_rows.append(group_row)
 
-                continue
-
         # Create a single cell and append result to `body_cells`
         for colinfo in column_vars:
             cell_content: Any = _get_cell(tbl_data, i, colinfo.var)

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -463,13 +463,17 @@ def create_body_component_h(data: GTData) -> str:
                     "gt_empty_group_heading" if group_label == "" else "gt_group_heading_row"
                 )
 
-                body_cells.append(
-                    f"<tr class={group_class}>"
-                    f'  <th class="gt_group_heading" colspan="{colspan_value}">'
-                    + group_label
-                    + "</th></tr>"
-                )
+                group_row = f"""  <tr class="{group_class}">
+    <th class="gt_group_heading" colspan="{colspan_value}">{group_label}</th>
+  </tr>"""
 
+                prev_group_label = group_label
+
+                body_rows.append(group_row)
+
+                continue
+
+        # Create a single cell and append result to `body_cells`
         for colinfo in column_vars:
             cell_content: Any = _get_cell(tbl_data, i, colinfo.var)
             cell_str: str = str(cell_content)
@@ -498,18 +502,20 @@ def create_body_component_h(data: GTData) -> str:
                 cell_styles = ""
 
             if is_stub_cell:
-                body_cells.append('  <th class="gt_row gt_left gt_stub">' + cell_str + "</th>")
+                body_cells.append(f"""    <th class="gt_row gt_left gt_stub">{cell_str}</th>""")
             else:
                 body_cells.append(
-                    f'  <td {cell_styles}class="gt_row gt_{cell_alignment}">' + cell_str + "</td>"
+                    f"""    <td {cell_styles}class="gt_row gt_{cell_alignment}">{cell_str}</td>"""
                 )
 
         prev_group_label = group_label
-        body_rows.append("<tr>\n" + "\n".join(body_cells) + "\n</tr>")
+        body_rows.append("  <tr>\n" + "\n".join(body_cells) + "\n  </tr>")
 
     all_body_rows = "\n".join(body_rows)
 
-    return f'<tbody class="gt_table_body">\n{all_body_rows}\n</tbody>'
+    return f"""<tbody class="gt_table_body">
+{all_body_rows}
+</tbody>"""
 
 
 def create_source_notes_component_h(data: GTData) -> str:

--- a/tests/__snapshots__/test_export.ambr
+++ b/tests/__snapshots__/test_export.ambr
@@ -64,60 +64,60 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="currency">currency</th>
   </tr>
   <tbody class="gt_table_body">
-    <tr class="gt_group_heading_row">
+  <tr class="gt_group_heading_row">
       <th class="gt_group_heading" colspan="4">grp_a</th>
     </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">row_1</th>
-      <td class="gt_row gt_right">0.11</td>
-      <td class="gt_row gt_left">apricot</td>
-      <td class="gt_row gt_right">$49.95</td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">row_2</th>
-      <td class="gt_row gt_right">2.22</td>
-      <td class="gt_row gt_left">banana</td>
-      <td class="gt_row gt_right">$17.95</td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">row_3</th>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-      <td class="gt_row gt_right">$1.39</td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">row_4</th>
-      <td class="gt_row gt_right">444.40</td>
-      <td class="gt_row gt_left">durian</td>
-      <td class="gt_row gt_right">$65,100.00</td>
-    </tr>
-    <tr class="gt_group_heading_row">
+  <tr>
+    <th class="gt_row gt_left gt_stub">row_1</th>
+    <td class="gt_row gt_right">0.11</td>
+    <td class="gt_row gt_left">apricot</td>
+    <td class="gt_row gt_right">$49.95</td>
+  </tr>
+  <tr>
+    <th class="gt_row gt_left gt_stub">row_2</th>
+    <td class="gt_row gt_right">2.22</td>
+    <td class="gt_row gt_left">banana</td>
+    <td class="gt_row gt_right">$17.95</td>
+  </tr>
+  <tr>
+    <th class="gt_row gt_left gt_stub">row_3</th>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+    <td class="gt_row gt_right">$1.39</td>
+  </tr>
+  <tr>
+    <th class="gt_row gt_left gt_stub">row_4</th>
+    <td class="gt_row gt_right">444.40</td>
+    <td class="gt_row gt_left">durian</td>
+    <td class="gt_row gt_right">$65,100.00</td>
+  </tr>
+  <tr class="gt_group_heading_row">
       <th class="gt_group_heading" colspan="4">grp_b</th>
     </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">row_5</th>
-      <td class="gt_row gt_right">5,550.00</td>
-      <td class="gt_row gt_left"><NA></td>
-      <td class="gt_row gt_right">$1,325.81</td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">row_6</th>
-      <td class="gt_row gt_right">nan</td>
-      <td class="gt_row gt_left">fig</td>
-      <td class="gt_row gt_right">$13.26</td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">row_7</th>
-      <td class="gt_row gt_right">777,000.00</td>
-      <td class="gt_row gt_left">grapefruit</td>
-      <td class="gt_row gt_right"><NA></td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">row_8</th>
-      <td class="gt_row gt_right">8,880,000.00</td>
-      <td class="gt_row gt_left">honeydew</td>
-      <td class="gt_row gt_right">$0.44</td>
-    </tr>
+  <tr>
+    <th class="gt_row gt_left gt_stub">row_5</th>
+    <td class="gt_row gt_right">5,550.00</td>
+    <td class="gt_row gt_left"><NA></td>
+    <td class="gt_row gt_right">$1,325.81</td>
+  </tr>
+  <tr>
+    <th class="gt_row gt_left gt_stub">row_6</th>
+    <td class="gt_row gt_right">nan</td>
+    <td class="gt_row gt_left">fig</td>
+    <td class="gt_row gt_right">$13.26</td>
+  </tr>
+  <tr>
+    <th class="gt_row gt_left gt_stub">row_7</th>
+    <td class="gt_row gt_right">777,000.00</td>
+    <td class="gt_row gt_left">grapefruit</td>
+    <td class="gt_row gt_right"><NA></td>
+  </tr>
+  <tr>
+    <th class="gt_row gt_left gt_stub">row_8</th>
+    <td class="gt_row gt_right">8,880,000.00</td>
+    <td class="gt_row gt_left">honeydew</td>
+    <td class="gt_row gt_right">$0.44</td>
+  </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
     

--- a/tests/__snapshots__/test_export.ambr
+++ b/tests/__snapshots__/test_export.ambr
@@ -64,60 +64,60 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="currency">currency</th>
   </tr>
   <tbody class="gt_table_body">
-  <tr class="gt_group_heading_row">
+    <tr class="gt_group_heading_row">
       <th class="gt_group_heading" colspan="4">grp_a</th>
     </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">row_1</th>
-    <td class="gt_row gt_right">0.11</td>
-    <td class="gt_row gt_left">apricot</td>
-    <td class="gt_row gt_right">$49.95</td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">row_2</th>
-    <td class="gt_row gt_right">2.22</td>
-    <td class="gt_row gt_left">banana</td>
-    <td class="gt_row gt_right">$17.95</td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">row_3</th>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-    <td class="gt_row gt_right">$1.39</td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">row_4</th>
-    <td class="gt_row gt_right">444.40</td>
-    <td class="gt_row gt_left">durian</td>
-    <td class="gt_row gt_right">$65,100.00</td>
-  </tr>
-  <tr class="gt_group_heading_row">
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_1</th>
+      <td class="gt_row gt_right">0.11</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td class="gt_row gt_right">$49.95</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_2</th>
+      <td class="gt_row gt_right">2.22</td>
+      <td class="gt_row gt_left">banana</td>
+      <td class="gt_row gt_right">$17.95</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_3</th>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td class="gt_row gt_right">$1.39</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_4</th>
+      <td class="gt_row gt_right">444.40</td>
+      <td class="gt_row gt_left">durian</td>
+      <td class="gt_row gt_right">$65,100.00</td>
+    </tr>
+    <tr class="gt_group_heading_row">
       <th class="gt_group_heading" colspan="4">grp_b</th>
     </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">row_5</th>
-    <td class="gt_row gt_right">5,550.00</td>
-    <td class="gt_row gt_left"><NA></td>
-    <td class="gt_row gt_right">$1,325.81</td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">row_6</th>
-    <td class="gt_row gt_right">nan</td>
-    <td class="gt_row gt_left">fig</td>
-    <td class="gt_row gt_right">$13.26</td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">row_7</th>
-    <td class="gt_row gt_right">777,000.00</td>
-    <td class="gt_row gt_left">grapefruit</td>
-    <td class="gt_row gt_right"><NA></td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">row_8</th>
-    <td class="gt_row gt_right">8,880,000.00</td>
-    <td class="gt_row gt_left">honeydew</td>
-    <td class="gt_row gt_right">$0.44</td>
-  </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_5</th>
+      <td class="gt_row gt_right">5,550.00</td>
+      <td class="gt_row gt_left"><NA></td>
+      <td class="gt_row gt_right">$1,325.81</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_6</th>
+      <td class="gt_row gt_right">nan</td>
+      <td class="gt_row gt_left">fig</td>
+      <td class="gt_row gt_right">$13.26</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_7</th>
+      <td class="gt_row gt_right">777,000.00</td>
+      <td class="gt_row gt_left">grapefruit</td>
+      <td class="gt_row gt_right"><NA></td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_8</th>
+      <td class="gt_row gt_right">8,880,000.00</td>
+      <td class="gt_row gt_left">honeydew</td>
+      <td class="gt_row gt_right">$0.44</td>
+    </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
     

--- a/tests/__snapshots__/test_export.ambr
+++ b/tests/__snapshots__/test_export.ambr
@@ -64,56 +64,60 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="currency">currency</th>
   </tr>
   <tbody class="gt_table_body">
-  <tr>
-  <tr class=gt_group_heading_row>  <th class="gt_group_heading" colspan="4">grp_a</th></tr>
-    <th class="gt_row gt_left gt_stub">row_1</th>
-    <td class="gt_row gt_right">0.11</td>
-    <td class="gt_row gt_left">apricot</td>
-    <td class="gt_row gt_right">$49.95</td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">row_2</th>
-    <td class="gt_row gt_right">2.22</td>
-    <td class="gt_row gt_left">banana</td>
-    <td class="gt_row gt_right">$17.95</td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">row_3</th>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-    <td class="gt_row gt_right">$1.39</td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">row_4</th>
-    <td class="gt_row gt_right">444.40</td>
-    <td class="gt_row gt_left">durian</td>
-    <td class="gt_row gt_right">$65,100.00</td>
-  </tr>
-  <tr>
-  <tr class=gt_group_heading_row>  <th class="gt_group_heading" colspan="4">grp_b</th></tr>
-    <th class="gt_row gt_left gt_stub">row_5</th>
-    <td class="gt_row gt_right">5,550.00</td>
-    <td class="gt_row gt_left"><NA></td>
-    <td class="gt_row gt_right">$1,325.81</td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">row_6</th>
-    <td class="gt_row gt_right">nan</td>
-    <td class="gt_row gt_left">fig</td>
-    <td class="gt_row gt_right">$13.26</td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">row_7</th>
-    <td class="gt_row gt_right">777,000.00</td>
-    <td class="gt_row gt_left">grapefruit</td>
-    <td class="gt_row gt_right"><NA></td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">row_8</th>
-    <td class="gt_row gt_right">8,880,000.00</td>
-    <td class="gt_row gt_left">honeydew</td>
-    <td class="gt_row gt_right">$0.44</td>
-  </tr>
+    <tr class="gt_group_heading_row">
+      <th class="gt_group_heading" colspan="4">grp_a</th>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_1</th>
+      <td class="gt_row gt_right">0.11</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td class="gt_row gt_right">$49.95</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_2</th>
+      <td class="gt_row gt_right">2.22</td>
+      <td class="gt_row gt_left">banana</td>
+      <td class="gt_row gt_right">$17.95</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_3</th>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td class="gt_row gt_right">$1.39</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_4</th>
+      <td class="gt_row gt_right">444.40</td>
+      <td class="gt_row gt_left">durian</td>
+      <td class="gt_row gt_right">$65,100.00</td>
+    </tr>
+    <tr class="gt_group_heading_row">
+      <th class="gt_group_heading" colspan="4">grp_b</th>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_5</th>
+      <td class="gt_row gt_right">5,550.00</td>
+      <td class="gt_row gt_left"><NA></td>
+      <td class="gt_row gt_right">$1,325.81</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_6</th>
+      <td class="gt_row gt_right">nan</td>
+      <td class="gt_row gt_left">fig</td>
+      <td class="gt_row gt_right">$13.26</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_7</th>
+      <td class="gt_row gt_right">777,000.00</td>
+      <td class="gt_row gt_left">grapefruit</td>
+      <td class="gt_row gt_right"><NA></td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_8</th>
+      <td class="gt_row gt_right">8,880,000.00</td>
+      <td class="gt_row gt_left">honeydew</td>
+      <td class="gt_row gt_right">$0.44</td>
+    </tr>
   </tbody>
     <tfoot class="gt_sourcenotes">
     

--- a/tests/__snapshots__/test_formats.ambr
+++ b/tests/__snapshots__/test_formats.ambr
@@ -15,94 +15,94 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="group">group</th>
   </tr>
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">1.11 × 10<sup style='font-size: 65%;'>−1</sup></td>
-    <td class="gt_row gt_left">apricot</td>
-    <td class="gt_row gt_left">one</td>
-    <td class="gt_row gt_right">15 January 2015</td>
-    <td class="gt_row gt_right">13:35</td>
-    <td class="gt_row gt_right">2018-01-01 02:22</td>
-    <td class="gt_row gt_right">$49.95</td>
-    <td class="gt_row gt_left">row_1</td>
-    <td class="gt_row gt_left">grp_a</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.22</td>
-    <td class="gt_row gt_left">banana</td>
-    <td class="gt_row gt_left">two</td>
-    <td class="gt_row gt_right">15 February 2015</td>
-    <td class="gt_row gt_right">14:40</td>
-    <td class="gt_row gt_right">2018-02-02 14:33</td>
-    <td class="gt_row gt_right">$17.95</td>
-    <td class="gt_row gt_left">row_2</td>
-    <td class="gt_row gt_left">grp_a</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">3.33 × 10<sup style='font-size: 65%;'>1</sup></td>
-    <td class="gt_row gt_left">coconut</td>
-    <td class="gt_row gt_left">three</td>
-    <td class="gt_row gt_right">15 March 2015</td>
-    <td class="gt_row gt_right">15:45</td>
-    <td class="gt_row gt_right">2018-03-03 03:44</td>
-    <td class="gt_row gt_right">$1.39</td>
-    <td class="gt_row gt_left">row_3</td>
-    <td class="gt_row gt_left">grp_a</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">4.44 × 10<sup style='font-size: 65%;'>2</sup></td>
-    <td class="gt_row gt_left">durian</td>
-    <td class="gt_row gt_left">four</td>
-    <td class="gt_row gt_right">15 April 2015</td>
-    <td class="gt_row gt_right">16:50</td>
-    <td class="gt_row gt_right">2018-04-04 15:55</td>
-    <td class="gt_row gt_right">$65,100.00</td>
-    <td class="gt_row gt_left">row_4</td>
-    <td class="gt_row gt_left">grp_a</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">5.55 × 10<sup style='font-size: 65%;'>3</sup></td>
-    <td class="gt_row gt_left"><NA></td>
-    <td class="gt_row gt_left">five</td>
-    <td class="gt_row gt_right">15 May 2015</td>
-    <td class="gt_row gt_right">17:55</td>
-    <td class="gt_row gt_right">2018-05-05 04:00</td>
-    <td class="gt_row gt_right">$1,325.81</td>
-    <td class="gt_row gt_left">row_5</td>
-    <td class="gt_row gt_left">grp_b</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_left">fig</td>
-    <td class="gt_row gt_left">six</td>
-    <td class="gt_row gt_right">15 June 2015</td>
-    <td class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_right">2018-06-06 16:11</td>
-    <td class="gt_row gt_right">$13.26</td>
-    <td class="gt_row gt_left">row_6</td>
-    <td class="gt_row gt_left">grp_b</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">7.77 × 10<sup style='font-size: 65%;'>5</sup></td>
-    <td class="gt_row gt_left">grapefruit</td>
-    <td class="gt_row gt_left">seven</td>
-    <td class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_right">19:10</td>
-    <td class="gt_row gt_right">2018-07-07 05:22</td>
-    <td class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_left">row_7</td>
-    <td class="gt_row gt_left">grp_b</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">8.88 × 10<sup style='font-size: 65%;'>6</sup></td>
-    <td class="gt_row gt_left">honeydew</td>
-    <td class="gt_row gt_left">eight</td>
-    <td class="gt_row gt_right">15 August 2015</td>
-    <td class="gt_row gt_right">20:20</td>
-    <td class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_right">$0.44</td>
-    <td class="gt_row gt_left">row_8</td>
-    <td class="gt_row gt_left">grp_b</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">1.11 × 10<sup style='font-size: 65%;'>−1</sup></td>
+      <td class="gt_row gt_left">apricot</td>
+      <td class="gt_row gt_left">one</td>
+      <td class="gt_row gt_right">15 January 2015</td>
+      <td class="gt_row gt_right">13:35</td>
+      <td class="gt_row gt_right">2018-01-01 02:22</td>
+      <td class="gt_row gt_right">$49.95</td>
+      <td class="gt_row gt_left">row_1</td>
+      <td class="gt_row gt_left">grp_a</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.22</td>
+      <td class="gt_row gt_left">banana</td>
+      <td class="gt_row gt_left">two</td>
+      <td class="gt_row gt_right">15 February 2015</td>
+      <td class="gt_row gt_right">14:40</td>
+      <td class="gt_row gt_right">2018-02-02 14:33</td>
+      <td class="gt_row gt_right">$17.95</td>
+      <td class="gt_row gt_left">row_2</td>
+      <td class="gt_row gt_left">grp_a</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">3.33 × 10<sup style='font-size: 65%;'>1</sup></td>
+      <td class="gt_row gt_left">coconut</td>
+      <td class="gt_row gt_left">three</td>
+      <td class="gt_row gt_right">15 March 2015</td>
+      <td class="gt_row gt_right">15:45</td>
+      <td class="gt_row gt_right">2018-03-03 03:44</td>
+      <td class="gt_row gt_right">$1.39</td>
+      <td class="gt_row gt_left">row_3</td>
+      <td class="gt_row gt_left">grp_a</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">4.44 × 10<sup style='font-size: 65%;'>2</sup></td>
+      <td class="gt_row gt_left">durian</td>
+      <td class="gt_row gt_left">four</td>
+      <td class="gt_row gt_right">15 April 2015</td>
+      <td class="gt_row gt_right">16:50</td>
+      <td class="gt_row gt_right">2018-04-04 15:55</td>
+      <td class="gt_row gt_right">$65,100.00</td>
+      <td class="gt_row gt_left">row_4</td>
+      <td class="gt_row gt_left">grp_a</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">5.55 × 10<sup style='font-size: 65%;'>3</sup></td>
+      <td class="gt_row gt_left"><NA></td>
+      <td class="gt_row gt_left">five</td>
+      <td class="gt_row gt_right">15 May 2015</td>
+      <td class="gt_row gt_right">17:55</td>
+      <td class="gt_row gt_right">2018-05-05 04:00</td>
+      <td class="gt_row gt_right">$1,325.81</td>
+      <td class="gt_row gt_left">row_5</td>
+      <td class="gt_row gt_left">grp_b</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_left">fig</td>
+      <td class="gt_row gt_left">six</td>
+      <td class="gt_row gt_right">15 June 2015</td>
+      <td class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_right">2018-06-06 16:11</td>
+      <td class="gt_row gt_right">$13.26</td>
+      <td class="gt_row gt_left">row_6</td>
+      <td class="gt_row gt_left">grp_b</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">7.77 × 10<sup style='font-size: 65%;'>5</sup></td>
+      <td class="gt_row gt_left">grapefruit</td>
+      <td class="gt_row gt_left">seven</td>
+      <td class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_right">19:10</td>
+      <td class="gt_row gt_right">2018-07-07 05:22</td>
+      <td class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_left">row_7</td>
+      <td class="gt_row gt_left">grp_b</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">8.88 × 10<sup style='font-size: 65%;'>6</sup></td>
+      <td class="gt_row gt_left">honeydew</td>
+      <td class="gt_row gt_left">eight</td>
+      <td class="gt_row gt_right">15 August 2015</td>
+      <td class="gt_row gt_right">20:20</td>
+      <td class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_right">$0.44</td>
+      <td class="gt_row gt_left">row_8</td>
+      <td class="gt_row gt_left">grp_b</td>
+    </tr>
   </tbody>
   
   
@@ -112,94 +112,94 @@
 # name: test_format_snap
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">1.11 × 10<sup style='font-size: 65%;'>−1</sup></td>
-    <td class="gt_row gt_left">apricot</td>
-    <td class="gt_row gt_left">one</td>
-    <td class="gt_row gt_right">15 January 2015</td>
-    <td class="gt_row gt_right">13:35</td>
-    <td class="gt_row gt_right">2018-01-01 02:22</td>
-    <td class="gt_row gt_right">$49.95</td>
-    <td class="gt_row gt_left">row_1</td>
-    <td class="gt_row gt_left">grp_a</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.22</td>
-    <td class="gt_row gt_left">banana</td>
-    <td class="gt_row gt_left">two</td>
-    <td class="gt_row gt_right">15 February 2015</td>
-    <td class="gt_row gt_right">14:40</td>
-    <td class="gt_row gt_right">2018-02-02 14:33</td>
-    <td class="gt_row gt_right">$17.95</td>
-    <td class="gt_row gt_left">row_2</td>
-    <td class="gt_row gt_left">grp_a</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">3.33 × 10<sup style='font-size: 65%;'>1</sup></td>
-    <td class="gt_row gt_left">coconut</td>
-    <td class="gt_row gt_left">three</td>
-    <td class="gt_row gt_right">15 March 2015</td>
-    <td class="gt_row gt_right">15:45</td>
-    <td class="gt_row gt_right">2018-03-03 03:44</td>
-    <td class="gt_row gt_right">$1.39</td>
-    <td class="gt_row gt_left">row_3</td>
-    <td class="gt_row gt_left">grp_a</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">4.44 × 10<sup style='font-size: 65%;'>2</sup></td>
-    <td class="gt_row gt_left">durian</td>
-    <td class="gt_row gt_left">four</td>
-    <td class="gt_row gt_right">15 April 2015</td>
-    <td class="gt_row gt_right">16:50</td>
-    <td class="gt_row gt_right">2018-04-04 15:55</td>
-    <td class="gt_row gt_right">$65,100.00</td>
-    <td class="gt_row gt_left">row_4</td>
-    <td class="gt_row gt_left">grp_a</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">5.55 × 10<sup style='font-size: 65%;'>3</sup></td>
-    <td class="gt_row gt_left"><NA></td>
-    <td class="gt_row gt_left">five</td>
-    <td class="gt_row gt_right">15 May 2015</td>
-    <td class="gt_row gt_right">17:55</td>
-    <td class="gt_row gt_right">2018-05-05 04:00</td>
-    <td class="gt_row gt_right">$1,325.81</td>
-    <td class="gt_row gt_left">row_5</td>
-    <td class="gt_row gt_left">grp_b</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_left">fig</td>
-    <td class="gt_row gt_left">six</td>
-    <td class="gt_row gt_right">15 June 2015</td>
-    <td class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_right">2018-06-06 16:11</td>
-    <td class="gt_row gt_right">$13.26</td>
-    <td class="gt_row gt_left">row_6</td>
-    <td class="gt_row gt_left">grp_b</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">7.77 × 10<sup style='font-size: 65%;'>5</sup></td>
-    <td class="gt_row gt_left">grapefruit</td>
-    <td class="gt_row gt_left">seven</td>
-    <td class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_right">19:10</td>
-    <td class="gt_row gt_right">2018-07-07 05:22</td>
-    <td class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_left">row_7</td>
-    <td class="gt_row gt_left">grp_b</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">8.88 × 10<sup style='font-size: 65%;'>6</sup></td>
-    <td class="gt_row gt_left">honeydew</td>
-    <td class="gt_row gt_left">eight</td>
-    <td class="gt_row gt_right">15 August 2015</td>
-    <td class="gt_row gt_right">20:20</td>
-    <td class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_right">$0.44</td>
-    <td class="gt_row gt_left">row_8</td>
-    <td class="gt_row gt_left">grp_b</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">1.11 × 10<sup style='font-size: 65%;'>−1</sup></td>
+      <td class="gt_row gt_left">apricot</td>
+      <td class="gt_row gt_left">one</td>
+      <td class="gt_row gt_right">15 January 2015</td>
+      <td class="gt_row gt_right">13:35</td>
+      <td class="gt_row gt_right">2018-01-01 02:22</td>
+      <td class="gt_row gt_right">$49.95</td>
+      <td class="gt_row gt_left">row_1</td>
+      <td class="gt_row gt_left">grp_a</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.22</td>
+      <td class="gt_row gt_left">banana</td>
+      <td class="gt_row gt_left">two</td>
+      <td class="gt_row gt_right">15 February 2015</td>
+      <td class="gt_row gt_right">14:40</td>
+      <td class="gt_row gt_right">2018-02-02 14:33</td>
+      <td class="gt_row gt_right">$17.95</td>
+      <td class="gt_row gt_left">row_2</td>
+      <td class="gt_row gt_left">grp_a</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">3.33 × 10<sup style='font-size: 65%;'>1</sup></td>
+      <td class="gt_row gt_left">coconut</td>
+      <td class="gt_row gt_left">three</td>
+      <td class="gt_row gt_right">15 March 2015</td>
+      <td class="gt_row gt_right">15:45</td>
+      <td class="gt_row gt_right">2018-03-03 03:44</td>
+      <td class="gt_row gt_right">$1.39</td>
+      <td class="gt_row gt_left">row_3</td>
+      <td class="gt_row gt_left">grp_a</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">4.44 × 10<sup style='font-size: 65%;'>2</sup></td>
+      <td class="gt_row gt_left">durian</td>
+      <td class="gt_row gt_left">four</td>
+      <td class="gt_row gt_right">15 April 2015</td>
+      <td class="gt_row gt_right">16:50</td>
+      <td class="gt_row gt_right">2018-04-04 15:55</td>
+      <td class="gt_row gt_right">$65,100.00</td>
+      <td class="gt_row gt_left">row_4</td>
+      <td class="gt_row gt_left">grp_a</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">5.55 × 10<sup style='font-size: 65%;'>3</sup></td>
+      <td class="gt_row gt_left"><NA></td>
+      <td class="gt_row gt_left">five</td>
+      <td class="gt_row gt_right">15 May 2015</td>
+      <td class="gt_row gt_right">17:55</td>
+      <td class="gt_row gt_right">2018-05-05 04:00</td>
+      <td class="gt_row gt_right">$1,325.81</td>
+      <td class="gt_row gt_left">row_5</td>
+      <td class="gt_row gt_left">grp_b</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_left">fig</td>
+      <td class="gt_row gt_left">six</td>
+      <td class="gt_row gt_right">15 June 2015</td>
+      <td class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_right">2018-06-06 16:11</td>
+      <td class="gt_row gt_right">$13.26</td>
+      <td class="gt_row gt_left">row_6</td>
+      <td class="gt_row gt_left">grp_b</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">7.77 × 10<sup style='font-size: 65%;'>5</sup></td>
+      <td class="gt_row gt_left">grapefruit</td>
+      <td class="gt_row gt_left">seven</td>
+      <td class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_right">19:10</td>
+      <td class="gt_row gt_right">2018-07-07 05:22</td>
+      <td class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_left">row_7</td>
+      <td class="gt_row gt_left">grp_b</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">8.88 × 10<sup style='font-size: 65%;'>6</sup></td>
+      <td class="gt_row gt_left">honeydew</td>
+      <td class="gt_row gt_left">eight</td>
+      <td class="gt_row gt_right">15 August 2015</td>
+      <td class="gt_row gt_right">20:20</td>
+      <td class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_right">$0.44</td>
+      <td class="gt_row gt_left">row_8</td>
+      <td class="gt_row gt_left">grp_b</td>
+    </tr>
   </tbody>
   '''
 # ---

--- a/tests/__snapshots__/test_formats.ambr
+++ b/tests/__snapshots__/test_formats.ambr
@@ -15,94 +15,94 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="group">group</th>
   </tr>
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">1.11 × 10<sup style='font-size: 65%;'>−1</sup></td>
-      <td class="gt_row gt_left">apricot</td>
-      <td class="gt_row gt_left">one</td>
-      <td class="gt_row gt_right">15 January 2015</td>
-      <td class="gt_row gt_right">13:35</td>
-      <td class="gt_row gt_right">2018-01-01 02:22</td>
-      <td class="gt_row gt_right">$49.95</td>
-      <td class="gt_row gt_left">row_1</td>
-      <td class="gt_row gt_left">grp_a</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.22</td>
-      <td class="gt_row gt_left">banana</td>
-      <td class="gt_row gt_left">two</td>
-      <td class="gt_row gt_right">15 February 2015</td>
-      <td class="gt_row gt_right">14:40</td>
-      <td class="gt_row gt_right">2018-02-02 14:33</td>
-      <td class="gt_row gt_right">$17.95</td>
-      <td class="gt_row gt_left">row_2</td>
-      <td class="gt_row gt_left">grp_a</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">3.33 × 10<sup style='font-size: 65%;'>1</sup></td>
-      <td class="gt_row gt_left">coconut</td>
-      <td class="gt_row gt_left">three</td>
-      <td class="gt_row gt_right">15 March 2015</td>
-      <td class="gt_row gt_right">15:45</td>
-      <td class="gt_row gt_right">2018-03-03 03:44</td>
-      <td class="gt_row gt_right">$1.39</td>
-      <td class="gt_row gt_left">row_3</td>
-      <td class="gt_row gt_left">grp_a</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">4.44 × 10<sup style='font-size: 65%;'>2</sup></td>
-      <td class="gt_row gt_left">durian</td>
-      <td class="gt_row gt_left">four</td>
-      <td class="gt_row gt_right">15 April 2015</td>
-      <td class="gt_row gt_right">16:50</td>
-      <td class="gt_row gt_right">2018-04-04 15:55</td>
-      <td class="gt_row gt_right">$65,100.00</td>
-      <td class="gt_row gt_left">row_4</td>
-      <td class="gt_row gt_left">grp_a</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">5.55 × 10<sup style='font-size: 65%;'>3</sup></td>
-      <td class="gt_row gt_left"><NA></td>
-      <td class="gt_row gt_left">five</td>
-      <td class="gt_row gt_right">15 May 2015</td>
-      <td class="gt_row gt_right">17:55</td>
-      <td class="gt_row gt_right">2018-05-05 04:00</td>
-      <td class="gt_row gt_right">$1,325.81</td>
-      <td class="gt_row gt_left">row_5</td>
-      <td class="gt_row gt_left">grp_b</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_left">fig</td>
-      <td class="gt_row gt_left">six</td>
-      <td class="gt_row gt_right">15 June 2015</td>
-      <td class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_right">2018-06-06 16:11</td>
-      <td class="gt_row gt_right">$13.26</td>
-      <td class="gt_row gt_left">row_6</td>
-      <td class="gt_row gt_left">grp_b</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">7.77 × 10<sup style='font-size: 65%;'>5</sup></td>
-      <td class="gt_row gt_left">grapefruit</td>
-      <td class="gt_row gt_left">seven</td>
-      <td class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_right">19:10</td>
-      <td class="gt_row gt_right">2018-07-07 05:22</td>
-      <td class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_left">row_7</td>
-      <td class="gt_row gt_left">grp_b</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">8.88 × 10<sup style='font-size: 65%;'>6</sup></td>
-      <td class="gt_row gt_left">honeydew</td>
-      <td class="gt_row gt_left">eight</td>
-      <td class="gt_row gt_right">15 August 2015</td>
-      <td class="gt_row gt_right">20:20</td>
-      <td class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_right">$0.44</td>
-      <td class="gt_row gt_left">row_8</td>
-      <td class="gt_row gt_left">grp_b</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">1.11 × 10<sup style='font-size: 65%;'>−1</sup></td>
+    <td class="gt_row gt_left">apricot</td>
+    <td class="gt_row gt_left">one</td>
+    <td class="gt_row gt_right">15 January 2015</td>
+    <td class="gt_row gt_right">13:35</td>
+    <td class="gt_row gt_right">2018-01-01 02:22</td>
+    <td class="gt_row gt_right">$49.95</td>
+    <td class="gt_row gt_left">row_1</td>
+    <td class="gt_row gt_left">grp_a</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.22</td>
+    <td class="gt_row gt_left">banana</td>
+    <td class="gt_row gt_left">two</td>
+    <td class="gt_row gt_right">15 February 2015</td>
+    <td class="gt_row gt_right">14:40</td>
+    <td class="gt_row gt_right">2018-02-02 14:33</td>
+    <td class="gt_row gt_right">$17.95</td>
+    <td class="gt_row gt_left">row_2</td>
+    <td class="gt_row gt_left">grp_a</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">3.33 × 10<sup style='font-size: 65%;'>1</sup></td>
+    <td class="gt_row gt_left">coconut</td>
+    <td class="gt_row gt_left">three</td>
+    <td class="gt_row gt_right">15 March 2015</td>
+    <td class="gt_row gt_right">15:45</td>
+    <td class="gt_row gt_right">2018-03-03 03:44</td>
+    <td class="gt_row gt_right">$1.39</td>
+    <td class="gt_row gt_left">row_3</td>
+    <td class="gt_row gt_left">grp_a</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">4.44 × 10<sup style='font-size: 65%;'>2</sup></td>
+    <td class="gt_row gt_left">durian</td>
+    <td class="gt_row gt_left">four</td>
+    <td class="gt_row gt_right">15 April 2015</td>
+    <td class="gt_row gt_right">16:50</td>
+    <td class="gt_row gt_right">2018-04-04 15:55</td>
+    <td class="gt_row gt_right">$65,100.00</td>
+    <td class="gt_row gt_left">row_4</td>
+    <td class="gt_row gt_left">grp_a</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">5.55 × 10<sup style='font-size: 65%;'>3</sup></td>
+    <td class="gt_row gt_left"><NA></td>
+    <td class="gt_row gt_left">five</td>
+    <td class="gt_row gt_right">15 May 2015</td>
+    <td class="gt_row gt_right">17:55</td>
+    <td class="gt_row gt_right">2018-05-05 04:00</td>
+    <td class="gt_row gt_right">$1,325.81</td>
+    <td class="gt_row gt_left">row_5</td>
+    <td class="gt_row gt_left">grp_b</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_left">fig</td>
+    <td class="gt_row gt_left">six</td>
+    <td class="gt_row gt_right">15 June 2015</td>
+    <td class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">2018-06-06 16:11</td>
+    <td class="gt_row gt_right">$13.26</td>
+    <td class="gt_row gt_left">row_6</td>
+    <td class="gt_row gt_left">grp_b</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">7.77 × 10<sup style='font-size: 65%;'>5</sup></td>
+    <td class="gt_row gt_left">grapefruit</td>
+    <td class="gt_row gt_left">seven</td>
+    <td class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">19:10</td>
+    <td class="gt_row gt_right">2018-07-07 05:22</td>
+    <td class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_left">row_7</td>
+    <td class="gt_row gt_left">grp_b</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">8.88 × 10<sup style='font-size: 65%;'>6</sup></td>
+    <td class="gt_row gt_left">honeydew</td>
+    <td class="gt_row gt_left">eight</td>
+    <td class="gt_row gt_right">15 August 2015</td>
+    <td class="gt_row gt_right">20:20</td>
+    <td class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">$0.44</td>
+    <td class="gt_row gt_left">row_8</td>
+    <td class="gt_row gt_left">grp_b</td>
+  </tr>
   </tbody>
   
   
@@ -112,94 +112,94 @@
 # name: test_format_snap
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">1.11 × 10<sup style='font-size: 65%;'>−1</sup></td>
-      <td class="gt_row gt_left">apricot</td>
-      <td class="gt_row gt_left">one</td>
-      <td class="gt_row gt_right">15 January 2015</td>
-      <td class="gt_row gt_right">13:35</td>
-      <td class="gt_row gt_right">2018-01-01 02:22</td>
-      <td class="gt_row gt_right">$49.95</td>
-      <td class="gt_row gt_left">row_1</td>
-      <td class="gt_row gt_left">grp_a</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.22</td>
-      <td class="gt_row gt_left">banana</td>
-      <td class="gt_row gt_left">two</td>
-      <td class="gt_row gt_right">15 February 2015</td>
-      <td class="gt_row gt_right">14:40</td>
-      <td class="gt_row gt_right">2018-02-02 14:33</td>
-      <td class="gt_row gt_right">$17.95</td>
-      <td class="gt_row gt_left">row_2</td>
-      <td class="gt_row gt_left">grp_a</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">3.33 × 10<sup style='font-size: 65%;'>1</sup></td>
-      <td class="gt_row gt_left">coconut</td>
-      <td class="gt_row gt_left">three</td>
-      <td class="gt_row gt_right">15 March 2015</td>
-      <td class="gt_row gt_right">15:45</td>
-      <td class="gt_row gt_right">2018-03-03 03:44</td>
-      <td class="gt_row gt_right">$1.39</td>
-      <td class="gt_row gt_left">row_3</td>
-      <td class="gt_row gt_left">grp_a</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">4.44 × 10<sup style='font-size: 65%;'>2</sup></td>
-      <td class="gt_row gt_left">durian</td>
-      <td class="gt_row gt_left">four</td>
-      <td class="gt_row gt_right">15 April 2015</td>
-      <td class="gt_row gt_right">16:50</td>
-      <td class="gt_row gt_right">2018-04-04 15:55</td>
-      <td class="gt_row gt_right">$65,100.00</td>
-      <td class="gt_row gt_left">row_4</td>
-      <td class="gt_row gt_left">grp_a</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">5.55 × 10<sup style='font-size: 65%;'>3</sup></td>
-      <td class="gt_row gt_left"><NA></td>
-      <td class="gt_row gt_left">five</td>
-      <td class="gt_row gt_right">15 May 2015</td>
-      <td class="gt_row gt_right">17:55</td>
-      <td class="gt_row gt_right">2018-05-05 04:00</td>
-      <td class="gt_row gt_right">$1,325.81</td>
-      <td class="gt_row gt_left">row_5</td>
-      <td class="gt_row gt_left">grp_b</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_left">fig</td>
-      <td class="gt_row gt_left">six</td>
-      <td class="gt_row gt_right">15 June 2015</td>
-      <td class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_right">2018-06-06 16:11</td>
-      <td class="gt_row gt_right">$13.26</td>
-      <td class="gt_row gt_left">row_6</td>
-      <td class="gt_row gt_left">grp_b</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">7.77 × 10<sup style='font-size: 65%;'>5</sup></td>
-      <td class="gt_row gt_left">grapefruit</td>
-      <td class="gt_row gt_left">seven</td>
-      <td class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_right">19:10</td>
-      <td class="gt_row gt_right">2018-07-07 05:22</td>
-      <td class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_left">row_7</td>
-      <td class="gt_row gt_left">grp_b</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">8.88 × 10<sup style='font-size: 65%;'>6</sup></td>
-      <td class="gt_row gt_left">honeydew</td>
-      <td class="gt_row gt_left">eight</td>
-      <td class="gt_row gt_right">15 August 2015</td>
-      <td class="gt_row gt_right">20:20</td>
-      <td class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_right">$0.44</td>
-      <td class="gt_row gt_left">row_8</td>
-      <td class="gt_row gt_left">grp_b</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">1.11 × 10<sup style='font-size: 65%;'>−1</sup></td>
+    <td class="gt_row gt_left">apricot</td>
+    <td class="gt_row gt_left">one</td>
+    <td class="gt_row gt_right">15 January 2015</td>
+    <td class="gt_row gt_right">13:35</td>
+    <td class="gt_row gt_right">2018-01-01 02:22</td>
+    <td class="gt_row gt_right">$49.95</td>
+    <td class="gt_row gt_left">row_1</td>
+    <td class="gt_row gt_left">grp_a</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.22</td>
+    <td class="gt_row gt_left">banana</td>
+    <td class="gt_row gt_left">two</td>
+    <td class="gt_row gt_right">15 February 2015</td>
+    <td class="gt_row gt_right">14:40</td>
+    <td class="gt_row gt_right">2018-02-02 14:33</td>
+    <td class="gt_row gt_right">$17.95</td>
+    <td class="gt_row gt_left">row_2</td>
+    <td class="gt_row gt_left">grp_a</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">3.33 × 10<sup style='font-size: 65%;'>1</sup></td>
+    <td class="gt_row gt_left">coconut</td>
+    <td class="gt_row gt_left">three</td>
+    <td class="gt_row gt_right">15 March 2015</td>
+    <td class="gt_row gt_right">15:45</td>
+    <td class="gt_row gt_right">2018-03-03 03:44</td>
+    <td class="gt_row gt_right">$1.39</td>
+    <td class="gt_row gt_left">row_3</td>
+    <td class="gt_row gt_left">grp_a</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">4.44 × 10<sup style='font-size: 65%;'>2</sup></td>
+    <td class="gt_row gt_left">durian</td>
+    <td class="gt_row gt_left">four</td>
+    <td class="gt_row gt_right">15 April 2015</td>
+    <td class="gt_row gt_right">16:50</td>
+    <td class="gt_row gt_right">2018-04-04 15:55</td>
+    <td class="gt_row gt_right">$65,100.00</td>
+    <td class="gt_row gt_left">row_4</td>
+    <td class="gt_row gt_left">grp_a</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">5.55 × 10<sup style='font-size: 65%;'>3</sup></td>
+    <td class="gt_row gt_left"><NA></td>
+    <td class="gt_row gt_left">five</td>
+    <td class="gt_row gt_right">15 May 2015</td>
+    <td class="gt_row gt_right">17:55</td>
+    <td class="gt_row gt_right">2018-05-05 04:00</td>
+    <td class="gt_row gt_right">$1,325.81</td>
+    <td class="gt_row gt_left">row_5</td>
+    <td class="gt_row gt_left">grp_b</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_left">fig</td>
+    <td class="gt_row gt_left">six</td>
+    <td class="gt_row gt_right">15 June 2015</td>
+    <td class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">2018-06-06 16:11</td>
+    <td class="gt_row gt_right">$13.26</td>
+    <td class="gt_row gt_left">row_6</td>
+    <td class="gt_row gt_left">grp_b</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">7.77 × 10<sup style='font-size: 65%;'>5</sup></td>
+    <td class="gt_row gt_left">grapefruit</td>
+    <td class="gt_row gt_left">seven</td>
+    <td class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">19:10</td>
+    <td class="gt_row gt_right">2018-07-07 05:22</td>
+    <td class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_left">row_7</td>
+    <td class="gt_row gt_left">grp_b</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">8.88 × 10<sup style='font-size: 65%;'>6</sup></td>
+    <td class="gt_row gt_left">honeydew</td>
+    <td class="gt_row gt_left">eight</td>
+    <td class="gt_row gt_right">15 August 2015</td>
+    <td class="gt_row gt_right">20:20</td>
+    <td class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">$0.44</td>
+    <td class="gt_row gt_left">row_8</td>
+    <td class="gt_row gt_left">grp_b</td>
+  </tr>
   </tbody>
   '''
 # ---

--- a/tests/__snapshots__/test_repr.ambr
+++ b/tests/__snapshots__/test_repr.ambr
@@ -55,14 +55,14 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="y">y</th>
   </tr>
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">1</td>
-      <td class="gt_row gt_right">4</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2</td>
-      <td class="gt_row gt_right">5</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">1</td>
+    <td class="gt_row gt_right">4</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2</td>
+    <td class="gt_row gt_right">5</td>
+  </tr>
   </tbody>
   
   
@@ -128,14 +128,14 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="y">y</th>
   </tr>
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">1</td>
-      <td class="gt_row gt_right">4</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2</td>
-      <td class="gt_row gt_right">5</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">1</td>
+    <td class="gt_row gt_right">4</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2</td>
+    <td class="gt_row gt_right">5</td>
+  </tr>
   </tbody>
   
   
@@ -201,14 +201,14 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="y">y</th>
   </tr>
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">1</td>
-      <td class="gt_row gt_right">4</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2</td>
-      <td class="gt_row gt_right">5</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">1</td>
+    <td class="gt_row gt_right">4</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2</td>
+    <td class="gt_row gt_right">5</td>
+  </tr>
   </tbody>
   
   
@@ -274,14 +274,14 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="y">y</th>
   </tr>
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">1</td>
-      <td class="gt_row gt_right">4</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2</td>
-      <td class="gt_row gt_right">5</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">1</td>
+    <td class="gt_row gt_right">4</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2</td>
+    <td class="gt_row gt_right">5</td>
+  </tr>
   </tbody>
   
   

--- a/tests/__snapshots__/test_repr.ambr
+++ b/tests/__snapshots__/test_repr.ambr
@@ -55,14 +55,14 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="y">y</th>
   </tr>
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">1</td>
-    <td class="gt_row gt_right">4</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2</td>
-    <td class="gt_row gt_right">5</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">1</td>
+      <td class="gt_row gt_right">4</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2</td>
+      <td class="gt_row gt_right">5</td>
+    </tr>
   </tbody>
   
   
@@ -128,14 +128,14 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="y">y</th>
   </tr>
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">1</td>
-    <td class="gt_row gt_right">4</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2</td>
-    <td class="gt_row gt_right">5</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">1</td>
+      <td class="gt_row gt_right">4</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2</td>
+      <td class="gt_row gt_right">5</td>
+    </tr>
   </tbody>
   
   
@@ -201,14 +201,14 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="y">y</th>
   </tr>
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">1</td>
-    <td class="gt_row gt_right">4</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2</td>
-    <td class="gt_row gt_right">5</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">1</td>
+      <td class="gt_row gt_right">4</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2</td>
+      <td class="gt_row gt_right">5</td>
+    </tr>
   </tbody>
   
   
@@ -274,14 +274,14 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="y">y</th>
   </tr>
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">1</td>
-    <td class="gt_row gt_right">4</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2</td>
-    <td class="gt_row gt_right">5</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">1</td>
+      <td class="gt_row gt_right">4</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2</td>
+      <td class="gt_row gt_right">5</td>
+    </tr>
   </tbody>
   
   

--- a/tests/__snapshots__/test_utils_render_html.ambr
+++ b/tests/__snapshots__/test_utils_render_html.ambr
@@ -2,64 +2,64 @@
 # name: test_body_multiple_locations
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="background-color: red;" class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td style="background-color: red;" class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td style="background-color: red;" class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td style="background-color: red;" class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td style="background-color: red;" class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td style="background-color: red;" class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_body_multiple_styles
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="background-color: red; border-left: 1px solid #000000;" class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td style="background-color: red; border-left: 1px solid #000000;" class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_render_groups_reordered
   '''
   <tbody class="gt_table_body">
-  <tr class="gt_group_heading_row">
+    <tr class="gt_group_heading_row">
       <th class="gt_group_heading" colspan="2">A</th>
     </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">0</th>
-    <td class="gt_row gt_right">00</td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">2</th>
-    <td class="gt_row gt_right">22</td>
-  </tr>
-  <tr class="gt_group_heading_row">
+    <tr>
+      <th class="gt_row gt_left gt_stub">0</th>
+      <td class="gt_row gt_right">00</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">2</th>
+      <td class="gt_row gt_right">22</td>
+    </tr>
+    <tr class="gt_group_heading_row">
       <th class="gt_group_heading" colspan="2">B</th>
     </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">1</th>
-    <td class="gt_row gt_right">11</td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">3</th>
-    <td class="gt_row gt_right">33</td>
-  </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">1</th>
+      <td class="gt_row gt_right">11</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">3</th>
+      <td class="gt_row gt_right">33</td>
+    </tr>
   </tbody>
   '''
 # ---
@@ -92,180 +92,180 @@
 # name: test_styling_data_01
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: red;" class="gt_row gt_right">0.1111</td>
-    <td style="color: red;" class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td style="color: red;" class="gt_row gt_right">2.222</td>
-    <td style="color: red;" class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td style="color: red;" class="gt_row gt_right">33.33</td>
-    <td style="color: red;" class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td style="color: red;" class="gt_row gt_right">0.1111</td>
+      <td style="color: red;" class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td style="color: red;" class="gt_row gt_right">2.222</td>
+      <td style="color: red;" class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td style="color: red;" class="gt_row gt_right">33.33</td>
+      <td style="color: red;" class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_02
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td style="color: red;" class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td style="color: red;" class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td style="color: red;" class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td style="color: red;" class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td style="color: red;" class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td style="color: red;" class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_03
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td style="color: red;" class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td style="color: red;" class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td style="color: red;" class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td style="color: red;" class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_04
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_05
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_06
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_07
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td style="border-left: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td style="border-left: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_08
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td style="border-left: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td style="border-left: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_09
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td style="border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td style="border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td style="border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td style="border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_10
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td style="border-top: 1px solid #000000;border-bottom: 1px solid #000000;border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td style="border-top: 1px solid #000000;border-bottom: 1px solid #000000;border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td style="border-top: 1px solid #000000;border-bottom: 1px solid #000000;border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td style="border-top: 1px solid #000000;border-bottom: 1px solid #000000;border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---

--- a/tests/__snapshots__/test_utils_render_html.ambr
+++ b/tests/__snapshots__/test_utils_render_html.ambr
@@ -2,64 +2,64 @@
 # name: test_body_multiple_locations
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="background-color: red;" class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td style="background-color: red;" class="gt_row gt_left">banana</td>
-    </tr>
-    <tr>
-      <td style="background-color: red;" class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-    </tr>
+  <tr>
+    <td style="background-color: red;" class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td style="background-color: red;" class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td style="background-color: red;" class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_body_multiple_styles
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="background-color: red; border-left: 1px solid #000000;" class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-    </tr>
+  <tr>
+    <td style="background-color: red; border-left: 1px solid #000000;" class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_render_groups_reordered
   '''
   <tbody class="gt_table_body">
-    <tr class="gt_group_heading_row">
+  <tr class="gt_group_heading_row">
       <th class="gt_group_heading" colspan="2">A</th>
     </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">0</th>
-      <td class="gt_row gt_right">00</td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">2</th>
-      <td class="gt_row gt_right">22</td>
-    </tr>
-    <tr class="gt_group_heading_row">
+  <tr>
+    <th class="gt_row gt_left gt_stub">0</th>
+    <td class="gt_row gt_right">00</td>
+  </tr>
+  <tr>
+    <th class="gt_row gt_left gt_stub">2</th>
+    <td class="gt_row gt_right">22</td>
+  </tr>
+  <tr class="gt_group_heading_row">
       <th class="gt_group_heading" colspan="2">B</th>
     </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">1</th>
-      <td class="gt_row gt_right">11</td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">3</th>
-      <td class="gt_row gt_right">33</td>
-    </tr>
+  <tr>
+    <th class="gt_row gt_left gt_stub">1</th>
+    <td class="gt_row gt_right">11</td>
+  </tr>
+  <tr>
+    <th class="gt_row gt_left gt_stub">3</th>
+    <td class="gt_row gt_right">33</td>
+  </tr>
   </tbody>
   '''
 # ---
@@ -92,180 +92,180 @@
 # name: test_styling_data_01
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: red;" class="gt_row gt_right">0.1111</td>
-      <td style="color: red;" class="gt_row gt_left">apricot</td>
-    </tr>
-    <tr>
-      <td style="color: red;" class="gt_row gt_right">2.222</td>
-      <td style="color: red;" class="gt_row gt_left">banana</td>
-    </tr>
-    <tr>
-      <td style="color: red;" class="gt_row gt_right">33.33</td>
-      <td style="color: red;" class="gt_row gt_left">coconut</td>
-    </tr>
+  <tr>
+    <td style="color: red;" class="gt_row gt_right">0.1111</td>
+    <td style="color: red;" class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td style="color: red;" class="gt_row gt_right">2.222</td>
+    <td style="color: red;" class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td style="color: red;" class="gt_row gt_right">33.33</td>
+    <td style="color: red;" class="gt_row gt_left">coconut</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_02
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td style="color: red;" class="gt_row gt_left">apricot</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td style="color: red;" class="gt_row gt_left">banana</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td style="color: red;" class="gt_row gt_left">coconut</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td style="color: red;" class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td style="color: red;" class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td style="color: red;" class="gt_row gt_left">coconut</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_03
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td style="color: red;" class="gt_row gt_left">apricot</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td style="color: red;" class="gt_row gt_left">coconut</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td style="color: red;" class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td style="color: red;" class="gt_row gt_left">coconut</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_04
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_05
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_06
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_07
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td style="border-left: 1px solid #000000;" class="gt_row gt_left">apricot</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td style="border-left: 1px solid #000000;" class="gt_row gt_left">coconut</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_08
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td style="border-left: 1px solid #000000;" class="gt_row gt_left">apricot</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td style="border-left: 1px solid #000000;" class="gt_row gt_left">coconut</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_09
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td style="border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">apricot</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td style="border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">coconut</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td style="border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td style="border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_10
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td style="border-top: 1px solid #000000;border-bottom: 1px solid #000000;border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">apricot</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td style="border-top: 1px solid #000000;border-bottom: 1px solid #000000;border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">coconut</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td style="border-top: 1px solid #000000;border-bottom: 1px solid #000000;border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td style="border-top: 1px solid #000000;border-bottom: 1px solid #000000;border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+  </tr>
   </tbody>
   '''
 # ---

--- a/tests/__snapshots__/test_utils_render_html.ambr
+++ b/tests/__snapshots__/test_utils_render_html.ambr
@@ -2,60 +2,64 @@
 # name: test_body_multiple_locations
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="background-color: red;" class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td style="background-color: red;" class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td style="background-color: red;" class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td style="background-color: red;" class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td style="background-color: red;" class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td style="background-color: red;" class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_body_multiple_styles
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="background-color: red; border-left: 1px solid #000000;" class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td style="background-color: red; border-left: 1px solid #000000;" class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_render_groups_reordered
   '''
   <tbody class="gt_table_body">
-  <tr>
-  <tr class=gt_group_heading_row>  <th class="gt_group_heading" colspan="2">A</th></tr>
-    <th class="gt_row gt_left gt_stub">0</th>
-    <td class="gt_row gt_right">00</td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">2</th>
-    <td class="gt_row gt_right">22</td>
-  </tr>
-  <tr>
-  <tr class=gt_group_heading_row>  <th class="gt_group_heading" colspan="2">B</th></tr>
-    <th class="gt_row gt_left gt_stub">1</th>
-    <td class="gt_row gt_right">11</td>
-  </tr>
-  <tr>
-    <th class="gt_row gt_left gt_stub">3</th>
-    <td class="gt_row gt_right">33</td>
-  </tr>
+    <tr class="gt_group_heading_row">
+      <th class="gt_group_heading" colspan="2">A</th>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">0</th>
+      <td class="gt_row gt_right">00</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">2</th>
+      <td class="gt_row gt_right">22</td>
+    </tr>
+    <tr class="gt_group_heading_row">
+      <th class="gt_group_heading" colspan="2">B</th>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">1</th>
+      <td class="gt_row gt_right">11</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">3</th>
+      <td class="gt_row gt_right">33</td>
+    </tr>
   </tbody>
   '''
 # ---
@@ -88,180 +92,180 @@
 # name: test_styling_data_01
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: red;" class="gt_row gt_right">0.1111</td>
-    <td style="color: red;" class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td style="color: red;" class="gt_row gt_right">2.222</td>
-    <td style="color: red;" class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td style="color: red;" class="gt_row gt_right">33.33</td>
-    <td style="color: red;" class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td style="color: red;" class="gt_row gt_right">0.1111</td>
+      <td style="color: red;" class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td style="color: red;" class="gt_row gt_right">2.222</td>
+      <td style="color: red;" class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td style="color: red;" class="gt_row gt_right">33.33</td>
+      <td style="color: red;" class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_02
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td style="color: red;" class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td style="color: red;" class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td style="color: red;" class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td style="color: red;" class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td style="color: red;" class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td style="color: red;" class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_03
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td style="color: red;" class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td style="color: red;" class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td style="color: red;" class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td style="color: red;" class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_04
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_05
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_06
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_07
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td style="border-left: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td style="border-left: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_08
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td style="border-left: 1px solid #000000;" class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td style="border-left: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td style="border-left: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_09
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td style="border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td style="border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td style="border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td style="border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_styling_data_10
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td style="border-top: 1px solid #000000;border-bottom: 1px solid #000000;border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">apricot</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td style="border-top: 1px solid #000000;border-bottom: 1px solid #000000;border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">coconut</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td style="border-top: 1px solid #000000;border-bottom: 1px solid #000000;border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td style="border-top: 1px solid #000000;border-bottom: 1px solid #000000;border-left: 1px solid #000000;border-right: 1px solid #000000;" class="gt_row gt_left">coconut</td>
+    </tr>
   </tbody>
   '''
 # ---

--- a/tests/data_color/__snapshots__/test_data_color.ambr
+++ b/tests/data_color/__snapshots__/test_data_color.ambr
@@ -2,587 +2,587 @@
 # name: test_all_missing_from_multiple_rows_pd
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_right">3</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_right">6</td>
-    </tr>
+  <tr>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">6</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_all_missing_from_multiple_rows_pl
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
-      <td class="gt_row gt_right">3</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
-      <td class="gt_row gt_right">6</td>
-    </tr>
+  <tr>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
+    <td class="gt_row gt_right">6</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_all_values_have_zero_range_domain_pd
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2.0</td>
-      <td class="gt_row gt_right">3</td>
-    </tr>
-    <tr>
-      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2.0</td>
-      <td class="gt_row gt_right">4</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #808080;" class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_right">5</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #808080;" class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_right">6</td>
-    </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2.0</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2.0</td>
+    <td class="gt_row gt_right">4</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #808080;" class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">5</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #808080;" class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">6</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_all_values_have_zero_range_domain_pl
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2</td>
-      <td class="gt_row gt_right">3</td>
-    </tr>
-    <tr>
-      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2</td>
-      <td class="gt_row gt_right">4</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #808080;" class="gt_row gt_right">None</td>
-      <td class="gt_row gt_right">5</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #808080;" class="gt_row gt_right">None</td>
-      <td class="gt_row gt_right">6</td>
-    </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2</td>
+    <td class="gt_row gt_right">4</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #808080;" class="gt_row gt_right">None</td>
+    <td class="gt_row gt_right">5</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #808080;" class="gt_row gt_right">None</td>
+    <td class="gt_row gt_right">6</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_autocolor_text_false[pandas]
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-      <td style="background-color: #ff0000;" class="gt_row gt_right">49.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-      <td style="background-color: #5c5200;" class="gt_row gt_right">17.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-      <td style="background-color: #077c00;" class="gt_row gt_right">1.39</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">444.4</td>
-      <td class="gt_row gt_left">durian</td>
-      <td style="background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+    <td style="background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+    <td style="background-color: #5c5200;" class="gt_row gt_right">17.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+    <td style="background-color: #077c00;" class="gt_row gt_right">1.39</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">444.4</td>
+    <td class="gt_row gt_left">durian</td>
+    <td style="background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_autocolor_text_false[polars]
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-      <td style="background-color: #ff0000;" class="gt_row gt_right">49.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-      <td style="background-color: #5c5200;" class="gt_row gt_right">17.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-      <td style="background-color: #077c00;" class="gt_row gt_right">1.39</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">444.4</td>
-      <td class="gt_row gt_left">durian</td>
-      <td style="background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+    <td style="background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+    <td style="background-color: #5c5200;" class="gt_row gt_right">17.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+    <td style="background-color: #077c00;" class="gt_row gt_right">1.39</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">444.4</td>
+    <td class="gt_row gt_left">durian</td>
+    <td style="background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_colorbrewer_snap
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #000000; background-color: #f7fcf5;" class="gt_row gt_right">1</td>
-      <td style="color: #FFFFFF; background-color: #00441b;" class="gt_row gt_right">10</td>
-      <td class="gt_row gt_left">one</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #c7e9c0;" class="gt_row gt_right">2</td>
-      <td style="color: #000000; background-color: #238b45;" class="gt_row gt_right">9</td>
-      <td class="gt_row gt_left">two</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #74c476;" class="gt_row gt_right">3</td>
-      <td style="color: #000000; background-color: #74c476;" class="gt_row gt_right">8</td>
-      <td class="gt_row gt_left">three</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #238b45;" class="gt_row gt_right">4</td>
-      <td style="color: #000000; background-color: #c7e9c0;" class="gt_row gt_right">7</td>
-      <td class="gt_row gt_left">four</td>
-    </tr>
-    <tr>
-      <td style="color: #FFFFFF; background-color: #00441b;" class="gt_row gt_right">5</td>
-      <td style="color: #000000; background-color: #f7fcf5;" class="gt_row gt_right">6</td>
-      <td class="gt_row gt_left">five</td>
-    </tr>
+  <tr>
+    <td style="color: #000000; background-color: #f7fcf5;" class="gt_row gt_right">1</td>
+    <td style="color: #FFFFFF; background-color: #00441b;" class="gt_row gt_right">10</td>
+    <td class="gt_row gt_left">one</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #c7e9c0;" class="gt_row gt_right">2</td>
+    <td style="color: #000000; background-color: #238b45;" class="gt_row gt_right">9</td>
+    <td class="gt_row gt_left">two</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #74c476;" class="gt_row gt_right">3</td>
+    <td style="color: #000000; background-color: #74c476;" class="gt_row gt_right">8</td>
+    <td class="gt_row gt_left">three</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #238b45;" class="gt_row gt_right">4</td>
+    <td style="color: #000000; background-color: #c7e9c0;" class="gt_row gt_right">7</td>
+    <td class="gt_row gt_left">four</td>
+  </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #00441b;" class="gt_row gt_right">5</td>
+    <td style="color: #000000; background-color: #f7fcf5;" class="gt_row gt_right">6</td>
+    <td class="gt_row gt_left">five</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_domain_na_color_reverse_snap[pandas]
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-      <td style="color: #FFFFFF; background-color: #5c5200;" class="gt_row gt_right">17.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-      <td style="color: #FFFFFF; background-color: #077c00;" class="gt_row gt_right">1.39</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">444.4</td>
-      <td class="gt_row gt_left">durian</td>
-      <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+    <td style="color: #FFFFFF; background-color: #5c5200;" class="gt_row gt_right">17.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+    <td style="color: #FFFFFF; background-color: #077c00;" class="gt_row gt_right">1.39</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">444.4</td>
+    <td class="gt_row gt_left">durian</td>
+    <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_domain_na_color_reverse_snap[polars]
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-      <td style="color: #FFFFFF; background-color: #5c5200;" class="gt_row gt_right">17.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-      <td style="color: #FFFFFF; background-color: #077c00;" class="gt_row gt_right">1.39</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">444.4</td>
-      <td class="gt_row gt_left">durian</td>
-      <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+    <td style="color: #FFFFFF; background-color: #5c5200;" class="gt_row gt_right">17.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+    <td style="color: #FFFFFF; background-color: #077c00;" class="gt_row gt_right">1.39</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">444.4</td>
+    <td class="gt_row gt_left">durian</td>
+    <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_domain_na_color_snap[pandas]
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">49.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-      <td style="color: #FFFFFF; background-color: #a32e00;" class="gt_row gt_right">17.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-      <td style="color: #000000; background-color: #f80400;" class="gt_row gt_right">1.39</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">444.4</td>
-      <td class="gt_row gt_left">durian</td>
-      <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">49.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+    <td style="color: #FFFFFF; background-color: #a32e00;" class="gt_row gt_right">17.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+    <td style="color: #000000; background-color: #f80400;" class="gt_row gt_right">1.39</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">444.4</td>
+    <td class="gt_row gt_left">durian</td>
+    <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_domain_na_color_snap[polars]
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">49.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-      <td style="color: #FFFFFF; background-color: #a32e00;" class="gt_row gt_right">17.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-      <td style="color: #000000; background-color: #f80400;" class="gt_row gt_right">1.39</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">444.4</td>
-      <td class="gt_row gt_left">durian</td>
-      <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">49.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+    <td style="color: #FFFFFF; background-color: #a32e00;" class="gt_row gt_right">17.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+    <td style="color: #000000; background-color: #f80400;" class="gt_row gt_right">1.39</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">444.4</td>
+    <td class="gt_row gt_left">durian</td>
+    <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_overlapping_domain[pandas]
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">444.4</td>
-      <td class="gt_row gt_left">durian</td>
-      <td style="color: #FFFFFF; background-color: #673498;" class="gt_row gt_right">65100.0</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">444.4</td>
+    <td class="gt_row gt_left">durian</td>
+    <td style="color: #FFFFFF; background-color: #673498;" class="gt_row gt_right">65100.0</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_overlapping_domain[polars]
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">444.4</td>
-      <td class="gt_row gt_left">durian</td>
-      <td style="color: #FFFFFF; background-color: #673498;" class="gt_row gt_right">65100.0</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">444.4</td>
+    <td class="gt_row gt_left">durian</td>
+    <td style="color: #FFFFFF; background-color: #673498;" class="gt_row gt_right">65100.0</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_palette_snap[pandas]
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #fe0100;" class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">17.95</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #ec0a00;" class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">1.39</td>
-    </tr>
-    <tr>
-      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">444.4</td>
-      <td class="gt_row gt_left">durian</td>
-      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">65100.0</td>
-    </tr>
+  <tr>
+    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #fe0100;" class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">17.95</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #ec0a00;" class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">1.39</td>
+  </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">444.4</td>
+    <td class="gt_row gt_left">durian</td>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">65100.0</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_palette_snap[polars]
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #fe0100;" class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">17.95</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #ec0a00;" class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">1.39</td>
-    </tr>
-    <tr>
-      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">444.4</td>
-      <td class="gt_row gt_left">durian</td>
-      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">65100.0</td>
-    </tr>
+  <tr>
+    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #fe0100;" class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">17.95</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #ec0a00;" class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">1.39</td>
+  </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">444.4</td>
+    <td class="gt_row gt_left">durian</td>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">65100.0</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_simple_df_snap
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1</td>
-      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">10</td>
-      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">one</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_right">2</td>
-      <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_right">9</td>
-      <td style="color: #000000; background-color: #4cbd81;" class="gt_row gt_left">two</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">3</td>
-      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">8</td>
-      <td style="color: #FFFFFF; background-color: #9653ca;" class="gt_row gt_left">three</td>
-    </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1</td>
+    <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">10</td>
+    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">one</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_right">2</td>
+    <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_right">9</td>
+    <td style="color: #000000; background-color: #4cbd81;" class="gt_row gt_left">two</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">3</td>
+    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">8</td>
+    <td style="color: #FFFFFF; background-color: #9653ca;" class="gt_row gt_left">three</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_simple_exibble_snap[pandas]
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">0.1111</td>
-      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">apricot</td>
-      <td style="color: #FFFFFF; background-color: #010001;" class="gt_row gt_right">49.95</td>
-    </tr>
-    <tr>
-      <td style="color: #FFFFFF; background-color: #070304;" class="gt_row gt_right">2.222</td>
-      <td style="color: #000000; background-color: #80b156;" class="gt_row gt_left">banana</td>
-      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">17.95</td>
-    </tr>
-    <tr>
-      <td style="color: #FFFFFF; background-color: #752b38;" class="gt_row gt_right">33.33</td>
-      <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_left">coconut</td>
-      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1.39</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">444.4</td>
-      <td style="color: #000000; background-color: #d73a91;" class="gt_row gt_left">durian</td>
-      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">65100.0</td>
-    </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">0.1111</td>
+    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">apricot</td>
+    <td style="color: #FFFFFF; background-color: #010001;" class="gt_row gt_right">49.95</td>
+  </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #070304;" class="gt_row gt_right">2.222</td>
+    <td style="color: #000000; background-color: #80b156;" class="gt_row gt_left">banana</td>
+    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">17.95</td>
+  </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #752b38;" class="gt_row gt_right">33.33</td>
+    <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_left">coconut</td>
+    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1.39</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">444.4</td>
+    <td style="color: #000000; background-color: #d73a91;" class="gt_row gt_left">durian</td>
+    <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">65100.0</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_simple_exibble_snap[polars]
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">0.1111</td>
-      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">apricot</td>
-      <td style="color: #FFFFFF; background-color: #010001;" class="gt_row gt_right">49.95</td>
-    </tr>
-    <tr>
-      <td style="color: #FFFFFF; background-color: #070304;" class="gt_row gt_right">2.222</td>
-      <td style="color: #000000; background-color: #80b156;" class="gt_row gt_left">banana</td>
-      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">17.95</td>
-    </tr>
-    <tr>
-      <td style="color: #FFFFFF; background-color: #752b38;" class="gt_row gt_right">33.33</td>
-      <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_left">coconut</td>
-      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1.39</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">444.4</td>
-      <td style="color: #000000; background-color: #d73a91;" class="gt_row gt_left">durian</td>
-      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">65100.0</td>
-    </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">0.1111</td>
+    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">apricot</td>
+    <td style="color: #FFFFFF; background-color: #010001;" class="gt_row gt_right">49.95</td>
+  </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #070304;" class="gt_row gt_right">2.222</td>
+    <td style="color: #000000; background-color: #80b156;" class="gt_row gt_left">banana</td>
+    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">17.95</td>
+  </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #752b38;" class="gt_row gt_right">33.33</td>
+    <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_left">coconut</td>
+    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1.39</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">444.4</td>
+    <td style="color: #000000; background-color: #d73a91;" class="gt_row gt_left">durian</td>
+    <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">65100.0</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_subset_domain[pandas]
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">444.4</td>
-      <td class="gt_row gt_left">durian</td>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">65100.0</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">444.4</td>
+    <td class="gt_row gt_left">durian</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">65100.0</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_subset_domain[polars]
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">0.1111</td>
-      <td class="gt_row gt_left">apricot</td>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.222</td>
-      <td class="gt_row gt_left">banana</td>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">33.33</td>
-      <td class="gt_row gt_left">coconut</td>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">444.4</td>
-      <td class="gt_row gt_left">durian</td>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">65100.0</td>
-    </tr>
+  <tr>
+    <td class="gt_row gt_right">0.1111</td>
+    <td class="gt_row gt_left">apricot</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">2.222</td>
+    <td class="gt_row gt_left">banana</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">33.33</td>
+    <td class="gt_row gt_left">coconut</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_right">444.4</td>
+    <td class="gt_row gt_left">durian</td>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">65100.0</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_viridis_snap
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #FFFFFF; background-color: #440154;" class="gt_row gt_right">1</td>
-      <td style="color: #000000; background-color: #fde725;" class="gt_row gt_right">10</td>
-      <td class="gt_row gt_left">one</td>
-    </tr>
-    <tr>
-      <td style="color: #FFFFFF; background-color: #3b518a;" class="gt_row gt_right">2</td>
-      <td style="color: #000000; background-color: #5fc861;" class="gt_row gt_right">9</td>
-      <td class="gt_row gt_left">two</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #22908c;" class="gt_row gt_right">3</td>
-      <td style="color: #000000; background-color: #22908c;" class="gt_row gt_right">8</td>
-      <td class="gt_row gt_left">three</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #5fc861;" class="gt_row gt_right">4</td>
-      <td style="color: #FFFFFF; background-color: #3b518a;" class="gt_row gt_right">7</td>
-      <td class="gt_row gt_left">four</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #fde725;" class="gt_row gt_right">5</td>
-      <td style="color: #FFFFFF; background-color: #440154;" class="gt_row gt_right">6</td>
-      <td class="gt_row gt_left">five</td>
-    </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #440154;" class="gt_row gt_right">1</td>
+    <td style="color: #000000; background-color: #fde725;" class="gt_row gt_right">10</td>
+    <td class="gt_row gt_left">one</td>
+  </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #3b518a;" class="gt_row gt_right">2</td>
+    <td style="color: #000000; background-color: #5fc861;" class="gt_row gt_right">9</td>
+    <td class="gt_row gt_left">two</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #22908c;" class="gt_row gt_right">3</td>
+    <td style="color: #000000; background-color: #22908c;" class="gt_row gt_right">8</td>
+    <td class="gt_row gt_left">three</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #5fc861;" class="gt_row gt_right">4</td>
+    <td style="color: #FFFFFF; background-color: #3b518a;" class="gt_row gt_right">7</td>
+    <td class="gt_row gt_left">four</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #fde725;" class="gt_row gt_right">5</td>
+    <td style="color: #FFFFFF; background-color: #440154;" class="gt_row gt_right">6</td>
+    <td class="gt_row gt_left">five</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_single_value_and_missing_pd
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_right">3</td>
-    </tr>
+  <tr>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_single_value_and_missing_pl
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
-      <td class="gt_row gt_right">3</td>
-    </tr>
+  <tr>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_single_value_from_multiple_rows_pd
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1.0</td>
-      <td class="gt_row gt_right">3</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_right">4</td>
-    </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1.0</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+    <td class="gt_row gt_right">4</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_single_value_from_multiple_rows_pl
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
-      <td class="gt_row gt_right">3</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">None</td>
-      <td class="gt_row gt_right">4</td>
-    </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
+  <tr>
+    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">None</td>
+    <td class="gt_row gt_right">4</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_single_value_pd
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
-      <td class="gt_row gt_right">3</td>
-    </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
   </tbody>
   '''
 # ---
 # name: test_single_value_pl
   '''
   <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
-      <td class="gt_row gt_right">3</td>
-    </tr>
+  <tr>
+    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
+    <td class="gt_row gt_right">3</td>
+  </tr>
   </tbody>
   '''
 # ---

--- a/tests/data_color/__snapshots__/test_data_color.ambr
+++ b/tests/data_color/__snapshots__/test_data_color.ambr
@@ -2,587 +2,587 @@
 # name: test_all_missing_from_multiple_rows_pd
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_right">3</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_right">6</td>
-  </tr>
+    <tr>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_right">3</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_right">6</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_all_missing_from_multiple_rows_pl
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
-    <td class="gt_row gt_right">3</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
-    <td class="gt_row gt_right">6</td>
-  </tr>
+    <tr>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
+      <td class="gt_row gt_right">3</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
+      <td class="gt_row gt_right">6</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_all_values_have_zero_range_domain_pd
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2.0</td>
-    <td class="gt_row gt_right">3</td>
-  </tr>
-  <tr>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2.0</td>
-    <td class="gt_row gt_right">4</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #808080;" class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_right">5</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #808080;" class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_right">6</td>
-  </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2.0</td>
+      <td class="gt_row gt_right">3</td>
+    </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2.0</td>
+      <td class="gt_row gt_right">4</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #808080;" class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_right">5</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #808080;" class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_right">6</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_all_values_have_zero_range_domain_pl
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2</td>
-    <td class="gt_row gt_right">3</td>
-  </tr>
-  <tr>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2</td>
-    <td class="gt_row gt_right">4</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #808080;" class="gt_row gt_right">None</td>
-    <td class="gt_row gt_right">5</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #808080;" class="gt_row gt_right">None</td>
-    <td class="gt_row gt_right">6</td>
-  </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2</td>
+      <td class="gt_row gt_right">3</td>
+    </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">2</td>
+      <td class="gt_row gt_right">4</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #808080;" class="gt_row gt_right">None</td>
+      <td class="gt_row gt_right">5</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #808080;" class="gt_row gt_right">None</td>
+      <td class="gt_row gt_right">6</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_autocolor_text_false[pandas]
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-    <td style="background-color: #ff0000;" class="gt_row gt_right">49.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-    <td style="background-color: #5c5200;" class="gt_row gt_right">17.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-    <td style="background-color: #077c00;" class="gt_row gt_right">1.39</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">444.4</td>
-    <td class="gt_row gt_left">durian</td>
-    <td style="background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="background-color: #5c5200;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="background-color: #077c00;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_autocolor_text_false[polars]
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-    <td style="background-color: #ff0000;" class="gt_row gt_right">49.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-    <td style="background-color: #5c5200;" class="gt_row gt_right">17.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-    <td style="background-color: #077c00;" class="gt_row gt_right">1.39</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">444.4</td>
-    <td class="gt_row gt_left">durian</td>
-    <td style="background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="background-color: #5c5200;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="background-color: #077c00;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_colorbrewer_snap
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #000000; background-color: #f7fcf5;" class="gt_row gt_right">1</td>
-    <td style="color: #FFFFFF; background-color: #00441b;" class="gt_row gt_right">10</td>
-    <td class="gt_row gt_left">one</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #c7e9c0;" class="gt_row gt_right">2</td>
-    <td style="color: #000000; background-color: #238b45;" class="gt_row gt_right">9</td>
-    <td class="gt_row gt_left">two</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #74c476;" class="gt_row gt_right">3</td>
-    <td style="color: #000000; background-color: #74c476;" class="gt_row gt_right">8</td>
-    <td class="gt_row gt_left">three</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #238b45;" class="gt_row gt_right">4</td>
-    <td style="color: #000000; background-color: #c7e9c0;" class="gt_row gt_right">7</td>
-    <td class="gt_row gt_left">four</td>
-  </tr>
-  <tr>
-    <td style="color: #FFFFFF; background-color: #00441b;" class="gt_row gt_right">5</td>
-    <td style="color: #000000; background-color: #f7fcf5;" class="gt_row gt_right">6</td>
-    <td class="gt_row gt_left">five</td>
-  </tr>
+    <tr>
+      <td style="color: #000000; background-color: #f7fcf5;" class="gt_row gt_right">1</td>
+      <td style="color: #FFFFFF; background-color: #00441b;" class="gt_row gt_right">10</td>
+      <td class="gt_row gt_left">one</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #c7e9c0;" class="gt_row gt_right">2</td>
+      <td style="color: #000000; background-color: #238b45;" class="gt_row gt_right">9</td>
+      <td class="gt_row gt_left">two</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #74c476;" class="gt_row gt_right">3</td>
+      <td style="color: #000000; background-color: #74c476;" class="gt_row gt_right">8</td>
+      <td class="gt_row gt_left">three</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #238b45;" class="gt_row gt_right">4</td>
+      <td style="color: #000000; background-color: #c7e9c0;" class="gt_row gt_right">7</td>
+      <td class="gt_row gt_left">four</td>
+    </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #00441b;" class="gt_row gt_right">5</td>
+      <td style="color: #000000; background-color: #f7fcf5;" class="gt_row gt_right">6</td>
+      <td class="gt_row gt_left">five</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_domain_na_color_reverse_snap[pandas]
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-    <td style="color: #FFFFFF; background-color: #5c5200;" class="gt_row gt_right">17.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-    <td style="color: #FFFFFF; background-color: #077c00;" class="gt_row gt_right">1.39</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">444.4</td>
-    <td class="gt_row gt_left">durian</td>
-    <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #FFFFFF; background-color: #5c5200;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #FFFFFF; background-color: #077c00;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_domain_na_color_reverse_snap[polars]
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-    <td style="color: #FFFFFF; background-color: #5c5200;" class="gt_row gt_right">17.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-    <td style="color: #FFFFFF; background-color: #077c00;" class="gt_row gt_right">1.39</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">444.4</td>
-    <td class="gt_row gt_left">durian</td>
-    <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #FFFFFF; background-color: #5c5200;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #FFFFFF; background-color: #077c00;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_domain_na_color_snap[pandas]
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">49.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-    <td style="color: #FFFFFF; background-color: #a32e00;" class="gt_row gt_right">17.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-    <td style="color: #000000; background-color: #f80400;" class="gt_row gt_right">1.39</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">444.4</td>
-    <td class="gt_row gt_left">durian</td>
-    <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #FFFFFF; background-color: #a32e00;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #000000; background-color: #f80400;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_domain_na_color_snap[polars]
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">49.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-    <td style="color: #FFFFFF; background-color: #a32e00;" class="gt_row gt_right">17.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-    <td style="color: #000000; background-color: #f80400;" class="gt_row gt_right">1.39</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">444.4</td>
-    <td class="gt_row gt_left">durian</td>
-    <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #FFFFFF; background-color: #a32e00;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #000000; background-color: #f80400;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_overlapping_domain[pandas]
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">444.4</td>
-    <td class="gt_row gt_left">durian</td>
-    <td style="color: #FFFFFF; background-color: #673498;" class="gt_row gt_right">65100.0</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #FFFFFF; background-color: #673498;" class="gt_row gt_right">65100.0</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_overlapping_domain[polars]
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">444.4</td>
-    <td class="gt_row gt_left">durian</td>
-    <td style="color: #FFFFFF; background-color: #673498;" class="gt_row gt_right">65100.0</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #FFFFFF; background-color: #673498;" class="gt_row gt_right">65100.0</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_palette_snap[pandas]
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #fe0100;" class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">17.95</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #ec0a00;" class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">1.39</td>
-  </tr>
-  <tr>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">444.4</td>
-    <td class="gt_row gt_left">durian</td>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">65100.0</td>
-  </tr>
+    <tr>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #fe0100;" class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #ec0a00;" class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">65100.0</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_palette_snap[polars]
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #fe0100;" class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">17.95</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #ec0a00;" class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-    <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">1.39</td>
-  </tr>
-  <tr>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">444.4</td>
-    <td class="gt_row gt_left">durian</td>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">65100.0</td>
-  </tr>
+    <tr>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #fe0100;" class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #ec0a00;" class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">65100.0</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_simple_df_snap
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1</td>
-    <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">10</td>
-    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">one</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_right">2</td>
-    <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_right">9</td>
-    <td style="color: #000000; background-color: #4cbd81;" class="gt_row gt_left">two</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">3</td>
-    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">8</td>
-    <td style="color: #FFFFFF; background-color: #9653ca;" class="gt_row gt_left">three</td>
-  </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1</td>
+      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">10</td>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">one</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_right">2</td>
+      <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_right">9</td>
+      <td style="color: #000000; background-color: #4cbd81;" class="gt_row gt_left">two</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">3</td>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">8</td>
+      <td style="color: #FFFFFF; background-color: #9653ca;" class="gt_row gt_left">three</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_simple_exibble_snap[pandas]
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">0.1111</td>
-    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">apricot</td>
-    <td style="color: #FFFFFF; background-color: #010001;" class="gt_row gt_right">49.95</td>
-  </tr>
-  <tr>
-    <td style="color: #FFFFFF; background-color: #070304;" class="gt_row gt_right">2.222</td>
-    <td style="color: #000000; background-color: #80b156;" class="gt_row gt_left">banana</td>
-    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">17.95</td>
-  </tr>
-  <tr>
-    <td style="color: #FFFFFF; background-color: #752b38;" class="gt_row gt_right">33.33</td>
-    <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_left">coconut</td>
-    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1.39</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">444.4</td>
-    <td style="color: #000000; background-color: #d73a91;" class="gt_row gt_left">durian</td>
-    <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">65100.0</td>
-  </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">0.1111</td>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">apricot</td>
+      <td style="color: #FFFFFF; background-color: #010001;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #070304;" class="gt_row gt_right">2.222</td>
+      <td style="color: #000000; background-color: #80b156;" class="gt_row gt_left">banana</td>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #752b38;" class="gt_row gt_right">33.33</td>
+      <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_left">coconut</td>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">444.4</td>
+      <td style="color: #000000; background-color: #d73a91;" class="gt_row gt_left">durian</td>
+      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">65100.0</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_simple_exibble_snap[polars]
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">0.1111</td>
-    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">apricot</td>
-    <td style="color: #FFFFFF; background-color: #010001;" class="gt_row gt_right">49.95</td>
-  </tr>
-  <tr>
-    <td style="color: #FFFFFF; background-color: #070304;" class="gt_row gt_right">2.222</td>
-    <td style="color: #000000; background-color: #80b156;" class="gt_row gt_left">banana</td>
-    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">17.95</td>
-  </tr>
-  <tr>
-    <td style="color: #FFFFFF; background-color: #752b38;" class="gt_row gt_right">33.33</td>
-    <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_left">coconut</td>
-    <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1.39</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">444.4</td>
-    <td style="color: #000000; background-color: #d73a91;" class="gt_row gt_left">durian</td>
-    <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">65100.0</td>
-  </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">0.1111</td>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">apricot</td>
+      <td style="color: #FFFFFF; background-color: #010001;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #070304;" class="gt_row gt_right">2.222</td>
+      <td style="color: #000000; background-color: #80b156;" class="gt_row gt_left">banana</td>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #752b38;" class="gt_row gt_right">33.33</td>
+      <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_left">coconut</td>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">444.4</td>
+      <td style="color: #000000; background-color: #d73a91;" class="gt_row gt_left">durian</td>
+      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">65100.0</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_subset_domain[pandas]
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">444.4</td>
-    <td class="gt_row gt_left">durian</td>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">65100.0</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">65100.0</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_subset_domain[polars]
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td class="gt_row gt_right">0.1111</td>
-    <td class="gt_row gt_left">apricot</td>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">2.222</td>
-    <td class="gt_row gt_left">banana</td>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">33.33</td>
-    <td class="gt_row gt_left">coconut</td>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_right">444.4</td>
-    <td class="gt_row gt_left">durian</td>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">65100.0</td>
-  </tr>
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">65100.0</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_data_color_viridis_snap
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #FFFFFF; background-color: #440154;" class="gt_row gt_right">1</td>
-    <td style="color: #000000; background-color: #fde725;" class="gt_row gt_right">10</td>
-    <td class="gt_row gt_left">one</td>
-  </tr>
-  <tr>
-    <td style="color: #FFFFFF; background-color: #3b518a;" class="gt_row gt_right">2</td>
-    <td style="color: #000000; background-color: #5fc861;" class="gt_row gt_right">9</td>
-    <td class="gt_row gt_left">two</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #22908c;" class="gt_row gt_right">3</td>
-    <td style="color: #000000; background-color: #22908c;" class="gt_row gt_right">8</td>
-    <td class="gt_row gt_left">three</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #5fc861;" class="gt_row gt_right">4</td>
-    <td style="color: #FFFFFF; background-color: #3b518a;" class="gt_row gt_right">7</td>
-    <td class="gt_row gt_left">four</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #fde725;" class="gt_row gt_right">5</td>
-    <td style="color: #FFFFFF; background-color: #440154;" class="gt_row gt_right">6</td>
-    <td class="gt_row gt_left">five</td>
-  </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #440154;" class="gt_row gt_right">1</td>
+      <td style="color: #000000; background-color: #fde725;" class="gt_row gt_right">10</td>
+      <td class="gt_row gt_left">one</td>
+    </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #3b518a;" class="gt_row gt_right">2</td>
+      <td style="color: #000000; background-color: #5fc861;" class="gt_row gt_right">9</td>
+      <td class="gt_row gt_left">two</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #22908c;" class="gt_row gt_right">3</td>
+      <td style="color: #000000; background-color: #22908c;" class="gt_row gt_right">8</td>
+      <td class="gt_row gt_left">three</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #5fc861;" class="gt_row gt_right">4</td>
+      <td style="color: #FFFFFF; background-color: #3b518a;" class="gt_row gt_right">7</td>
+      <td class="gt_row gt_left">four</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #fde725;" class="gt_row gt_right">5</td>
+      <td style="color: #FFFFFF; background-color: #440154;" class="gt_row gt_right">6</td>
+      <td class="gt_row gt_left">five</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_single_value_and_missing_pd
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_right">3</td>
-  </tr>
+    <tr>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_right">3</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_single_value_and_missing_pl
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
-    <td class="gt_row gt_right">3</td>
-  </tr>
+    <tr>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_center">None</td>
+      <td class="gt_row gt_right">3</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_single_value_from_multiple_rows_pd
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1.0</td>
-    <td class="gt_row gt_right">3</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
-    <td class="gt_row gt_right">4</td>
-  </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1.0</td>
+      <td class="gt_row gt_right">3</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_right">4</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_single_value_from_multiple_rows_pl
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
-    <td class="gt_row gt_right">3</td>
-  </tr>
-  <tr>
-    <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">None</td>
-    <td class="gt_row gt_right">4</td>
-  </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
+      <td class="gt_row gt_right">3</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">None</td>
+      <td class="gt_row gt_right">4</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_single_value_pd
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
-    <td class="gt_row gt_right">3</td>
-  </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
+      <td class="gt_row gt_right">3</td>
+    </tr>
   </tbody>
   '''
 # ---
 # name: test_single_value_pl
   '''
   <tbody class="gt_table_body">
-  <tr>
-    <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
-    <td class="gt_row gt_right">3</td>
-  </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">1</td>
+      <td class="gt_row gt_right">3</td>
+    </tr>
   </tbody>
   '''
 # ---


### PR DESCRIPTION
From a simple rendering of:

```python
from great_tables import GT, exibble

GT(exibble, rowname_col="row", groupname_col="group").as_raw_html()
```

the following invalid HTML is generated for a group label row and the row below:

```html
<tbody class="gt_table_body">
<tr>
<tr class=gt_group_heading_row>  <th class="gt_group_heading" colspan="8">grp_a</th></tr>
  <th class="gt_row gt_left gt_stub">row_1</th>
  <td class="gt_row gt_right">0.1111</td>
  <td class="gt_row gt_left">apricot</td>
  <td class="gt_row gt_left">one</td>
  <td class="gt_row gt_right">2015-01-15</td>
  <td class="gt_row gt_right">13:35</td>
  <td class="gt_row gt_right">2018-01-01 02:22</td>
  <td class="gt_row gt_right">49.95</td>
</tr>
```

The first `<tr>` should instead be opening tag for the collection of `<th>` and `<td>` tags. Browsers could handle this invalid code and generate a suitable table display but not Quarto/Pandoc (requires that the HTML be valid in order for it to be parsed).

With this PR, the HTML generated should instead be:

```html
<tbody class="gt_table_body">
  <tr class="gt_group_heading_row">
    <th class="gt_group_heading" colspan="8">grp_a</th>
  </tr>
  <tr>
    <th class="gt_row gt_left gt_stub">row_1</th>
    <td class="gt_row gt_right">0.1111</td>
    <td class="gt_row gt_left">apricot</td>
    <td class="gt_row gt_left">one</td>
    <td class="gt_row gt_right">2015-01-15</td>
    <td class="gt_row gt_right">13:35</td>
    <td class="gt_row gt_right">2018-01-01 02:22</td>
    <td class="gt_row gt_right">49.95</td>
  </tr>
```

Fixes: https://github.com/posit-dev/great-tables/issues/306