### PR TITLE
fix: Polars selectors error in `GT.cols_hide()`

### DIFF
--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -467,7 +467,7 @@ def cols_hide(data: GTSelf, columns: SelectExpr) -> GTSelf:
 
     if not len(sel_cols):
         raise Exception("No columns selected.")
-    elif not all([col in vars for col in columns]):
+    elif not all(col in vars for col in sel_cols):
         raise ValueError("All `columns` must exist and be visible in the input `data` table.")
 
     # New boxhead with hidden columns

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -161,6 +161,14 @@ def test_cols_hide():
     new_gt = cols_hide(src_gt, columns=["a", "b"])
     assert [col.var for col in new_gt._boxhead if col.visible] == ["c"]
 
+    import polars as pl
+    import polars.selectors as cs
+
+    df = pl.DataFrame({"col1": [1, 2], "col2": [3, 4], "abc": [5, 6]})
+    src_gt = GT(df)
+    new_gt = cols_hide(src_gt, columns=cs.starts_with("col"))
+    assert [col.var for col in new_gt._boxhead if col.visible] == ["abc"]
+
 
 def test_cols_move():
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})


### PR DESCRIPTION
Fix #313. 

```python
from great_tables import GT, exibble
import polars as pl
import polars.selectors as cs

exibble_pl = pl.from_pandas(exibble)

(
  GT(exibble_pl)
  .cols_hide(columns=cs.starts_with("date"))
)
```

![image](https://github.com/posit-dev/great-tables/assets/67060418/cae0f5ee-416a-41d9-8cb5-32abe30a90db)
