### PR TITLE
fix: missing values in `fmt_number`

### DIFF
--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -293,7 +293,7 @@ def fmt_number(
         dec_mark: str = dec_mark,
         force_sign: bool = force_sign,
     ):
-        if x is None:
+        if is_na(self._tbl_data, x):
             return x
 
         # Scale `x` value by a defined `scale_by` value

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -281,7 +281,7 @@ def fmt_number(
 
     # Generate a function that will operate on single `x` values in the table body
     def fmt_number_fn(
-        x: float,
+        x: float | None,
         decimals: int = decimals,
         n_sigfig: Optional[int] = n_sigfig,
         drop_trailing_zeros: bool = drop_trailing_zeros,
@@ -293,6 +293,9 @@ def fmt_number(
         dec_mark: str = dec_mark,
         force_sign: bool = force_sign,
     ):
+        if x is None:
+            return x
+
         # Scale `x` value by a defined `scale_by` value
         x = x * scale_by
 

--- a/tests/__snapshots__/test_export.ambr
+++ b/tests/__snapshots__/test_export.ambr
@@ -102,7 +102,7 @@
     </tr>
     <tr>
       <th class="gt_row gt_left gt_stub">row_6</th>
-      <td class="gt_row gt_right">nan</td>
+      <td class="gt_row gt_right"><NA></td>
       <td class="gt_row gt_left">fig</td>
       <td class="gt_row gt_right">$13.26</td>
     </tr>


### PR DESCRIPTION
Fix #314.

At first, I attempted to address this issue by utilizing the check from `fmt_scientific` to verify `x`:

```python
if is_na(self._tbl_data, x):
    return x
```

However, this caused a failure in `tests/test_export.py::test_html_string_generated`. Consequently, I opted to directly check whether `x` is `None` or not.

```python
from great_tables import GT, exibble
import polars as pl

exibble_pl = pl.from_pandas(exibble)

GT(exibble_pl).fmt_number(columns="num")
```
![image](https://github.com/posit-dev/great-tables/assets/67060418/74364751-8c4d-480f-9df0-92b1952c2b84)
