### PR TITLE
fix: the display issue of integerlike values in nanoplots

### DIFF
--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -1580,6 +1580,7 @@ def _is_intlike(n: Any, scaled_by: float = 1e17) -> bool:
 
     if isinstance(n, str):
         try:
+            # Replacement of minus sign (U+2212) with hyphen (necessary in some locales)
             n = float(n.replace("−", "-"))
         except ValueError:
             return False
@@ -1599,6 +1600,7 @@ def _remove_exponent(n: "str | int | float") -> int:
     from decimal import Decimal
 
     if isinstance(n, str):
+        # Replacement of minus sign (U+2212) with hyphen (necessary in some locales)
         n = str(n).replace("−", "-")
     d = Decimal(n)
     if d == d.to_integral():

--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -1592,7 +1592,7 @@ def _get_n_intlike(nums: list[Any]) -> int:
     return len([n for n in nums if _is_intlike(n)])
 
 
-def _remove_exponent(n: str | int | float) -> int:
+def _remove_exponent(n: "str | int | float") -> int:
     """
     https://docs.python.org/3/library/decimal.html#decimal-faq
     """

--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -1458,6 +1458,7 @@ def _generate_nanoplot(
     #
 
     if show_vertical_guides:
+        is_all_intify = len(y_vals) == _get_n_intlike(y_vals)
 
         g_guide_strings = []
 
@@ -1474,6 +1475,9 @@ def _generate_nanoplot(
 
             if y_value_i == "NA":
                 x_text = x_text + 2
+
+            if is_all_intify:
+                y_value_i = _remove_exponent(y_value_i)
 
             text_strings_i = f'<text x="{x_text}" y="{safe_y_d + 5}" fill="transparent" stroke="transparent" font-size="30px">{y_value_i}</text>'
 
@@ -1565,3 +1569,40 @@ def _generate_nanoplot(
     )
 
     return nanoplot_svg
+
+
+def _is_intlike(n: Any, scaled_by: float = 1e17) -> bool:
+    """
+    https://stackoverflow.com/a/71373152
+    """
+    import numbers
+    from decimal import Decimal
+
+    if isinstance(n, str):
+        try:
+            n = float(n.replace("−", "-"))
+        except ValueError:
+            return False
+    elif isinstance(n, Decimal):
+        n = float(n)
+    return isinstance(n, numbers.Real) and ((n * scaled_by - int(n) * scaled_by) == 0)
+
+
+def _get_n_intlike(nums: list[Any]) -> int:
+    return len([n for n in nums if _is_intlike(n)])
+
+
+def _remove_exponent(n: str | int | float) -> int:
+    """
+    https://docs.python.org/3/library/decimal.html#decimal-faq
+    """
+    from decimal import Decimal
+
+    if isinstance(n, str):
+        n = str(n).replace("−", "-")
+    d = Decimal(n)
+    if d == d.to_integral():
+        x = d.quantize(Decimal(1))
+    else:
+        x = d.normalize()
+    return int(x)

--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -1424,6 +1424,7 @@ def _generate_nanoplot(
     #
 
     if show_y_axis_guide:
+        is_all_intify_y_axis = len(y_vals) == _get_n_intlike(y_vals)
 
         rect_tag = f'<rect x="{left_x}" y="{top_y}" width="{safe_x_d + 15}" height="{bottom_y}" stroke="transparent" stroke-width="0" fill="transparent"></rect>'
 
@@ -1447,6 +1448,10 @@ def _generate_nanoplot(
             fn=y_axis_fmt_fn,
         )
 
+        if is_all_intify_y_axis:
+            y_value_max_label = _remove_exponent(y_value_max_label)
+            y_value_min_label = _remove_exponent(y_value_min_label)
+
         text_strings_min = f'<text x="{left_x}" y="{safe_y_d + data_y_height + safe_y_d - data_y_height / 25}" fill="transparent" stroke="transparent" font-size="25">{y_value_min_label}</text>'
 
         text_strings_max = f'<text x="{left_x}" y="{safe_y_d + data_y_height / 25}" fill="transparent" stroke="transparent" font-size="25">{y_value_max_label}</text>'
@@ -1458,7 +1463,7 @@ def _generate_nanoplot(
     #
 
     if show_vertical_guides:
-        is_all_intify = len(y_vals) == _get_n_intlike(y_vals)
+        is_all_intify_v_guides = len(y_vals) == _get_n_intlike(y_vals)
 
         g_guide_strings = []
 
@@ -1476,7 +1481,7 @@ def _generate_nanoplot(
             if y_value_i == "NA":
                 x_text = x_text + 2
 
-            if is_all_intify:
+            if is_all_intify_v_guides:
                 y_value_i = _remove_exponent(y_value_i)
 
             text_strings_i = f'<text x="{x_text}" y="{safe_y_d + 5}" fill="transparent" stroke="transparent" font-size="30px">{y_value_i}</text>'

--- a/tests/test__utils_nanoplots.py
+++ b/tests/test__utils_nanoplots.py
@@ -2058,5 +2058,5 @@ def test_get_n_intlike(nums: list[Any], n: int):
         ("−5.0", -5),  # not regular `-`
     ],
 )
-def test_remove_exponent(n: int | float | str, result: int):
+def test_remove_exponent(n: "int | float | str", result: int):
     assert _remove_exponent(n) == result

--- a/tests/test__utils_nanoplots.py
+++ b/tests/test__utils_nanoplots.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 import pytest
 import numpy as np
 from great_tables._utils_nanoplots import (
@@ -22,6 +23,9 @@ from great_tables._utils_nanoplots import (
     _get_extreme_value,
     _generate_ref_line_from_keyword,
     _generate_nanoplot,
+    _is_intlike,
+    _get_n_intlike,
+    _remove_exponent,
 )
 from typing import List, Union, Any
 
@@ -2001,3 +2005,58 @@ def test_nanoplot_x_y_vals_diff_length():
 def test_nanoplot_unknown_plot_type():
     with pytest.raises(ValueError):
         _generate_nanoplot(y_vals=[1, 2, 3], plot_type="unknown")
+
+
+@pytest.mark.parametrize(
+    "n, bool_",
+    [
+        (0, True),
+        (0.0, True),
+        (1, True),
+        (1.0, True),
+        (-12, True),
+        (-12.0, True),
+        ("-12", True),
+        ("−12", True),  # not regular `-`
+        (Decimal("1"), True),
+        (Decimal("1.0"), True),
+        (2.151515, False),
+        (-12.49849, False),
+        ("-12.49849", False),
+        ("−12.49849", False),  # not regular `-`
+        (Decimal("2.151515"), False),
+        ("abc", False),
+        (["abc"], False),
+        (tuple("abc"), False),
+        (set("abc"), False),
+        (dict.fromkeys("abc", object), False),
+    ],
+)
+def test_is_intlike(n: Any, bool_: bool):
+    assert _is_intlike(n) is bool_
+
+
+@pytest.mark.parametrize(
+    "nums, n",
+    [
+        (["1.0", 2.0, 3.00, Decimal(4), "-5.0"], 5),
+        (["1.1", 2.2, 3.03, "abc", "−12.49849"], 0),  # not regular `-`
+    ],
+)
+def test_get_n_intlike(nums: list[Any], n: int):
+    assert _get_n_intlike(nums) == n
+
+
+@pytest.mark.parametrize(
+    "n, result",
+    [
+        ("1.0", 1),
+        (2.0, 2),
+        (3.00, 3),
+        (Decimal(4), 4),
+        ("-5.0", -5),
+        ("−5.0", -5),  # not regular `-`
+    ],
+)
+def test_remove_exponent(n: int | float | str, result: int):
+    assert _remove_exponent(n) == result


### PR DESCRIPTION
Fix #279 . This PR aims to improve the display of integer or integerlike values in nanoplots. During the implementation, I came across two interesting findings in the code:
* Some locales may use the minus symbol `−` instead of `-`. Therefore, a conversion like `str(n).replace("−", "-")` might be necessary.
* The negative values appear to be handled appropriately with this approach.

## demo
```python
from great_tables import GT
import polars as pl

random_numbers_df = pl.DataFrame(
    {
        "i": range(1, 5),
        "lines": [
            "20 23 6 7 37 23 21 4 7 16",
            "2.3 6.8 9.2 2.42 3.5 12.1 5.3 3.6 7.2 3.74",
            "-12 -5 6 3.7 0 8 -7.4",
            "-12 0 15 7 8 10 1 24 17 13 6", # negative values should be ok
        ],
    }
).with_columns(bars=pl.col("lines"))

(
    GT(random_numbers_df, rowname_col="i")
    .fmt_nanoplot(columns="lines")
    .fmt_nanoplot(columns="bars", plot_type="bar")
)
```
![image](https://github.com/posit-dev/great-tables/assets/67060418/114ca562-250f-41e7-9979-bab00c09399b)

![image](https://github.com/posit-dev/great-tables/assets/67060418/ed087720-f124-4739-ad52-ce1b7542e401)
