### PR TITLE
fix: add tests for `cols_align` and extend support for `Polars` expressions

### DIFF
--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Any
 
+from ._locations import resolve_cols_c
 from ._utils import _assert_list_is_subset
+from ._tbl_data import SelectExpr
 
 if TYPE_CHECKING:
     from ._types import GTSelf
@@ -102,7 +104,7 @@ def cols_label(self: GTSelf, **kwargs: Any) -> GTSelf:
     return self._replace(_boxhead=boxhead)
 
 
-def cols_align(self: GTSelf, align: str = "left", columns: Optional[str] = None) -> GTSelf:
+def cols_align(self: GTSelf, align: str = "left", columns: SelectExpr = None) -> GTSelf:
     """
     Set the alignment of one or more columns.
 
@@ -161,5 +163,7 @@ def cols_align(self: GTSelf, align: str = "left", columns: Optional[str] = None)
     elif columns is None:
         columns = column_names
 
+    sel_cols = resolve_cols_c(data=self, expr=columns)
+
     # Set the alignment for each column
-    return self._replace(_boxhead=self._boxhead._set_column_aligns(columns, align=align))
+    return self._replace(_boxhead=self._boxhead._set_column_aligns(sel_cols, align=align))


### PR DESCRIPTION
Fix #51. This PR focuses on adding tests for `cols_align`. 

During the process, I discovered that it should be feasible for `cols_align` to support `Polars` expressions. This enhancement is achieved by adding `sel_cols = resolve_cols_c(data=self, expr=columns)`.
