### PR TITLE
fix: `CellStyleBorders` is not properly constructed when `sides` is set to "all"

### DIFF
--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -322,7 +322,12 @@ class CellStyleBorders(CellStyle):
 
         # If 'all' is provided then call the function recursively with all sides
         if "all" in self.sides:
-            return CellStyleBorders(sides=["top", "bottom", "left", "right"])._to_html_style()
+            return CellStyleBorders(
+                sides=["top", "bottom", "left", "right"],
+                color=self.color,
+                style=self.style,
+                weight=self.weight,
+            )._to_html_style()
 
         weight = self.weight
         if isinstance(weight, int):

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import polars as pl
-from great_tables._styles import CellStyleText, FromColumn
+from great_tables._styles import CellStyleText, CellStyleBorders, FromColumn
 
 
 def test_from_column_replace():
@@ -42,3 +42,14 @@ def test_cell_value_from_polars_expr():
     new_style = style._evaluate_expressions(df)._from_row(df, 0)
 
     assert new_style.color == "RED"
+
+
+def test_cell_style_borders_all():
+    res = CellStyleBorders(sides=["all"], color="blue")._to_html_style()
+    assert res.split(";") == [
+        "border-top: 1px solid blue",
+        "border-bottom: 1px solid blue",
+        "border-left: 1px solid blue",
+        "border-right: 1px solid blue",
+        "",
+    ]


### PR DESCRIPTION
It seems that the following code does not render as expected when `sides` is set to "all" for `style.borders`. The main reason might be the omission of other values while constructing a new `CellStyleBorders`.

```python
import polars as pl
from great_tables import GT, md, html, style, loc
from great_tables.data import islands

islands_mini = (
    pl.from_pandas(islands).sort("size", descending=True)
    .head(10)
)

(
    GT(islands_mini)
    .tab_style(
      style=style.borders(sides=["all"], style="solid", weight="4px", color="red"),
      locations=loc.body(rows=[-1])
    )
)
```

The table comparison before and after fixing can be found as below:

![comparison](https://github.com/posit-dev/great-tables/assets/67060418/e251bbfa-3cb8-4a2b-bc6a-2bc7d0fd77b9)
