### PR TITLE
docs: add examples to reference pages

### DIFF
--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -32,6 +32,18 @@ def as_raw_html(
     -------
     str
         An HTML fragment containing a table.
+
+    Examples:
+    ------
+    Let's use the `row` column of `exibble` dataset to create a table. With the `as_raw_html()`
+    method, we're able to output the HTML content.
+
+    ```{python}
+    from great_tables import GT, exibble
+
+    GT(exibble[["row"]]).as_raw_html()
+    ```
+
     """
     built_table = self._build_data(context="html")
 

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -98,6 +98,20 @@ def fmt(
     GT
         The GT object is returned. This is the same object that the method is called on so that we
         can facilitate method chaining.
+
+    Examples
+    --------
+    Let's use the `exibble` dataset to create a table. With the `fmt()` method, we'll add a prefix
+    `^` and a suffix `$` to the `row` and `group` columns.
+
+    ```{python}
+    from great_tables import GT, exibble
+
+    (
+        GT(exibble[["row", "group"]])
+        .fmt(lambda x: f"^{x}$")
+    )
+    ```
     """
 
     # If a single function is supplied to `fns` then

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -108,8 +108,8 @@ def fmt(
     from great_tables import GT, exibble
 
     (
-        GT(exibble[["row", "group"]])
-        .fmt(lambda x: f"^{x}$")
+        GT(exibble)
+        .fmt(lambda x: f"^{x}$", columns=["row", "group"])
     )
     ```
     """

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -872,6 +872,24 @@ def fmt_percent(
     [`GT()`](`great_tables.GT`)'s own `locale` argument (it is settable there as a value received by
     all other methods that have a `locale` argument).
 
+    Examples
+    --------
+    Let’s use the `towny` dataset as the input table. With the `fmt_percent()` method, we'll format
+    the `pop_change_2016_2021_pct` column to to display values as percentages (to two decimal
+    place).
+
+    ```{python}
+    from great_tables import GT
+    from great_tables.data import towny
+
+    towny_mini = (
+        towny[["name", "pop_change_2016_2021_pct"]]
+        .head(10)
+    )
+
+    (GT(towny_mini).fmt_percent("pop_change_2016_2021_pct", decimals=2))
+    ```
+
     See Also
     --------
     The functional version of this method,

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -3571,6 +3571,48 @@ def fmt_nanoplot(
     )
     ```
 
+    Here's an example to adjust some of the options using
+    [`nanoplot_options()`](`great_tables.nanoplot_options`).
+
+    ```{python}
+    (
+        GT(random_numbers_df, rowname_col="i")
+        .fmt_nanoplot(
+            columns="lines",
+            reference_line="mean",
+            reference_area=["min", "q1"],
+            options=nanoplot_options(
+                data_point_radius=8,
+                data_point_stroke_color="black",
+                data_point_stroke_width=2,
+                data_point_fill_color="white",
+                data_line_type="straight",
+                data_line_stroke_color="brown",
+                data_line_stroke_width=2,
+                data_area_fill_color="orange",
+                vertical_guide_stroke_color="green",
+            ),
+        )
+        .fmt_nanoplot(
+            columns="bars",
+            plot_type="bar",
+            reference_line="max",
+            reference_area=["max", "median"],
+            options=nanoplot_options(
+                data_bar_stroke_color="gray",
+                data_bar_stroke_width=2,
+                data_bar_fill_color="orange",
+                data_bar_negative_stroke_color="blue",
+                data_bar_negative_stroke_width=1,
+                data_bar_negative_fill_color="lightblue",
+                reference_line_color="pink",
+                reference_area_fill_color="bisque",
+                vertical_guide_stroke_color="blue",
+            ),
+        )
+    )
+    ```
+
     Single-value bar plots and line plots can be made with `fmt_nanoplot()`. These run in the
     horizontal direction, which is ideal for tabular presentation. The key thing here is that
     `fmt_nanoplot()` expects a column of numeric values. These plots are meant for comparison

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -2038,6 +2038,37 @@ def fmt_markdown(
         The GT object is returned. This is the same object that the method is called on so that we
         can facilitate method chaining.
 
+    Examples:
+    -------
+    Let’s first create a DataFrame containing some texts in Markdown-formatted and then introduce
+    that to [`GT()`](`great_tables.GT`). We’ll then transform the `md` column with the
+    `fmt_markdown()` method.
+
+    ```{python}
+    import pandas as pd
+    from great_tables import GT
+    from great_tables.data import towny
+
+    text_1 = \"""
+    ### This is Markdown.
+
+    Markdown’s syntax is comprised entirely of
+    punctuation characters, which punctuation
+    characters have been carefully chosen so as
+    to look like what they mean... assuming
+    you’ve ever used email.
+    \"""
+
+    text_2 = \"""
+    Info on Markdown syntax can be found
+    [here](https://daringfireball.net/projects/markdown/).
+    \"""
+
+    df = pd.DataFrame({"md": [text_1, text_2]})
+
+    (GT(df).fmt_markdown("md"))
+    ```
+
     See Also
     --------
     The functional version of this method,

--- a/great_tables/_helpers.py
+++ b/great_tables/_helpers.py
@@ -695,6 +695,10 @@ def nanoplot_options(
         If the values are to be displayed as currency values, supply either: (1) a 3-letter currency
         code (e.g., `"USD"` for U.S. Dollars, `"EUR"` for the Euro currency), or (2) a common
         currency name (e.g., `"dollar"`, `"pound"`, `"yen"`, etc.).
+
+    Examples
+    --------
+    See [`fmt_nanoplot()`](`great_tables.GT.fmt_nanoplot`)
     """
 
     data_point_radius = _normalize_listable_nanoplot_options(

--- a/great_tables/_helpers.py
+++ b/great_tables/_helpers.py
@@ -96,6 +96,10 @@ def md(text: str) -> Text:
     -------
     Text
         An instance of the Text class is returned, where the text `type` is `"from_markdown"`.
+
+    Examples
+    ------
+    See [`GT.tab_header()`](`great_tables._heading.tab_header`).
     """
     return Text(text=text, type="from_markdown")
 
@@ -117,6 +121,10 @@ def html(text: str) -> Text:
     -------
     Text
         An instance of the Text class is returned, where the text `type` is `"html"`.
+
+    Examples
+    ------
+    See [`GT.tab_header()`](`great_tables._heading.tab_header`).
     """
     return Text(text=text, type="html")
 

--- a/great_tables/_helpers.py
+++ b/great_tables/_helpers.py
@@ -99,7 +99,7 @@ def md(text: str) -> Text:
 
     Examples
     ------
-    See [`GT.tab_header()`](`great_tables._heading.tab_header`).
+    See [`GT.tab_header()`](`great_tables.GT.tab_header`).
     """
     return Text(text=text, type="from_markdown")
 
@@ -124,7 +124,7 @@ def html(text: str) -> Text:
 
     Examples
     ------
-    See [`GT.tab_header()`](`great_tables._heading.tab_header`).
+    See [`GT.tab_header()`](`great_tables.GT.tab_header`).
     """
     return Text(text=text, type="html")
 

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -103,6 +103,10 @@ class LocBody(Loc):
     -------
     LocBody
         A LocBody object, which is used for a `locations` argument if specifying the table body.
+
+    Examples
+    ------
+    See [`GT.tab_style()`](`great_tables._tab_create_modify.tab_style`).
     """
     columns: SelectExpr = None
     rows: RowSelectExpr = None

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -106,7 +106,7 @@ class LocBody(Loc):
 
     Examples
     ------
-    See [`GT.tab_style()`](`great_tables._tab_create_modify.tab_style`).
+    See [`GT.tab_style()`](`great_tables.GT.tab_style`).
     """
     columns: SelectExpr = None
     rows: RowSelectExpr = None

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1001,6 +1001,32 @@ def opt_table_outline(
     GT
         The GT object is returned. This is the same object that the method is called on so that we
         can facilitate method chaining.
+
+    Examples
+    --------
+    Using select columns from the `exibble` dataset, let's create a table with a number of
+    components added. Following that, we'll puts an outline around the entire table using the
+    `opt_table_outline()` method.
+
+    ```{python}
+    from great_tables import GT, exibble, md
+
+    (
+      GT(
+        exibble[["num", "char", "currency", "row", "group"]],
+        rowname_col="row",
+        groupname_col="group"
+      )
+      .tab_header(
+        title=md("Data listing from **exibble**"),
+        subtitle=md("`exibble` is a **Great Tables** dataset.")
+      )
+      .fmt_number(columns="num")
+      .fmt_currency(columns="currency")
+      .tab_source_note(source_note="This is only a subset of the dataset.")
+      .opt_table_outline()
+    )
+    ```
     """
 
     # Validate the `style` argument

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -446,6 +446,23 @@ def cols_hide(data: GTSelf, columns: SelectExpr) -> GTSelf:
         The GT object is returned. This is the same object that the method is called on so that we
         can facilitate method chaining.
 
+
+    Examples
+    --------
+    For this example, we'll use a portion of the `countrypops` dataset to create a simple table.
+    Let's hide the `year` column with the `cols_hide()` method.
+
+    ```{python}
+    from great_tables import GT
+    from great_tables.data import countrypops
+
+    countrypops_mini = countrypops.loc[countrypops["country_name"] == "Benin"][
+        ["country_name", "year", "population"]
+    ].tail(5)
+
+    GT(countrypops_mini).cols_hide(columns="year")
+    ```
+
     Details
     -------
     The hiding of columns is internally a rendering directive, so, all columns that are 'hidden' are

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -400,6 +400,7 @@ def cols_move_to_end(data: GTSelf, columns: SelectExpr) -> GTSelf:
 
     ```{python}
     GT(countrypops_mini).cols_move_to_end(columns=["year", "country_name"])
+    ```
     """
 
     # If `columns` is a string, convert it to a list

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -184,7 +184,7 @@ class CellStyleText(CellStyle):
 
     Examples
     ------
-    See [`GT.tab_style()`](`great_tables._tab_create_modify.tab_style`).
+    See [`GT.tab_style()`](`great_tables.GT.tab_style`).
     """
 
     color: str | ColumnExpr | None = None
@@ -270,7 +270,7 @@ class CellStyleFill(CellStyle):
 
     Examples
     ------
-    See [`GT.tab_style()`](`great_tables._tab_create_modify.tab_style`).
+    See [`GT.tab_style()`](`great_tables.GT.tab_style`).
     """
 
     color: str | ColumnExpr
@@ -311,7 +311,7 @@ class CellStyleBorders(CellStyle):
 
     Examples
     ------
-    See [`GT.tab_style()`](`great_tables._tab_create_modify.tab_style`).
+    See [`GT.tab_style()`](`great_tables.GT.tab_style`).
     """
 
     sides: (

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -181,6 +181,10 @@ class CellStyleText(CellStyle):
     CellStyleText
         A CellStyleText object, which is used for a `styles` argument if specifying any cell text
         properties.
+
+    Examples
+    ------
+    See [`GT.tab_style()`](`great_tables._tab_create_modify.tab_style`).
     """
 
     color: str | ColumnExpr | None = None
@@ -263,6 +267,10 @@ class CellStyleFill(CellStyle):
     CellStyleFill
         A CellStyleFill object, which is used for a `styles` argument if specifying a cell fill
         value.
+
+    Examples
+    ------
+    See [`GT.tab_style()`](`great_tables._tab_create_modify.tab_style`).
     """
 
     color: str | ColumnExpr
@@ -300,6 +308,10 @@ class CellStyleBorders(CellStyle):
     -------
     CellStyleBorders
         A CellStyleBorders object, which is used for a `styles` argument if specifying cell borders.
+
+    Examples
+    ------
+    See [`GT.tab_style()`](`great_tables._tab_create_modify.tab_style`).
     """
 
     sides: (

--- a/great_tables/_tab_create_modify.py
+++ b/great_tables/_tab_create_modify.py
@@ -73,11 +73,14 @@ def tab_style(
     ```
 
     Let's use `exibble` once again to create a simple, two-column output table (keeping only the
-    `num` and `currency` columns). With the `tab_style()` method (called twice), we'll add style to
+    `num` and `currency` columns). With the `tab_style()` method (called thrice), we'll add style to
     the values already formatted by `fmt_number()` and `fmt_currency()`. In the `style` argument of
-    each `tab_style()` call, we can define multiple types of styling with the `style.fill()` and
-    `style.text()` classes (enclosing these in a list). The cells to be targeted for styling require
-    the use of `loc.body()`, which is used here with different columns being targeted.
+    the first two `tab_style()` call, we can define multiple types of styling with the
+    `style.fill()` and `style.text()` classes (enclosing these in a list). The cells to be targeted
+    for styling require the use of `loc.body()`, which is used here with different columns being
+    targeted. For the final `tab_style()` call, we demonstrate the use of `style.borders()` class
+    as the `style` argument, which is employed in conjunction with `loc.body()` to locate the row to
+    be styled.
 
     ```{python}
     from great_tables import GT, style, loc, exibble
@@ -99,6 +102,10 @@ def tab_style(
                 style.text(style="italic")
             ],
             locations=loc.body(columns="currency")
+        )
+        .tab_style(
+            style=style.borders(sides=["top", "bottom"], weight='2px', color="red"),
+            locations=loc.body(rows=[4])
         )
     )
     ```

--- a/great_tables/_tab_create_modify.py
+++ b/great_tables/_tab_create_modify.py
@@ -40,6 +40,12 @@ def tab_style(
         The cell or set of cells to be associated with the style. The `loc.body()` class can be used
         here to easily target body cell locations.
 
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+
     Examples
     --------
     Let's use a small subset of the `exibble` dataset to demonstrate how to use `tab_style()` to
@@ -96,12 +102,6 @@ def tab_style(
         )
     )
     ```
-
-    Returns
-    -------
-    GT
-        The GT object is returned. This is the same object that the method is called on so that we
-        can facilitate method chaining.
     """
 
     if not isinstance(style, list):


### PR DESCRIPTION
Fix #322.

This PR aims to enhance our documentation by:
* Adding missing examples.
* Adding reference links for `md()` and `html()` to `GT.tab_header()`.
* Adding reference links for `loc.body()`, `style.fill()`, `style.text()`, and `style.borders()` to `GT.tab_style()`.

It appears that we might encounter a minor issue with `GT.save()` at this moment, so I'll leave the examples blank for now.