### PR TITLE
fix: ensure export() always captures full table

### DIFF
--- a/.github/scripts/save_browser_table.py
+++ b/.github/scripts/save_browser_table.py
@@ -20,9 +20,11 @@ with tempfile.TemporaryDirectory() as tmp_dir:
     p_tmp_dir = Path(tmp_dir)
     for driver in drivers:
         for scale in (0.5, 1.0, 2.0, 3.25):
-            fname = str(p_tmp_dir / f"exibble_{driver}_{scale}.png")
-            GT(exibble).save(fname, web_driver=driver, scale=scale)
-            driver_results[driver].append(fname)
+            for debug in [False, True]:
+                is_debug = "debug" if debug else "cropped"
+                fname = str(p_tmp_dir / f"exibble_{driver}_{scale}_{is_debug}.png")
+                GT(exibble).save(fname, web_driver=driver, scale=scale, debug_dump=debug)
+                driver_results[driver].append(fname)
 
     with open(out_name, "w") as f:
         f.write("<html><head></head><body>\n\n")

--- a/.github/scripts/save_browser_table.py
+++ b/.github/scripts/save_browser_table.py
@@ -20,10 +20,9 @@ with tempfile.TemporaryDirectory() as tmp_dir:
     p_tmp_dir = Path(tmp_dir)
     for driver in drivers:
         for scale in (0.5, 1.0, 2.0, 3.25):
-            for debug in [False, True]:
-                is_debug = "debug" if debug else "cropped"
-                fname = str(p_tmp_dir / f"exibble_{driver}_{scale}_{is_debug}.png")
-                GT(exibble).save(fname, web_driver=driver, scale=scale, debug_dump=debug)
+            for debug in [None, "zoom", "final_resize"]:
+                fname = str(p_tmp_dir / f"exibble_{driver}_{scale}_{debug}.png")
+                GT(exibble).save(fname, web_driver=driver, scale=scale, _debug_dump=debug)
                 driver_results[driver].append(fname)
 
     with open(out_name, "w") as f:

--- a/.github/scripts/save_browser_table.py
+++ b/.github/scripts/save_browser_table.py
@@ -1,0 +1,37 @@
+import base64
+import sys
+import tempfile
+
+from collections import defaultdict
+from great_tables import GT, exibble
+from pathlib import Path
+
+
+def file_to_base64(fname):
+    with open(fname, "rb") as f:
+        return base64.b64encode(f.read()).decode()
+
+
+out_name, drivers = sys.argv[1], sys.argv[2:]
+assert set(drivers).issubset({"chrome", "safari", "firefox", "edge"})
+
+driver_results = defaultdict(list)
+with tempfile.TemporaryDirectory() as tmp_dir:
+    p_tmp_dir = Path(tmp_dir)
+    for driver in drivers:
+        for scale in (0.5, 1.0, 2.0, 3.25):
+            fname = str(p_tmp_dir / f"exibble_{driver}_{scale}.png")
+            GT(exibble).save(fname, web_driver=driver, scale=scale)
+            driver_results[driver].append(fname)
+
+    with open(out_name, "w") as f:
+        f.write("<html><head></head><body>\n\n")
+        for driver, img_names in driver_results.items():
+            f.write(f"<h1>{driver}</h1>\n\n")
+            for fname in img_names:
+                style = """style="width: 400px; height: auto;" """
+                f.write(f"<h2>{Path(fname).name}</h2>\n\n")
+                f.write(
+                    f"""<img src="data:image/png;base64, {file_to_base64(fname)}" {style}> \n\n"""
+                )
+        f.write("</body></html>")

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -79,6 +79,9 @@ jobs:
       - run: firefox --version
       - uses: browser-actions/setup-chrome@v1
       - run: chrome --version
+      - uses: browser-actions/setup-edge@v1
+      - name: Print Edge version
+        run: (Get-Item (Get-Command msedge).Source).VersionInfo.ProductVersion
 
       #
       - uses: actions/checkout@v4
@@ -92,7 +95,7 @@ jobs:
           pip install pandas
       - name: save browser tables
         run: |
-            make save-browser-table
+            make save-browser-table-ci
       - uses: actions/upload-artifact@v4
         with:
           name: browser-save-image

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -40,6 +40,21 @@ jobs:
           name: "py${{ matrix.python-version }}"
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          pip install -e '.[all]'
+      - name: pytest unit tests
+        run: |
+          make test
+
   test-pandas:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -80,8 +80,6 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
       - run: chrome --version
       - uses: browser-actions/setup-edge@v1
-      - name: Print Edge version
-        run: (Get-Item (Get-Command msedge).Source).VersionInfo.ProductVersion
 
       #
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -55,6 +55,35 @@ jobs:
         run: |
           make test-no-pandas
 
+  browser-save-image-test:
+    name: "Test for saving table image with browser"
+    runs-on: ubuntu-latest
+    steps:
+      # browsers
+      - uses: browser-actions/setup-firefox@v1
+      - run: firefox --version
+      - uses: browser-actions/setup-chrome@v1
+      - run: chrome --version
+
+      #
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          pip install -e '.[extra]'
+          pip install pandas
+      - name: save browser tables
+        run: |
+            make save-browser-table
+      - uses: actions/upload-artifact@v4
+        with:
+          name: browser-save-image
+          path: _browser-tests.html
+          if-no-files-found: error
+
   release-pypi:
     name: "Release to pypi"
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,6 @@ install: dist ## install the package to the active Python's site-packages
 
 save-browser-table:
 	python .github/scripts/save_browser_table.py _browser-tests.html chrome firefox
+
+save-browser-table-ci:
+	python .github/scripts/save_browser_table.py _browser-tests.html chrome firefox edge

--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,6 @@ docs-build:
 
 install: dist ## install the package to the active Python's site-packages
 	python3 -m pip install --force-reinstall dist/gt*.whl
+
+save-browser-table:
+	python .github/scripts/save_browser_table.py _browser-tests.html chrome firefox

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import tempfile
+import time
 import warnings
 
 from typing import TYPE_CHECKING, Literal
@@ -228,6 +229,10 @@ def _save_screenshot(
     # This approach works on the following assumptions:
     #   * Zoomed table width cannot always be obtained directly, but is its clientWidth * scale
     #   * Zoomed table height is obtained by the height of the div wrapping it
+    #   * A sleep may be necessary before the final screen capture
+    #
+    # I can't say for sure whether the final sleep is needed. Only that it seems like
+    # on CI with firefox sometimes the final screencapture is wider than necessary.
 
     original_size = driver.get_window_size()
 
@@ -276,6 +281,8 @@ def _save_screenshot(
         return _dump_debug_screenshot(driver, path)
 
     el = driver.find_element(by=By.TAG_NAME, value="body")
+
+    time.sleep(0.05)
 
     if path.endswith(".png"):
         el.screenshot(path)

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -76,6 +76,7 @@ def save(
     web_driver: WebDrivers = "chrome",
     window_size: tuple[int, int] = (6000, 6000),
     debug_port: None | int = None,
+    debug_dump: bool = False,
 ) -> None:
     """
     Produce a high-resolution image file or PDF of the table.
@@ -105,6 +106,9 @@ def save(
         to capture a table, but may affect the tables appearance.
     debug_port
         Port number to use for debugging. By default no debugging port is opened.
+    debug_dump
+        Whether the saved image should be a big browser window, with key elements outlined. This is
+        helpful for debugging this function's resizing, cropping heuristics.
 
     Returns
     -------
@@ -197,7 +201,7 @@ def save(
         headless_browser.set_window_size(window_size[0], window_size[1])
         headless_browser.get("file://" + temp_file.name)
 
-        _save_screenshot(headless_browser, scale, file)
+        _save_screenshot(headless_browser, scale, file, debug=debug_dump)
 
         if debug_port:
             input(
@@ -208,7 +212,7 @@ def save(
             )
 
 
-def _save_screenshot(driver: webdriver.Chrome, scale, path: str) -> None:
+def _save_screenshot(driver: webdriver.Chrome, scale, path: str, debug: bool = False) -> None:
     from io import BytesIO
     from selenium.webdriver.common.by import By
 
@@ -229,6 +233,15 @@ def _save_screenshot(driver: webdriver.Chrome, scale, path: str) -> None:
         "el.parentNode.style.display='none'; "
         "el.parentNode.style.display='';"
     )
+
+    if debug:
+        driver.execute_script(
+            "document.body.style.border = '5px solid blue'; "
+            "document.body.childNodes[0].style.border = '5px solid orange'; "
+            "document.getElementsByTagName('table')[0].style.border = '5px solid green'; "
+        )
+        driver.save_screenshot(path)
+        return
 
     # get table width and height, resizing window as we go ----
 

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -174,12 +174,14 @@ def save(
         wd_options = webdriver.EdgeOptions()
 
     # specify headless flag ----
-    # note that safari currently doesn't support headless browsing
-    if web_driver == "firefox":
+    if web_driver in {"firefox", "edge"}:
         wd_options.add_argument("--headless")
-    else:
+    elif web_driver == "chrome":
         # Operate all webdrivers in headless mode
         wd_options.add_argument("--headless=new")
+    else:
+        # note that safari currently doesn't support headless browsing
+        pass
 
     if debug_port:
         if web_driver == "chrome":

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
     # Note that as_raw_html uses methods on the GT class, not just data
     from .gt import GT
 
+    from selenium import webdriver
+
 
 def as_raw_html(
     self: GT,
@@ -72,17 +74,12 @@ def save(
     expand: int = 5,
     web_driver: WebDrivers = "chrome",
     window_size: tuple[int, int] = (6000, 6000),
+    debug_port: None | int = None,
 ) -> None:
     """
-    Save a table as an image file or a PDF document.
+    Produce a high-resolution image file or PDF of the table.
 
-    The `save()` method makes it easy to save a table object as an image file. The function produces
-    a high-resolution image file or PDF of the table. The output file is create by first taking a
-    screenshot of the table using a headless Chrome browser (other browser options are possible if
-    Chrome isn't present). The screenshot is then cropped to only include the table element, with
-    some additional pixels added around the table (controlled by the `expand=` parameter). Finally,
-    the resulting image is saved to the specified file path in the format specified (via the file
-    extension).
+    The output file is created by taking a screenshot of the table using a headless browser.
 
     Parameters
     ----------
@@ -90,33 +87,23 @@ def save(
         The name of the file to save the image to. Accepts names ending with .png, .bmp, and other
         image extensions. Also accepts the extension .pdf.
     selector
-        The HTML element selector to use to select the table. By default, this is set to "table",
-        which selects the first table element in the HTML content.
+        (NOT IMPLEMENTED) The HTML element name used to select table. Defaults to the whole table.
     scale
-        The scaling factor that will be used when generating the image. By default, this is set to a
-        value of `1.0`. Lowering this will result in a smaller image, whereas increasing it will
-        result in a much higher-resolution image. This can be considered a quality setting, yet it
-        also affects the file size. The default value of `1.0` is a good balance between file size
-        and quality.
+        The scaling factor that will be used when generating the image.  Lower values decrease
+        resolution. A scale of 2 is equivalent to doubling the width of the table in pixels. Note
+        that higher resolution results in larger file sizes.
     expand
-        The number of pixels to expand the screenshot by. By default, this is set to 5. This can be
+        (NOT IMPLEMENTED) The number of pixels to expand the screenshot by.  This can be
         increased to capture more of the surrounding area, or decreased to capture less.
     web_driver
-        The webdriver to use when taking the screenshot. By default, this is set to `"chrome"` which
-        uses Google Chrome in headless mode. If that browser isn't available on the host system,
-        there are other options available: `"firefox"` (Mozilla Firefox), `"safari"` (Apple Safari),
-        and `"edge"` (Microsoft Edge). Ensure that at least one of these browsers is installed on
-        the system and choose the appropriate option based on that.
+        The webdriver to use when taking the screenshot. By default, uses Google Chrome. Supports
+        `"firefox"` (Mozilla Firefox), `"safari"` (Apple Safari), and `"edge"` (Microsoft Edge).
+        Specified browser must be installed.
     window_size
-        The size of the window to use when taking the screenshot. This is a tuple of two integers,
-        representing the width and height of the window. By default, this is set to `(6000, 6000)`,
-        a large size that should be sufficient for most tables. If the table is larger than this
-        (and this will be obvious once inspecting the image file) you can increase the appropriate
-        values of the tuple. If the table is very small, then a reduction in these these values will
-        result in a speed gain during image capture. Please note that the window size is *not* the
-        same as the final image size. The table will be captured at the same size as it is displayed
-        in the headless browser, and the window size is used to ensure that the entire table is
-        visible in the screen capture before the cropping process occurs.
+        The size of the browser window to use when laying out the table. This shouldn't be necessary
+        to capture a table, but may affect the tables appearance.
+    debug_port
+        Port number to use for debugging. By default no debugging port is opened.
 
     Returns
     -------
@@ -146,15 +133,13 @@ def save(
     """
 
     # Import the required packages
-    _try_import(name="selenium", pip_install_line="pip install selenium")
     _try_import(name="PIL", pip_install_line="pip install pillow")
+    _try_import(name="selenium", pip_install_line="pip install selenium")
 
     from selenium import webdriver
-    from selenium.webdriver.common.by import By
-    from PIL import Image
-    from io import BytesIO
 
-    Image.MAX_IMAGE_PIXELS = None
+    if selector != "table":
+        raise NotImplementedError("Currently, only selector='table' is supported.")
 
     # Get the file extension from the file name
     file_extension = file.split(".")[-1]
@@ -188,8 +173,8 @@ def save(
     if web_driver != "firefox":
         wd_options.add_argument(str("--headless"))
 
-    wd_options.add_argument(f"--width={window_size[0]}")
-    wd_options.add_argument(f"--height={window_size[1]}")
+    if debug_port:
+        wd_options.add_argument(f"--remote-debugging-port={debug_port}")
 
     with (
         tempfile.NamedTemporaryFile(suffix=".html", dir=temp_dir) as temp_file,
@@ -200,44 +185,58 @@ def save(
         with open(temp_file.name, "w") as fp:
             fp.write(html_content)
 
-        # Convert the scale value to a percentage string used by the
-        # Chrome browser for zooming
-        zoom_level = str(scale * 100) + "%"
-
-        # Get the scaling factor by multiplying `scale` by 2
-        scaling_factor = scale * 2
-
-        # Adjust the expand value by the scaling factor
-        expansion_amount = expand * scaling_factor
-
         # Open the HTML file in the headless browser
+        headless_browser.set_window_size(window_size[0], window_size[1])
         headless_browser.get("file://" + temp_file.name)
-        headless_browser.execute_script(f"document.body.style.zoom = '{zoom_level}'")
 
-        # Get only the chosen element from the page; by default, this is the table element
-        element = headless_browser.find_element(by=By.TAG_NAME, value=selector)
+        _save_screenshot(headless_browser, scale, file)
 
-        # Get the location and size of the table element; this will be used
-        # to crop the screenshot later
-        location = element.location
-        size = element.size
+        if debug_port:
+            input(
+                f"Currently debugging on port {debug_port}.\n\n"
+                "If you are using Chrome, enter chrome://inspect to preview the headless browser."
+                "Other browsers may have different ways to preview headless browser sessions.\n\n"
+                "Press enter to continue."
+            )
 
-        # Get a screenshot of the entire page as a PNG image
-        png = headless_browser.get_screenshot_as_png()
 
-    # Open the screenshot as an image with the PIL library; since the screenshot will be large
-    # (due to the large window size), we use the BytesIO class to handle the large image data
-    image = Image.open(fp=BytesIO(png))
+def _save_screenshot(driver: webdriver.Chrome, scale, path: str) -> None:
+    from PIL import Image
+    from io import BytesIO
+    from selenium.webdriver.common.by import By
 
-    # Crop the image to only include the table element; the scaling factor
-    # of 6 is used to account for the zoom level of 300% set earlier
-    left = (location["x"] * scaling_factor) - expansion_amount
-    top = (location["y"] * scaling_factor) - expansion_amount
-    right = ((location["x"] + size["width"]) * scaling_factor) + expansion_amount
-    bottom = ((location["y"] + size["height"]) * scaling_factor) + expansion_amount
+    # Based on: https://stackoverflow.com/a/52572919/
+    # In some headless browsers, element position and width do not always reflect
+    # css transforms like zoom.
+    #
+    # This approach works on the following assumptions:
+    #   * Zoomed table width cannot always be obtained directly, but is clientWidth * scale
+    #   * Zoomed table height is accurately obtained by body scrollHeight
 
-    # Save the cropped image to the output path
-    image = image.crop((left, top, right, bottom))
+    original_size = driver.get_window_size()
 
-    # Save the image to the output path in the specified format
-    image.save(fp=file)
+    # set table zoom ----
+    driver.execute_script(
+        f"var el = document.getElementsByTagName('table')[0]; el.style.zoom = '{scale}';"
+    )
+
+    # get table width and height ----
+    reported_width = driver.execute_script(
+        "return document.getElementsByTagName('table')[0].clientWidth"
+    )
+
+    required_width = reported_width * scale
+    required_height = driver.execute_script("return document.body.scrollHeight")
+
+    # resize window and capture image ----
+    driver.set_window_size(required_width, required_height)
+    el = driver.find_element(by=By.TAG_NAME, value="body")
+
+    if path.endswith(".png"):
+        el.screenshot(path)
+    else:
+        png = driver.get_screenshot_as_png()
+        Image.open(fp=BytesIO(png)).save(fp=path)
+
+    # set window back to original size ----
+    driver.set_window_size(original_size["width"], original_size["height"])

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -152,9 +152,6 @@ def save(
     # Get the HTML content from the displayed output
     html_content = as_raw_html(self)
 
-    # Create a temp directory to store the HTML file
-    temp_dir = tempfile.mkdtemp()
-
     # Set the webdriver and options based on the chosen browser (`web_driver=` argument)
     if web_driver == "chrome":
         wdriver = webdriver.Chrome
@@ -189,13 +186,13 @@ def save(
 
     # run browser ----
     with (
-        tempfile.NamedTemporaryFile(suffix=".html", dir=temp_dir) as temp_file,
+        tempfile.TemporaryDirectory() as tmp_dir,
         wdriver(options=wd_options) as headless_browser,
     ):
 
         # Write the HTML content to the temp file
-        with open(temp_file.name, "w") as fp:
-            fp.write(html_content)
+        with open(f"{tmp_dir}/table.html", "w") as temp_file:
+            temp_file.write(html_content)
 
         # Open the HTML file in the headless browser
         headless_browser.set_window_size(window_size[0], window_size[1])

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -134,7 +134,6 @@ def save(
     """
 
     # Import the required packages
-    _try_import(name="PIL", pip_install_line="pip install pillow")
     _try_import(name="selenium", pip_install_line="pip install selenium")
 
     from selenium import webdriver
@@ -210,7 +209,6 @@ def save(
 
 
 def _save_screenshot(driver: webdriver.Chrome, scale, path: str) -> None:
-    from PIL import Image
     from io import BytesIO
     from selenium.webdriver.common.by import By
 
@@ -236,7 +234,8 @@ def _save_screenshot(driver: webdriver.Chrome, scale, path: str) -> None:
 
     # the window can be bigger than the table, but smaller risks pushing text
     # onto new lines. this pads width and height for a little slack.
-    crud_factor = 10
+    # note that this is mostly to account for body, div padding, and table borders.
+    crud_factor = 100
 
     offset_left, offset_top = driver.execute_script(
         "var div = document.body.childNodes[0]; return [div.offsetLeft, div.offsetTop];"
@@ -263,5 +262,14 @@ def _save_screenshot(driver: webdriver.Chrome, scale, path: str) -> None:
     if path.endswith(".png"):
         el.screenshot(path)
     else:
-        png = driver.get_screenshot_as_png()
-        Image.open(fp=BytesIO(png)).save(fp=path)
+        _try_import(name="PIL", pip_install_line="pip install pillow")
+
+        from PIL import Image
+
+        # convert to other formats (e.g. pdf, bmp) using PIL
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            fname = f"{tmp_dir}/image.png"
+            el.screenshot(fname)
+
+            with open(fname, "rb") as f:
+                Image.open(fp=BytesIO(f)).save(fp=path)

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import tempfile
-from typing import TYPE_CHECKING, Literal
+import warnings
 
+from typing import TYPE_CHECKING, Literal
 from typing_extensions import TypeAlias
 
 from ._utils import _try_import
@@ -177,7 +178,14 @@ def save(
         wd_options.add_argument("--headless=new")
 
     if debug_port:
-        wd_options.add_argument(f"--remote-debugging-port={debug_port}")
+        if web_driver == "chrome":
+            wd_options.add_argument(f"--remote-debugging-port={debug_port}")
+        elif web_driver == "firefox":
+            # TODO: not sure how to connect to this session on firefox?
+            wd_options.add_argument(f"--start-debugger-server {debug_port}")
+        else:
+            warnings.warn("debug_port argument only supported on chrome and firefox")
+            debug_port = None
 
     # run browser ----
     with (
@@ -231,7 +239,7 @@ def _save_screenshot(driver: webdriver.Chrome, scale, path: str) -> None:
 
     # the window can be bigger than the table, but smaller risks pushing text
     # onto new lines. this pads width and height for a little slack.
-    crud_factor = 100
+    crud_factor = 10
 
     offset_left, offset_top = driver.execute_script(
         "var div = document.body.childNodes[0]; return [div.offsetLeft, div.offsetTop];"

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -168,10 +168,8 @@ def save(
         wdriver = webdriver.Edge
         wd_options = webdriver.EdgeOptions()
 
-    # All webdrivers except for 'Firefox' can operate in headless mode; they all accept window size
-    # options are separate width and height arguments
-    if web_driver != "firefox":
-        wd_options.add_argument(str("--headless"))
+    # Operate all webdrivers in headless mode
+    wd_options.add_argument("--headless=new")
 
     if debug_port:
         wd_options.add_argument(f"--remote-debugging-port={debug_port}")

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -168,12 +168,18 @@ def save(
         wdriver = webdriver.Edge
         wd_options = webdriver.EdgeOptions()
 
-    # Operate all webdrivers in headless mode
-    wd_options.add_argument("--headless=new")
+    # specify headless flag ----
+    # note that safari currently doesn't support headless browsing
+    if web_driver == "firefox":
+        wd_options.add_argument("--headless")
+    else:
+        # Operate all webdrivers in headless mode
+        wd_options.add_argument("--headless=new")
 
     if debug_port:
         wd_options.add_argument(f"--remote-debugging-port={debug_port}")
 
+    # run browser ----
     with (
         tempfile.NamedTemporaryFile(suffix=".html", dir=temp_dir) as temp_file,
         wdriver(options=wd_options) as headless_browser,

--- a/great_tables/_locale.py
+++ b/great_tables/_locale.py
@@ -9,7 +9,7 @@ DATA_MOD = files("great_tables") / "data"
 
 
 def read_csv(fname: str) -> list[dict[str, Any]]:
-    with open(fname) as f:
+    with open(fname, encoding="utf8") as f:
         return list(DictReader(f))
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,3 +1,4 @@
+import sys
 import time
 from pathlib import Path
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -30,6 +30,7 @@ def test_html_string_generated(gt_tbl: GT, snapshot: str):
     assert snapshot == gt_tbl.as_raw_html()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="chrome might not be installed.")
 @pytest.mark.extra
 def test_save_image_file(gt_tbl: GT):
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -4,6 +4,7 @@ from typing import Any, Union
 import pandas as pd
 import polars as pl
 import pytest
+import sys
 from great_tables import GT, _locale
 from great_tables._data_color.base import _html_color
 from great_tables._formats import (
@@ -1481,6 +1482,7 @@ def test_fmt_image_width_int():
         formatter.to_html("/a")
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="uses linux specific paths")
 def test_fmt_image_path():
     formatter = FmtImage(encode=False, path="/a/b")
     res = formatter.to_html("c")

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -38,6 +38,13 @@ def assert_repr_html(snapshot, gt):
     assert snapshot == body
 
 
+def strip_windows_drive(x):
+    # this is a hacky approach to ensuring fmt_image path tests succeed
+    # on our windows build. On linux root is just "/". On windows its a
+    # drive name. Assumes our windows runner uses D:\
+    return x.replace('src="D:\\', 'src="')
+
+
 def test_format_fns():
     df = pd.DataFrame({"x": [1, 2]})
     gt = GT(df)
@@ -1408,7 +1415,7 @@ def test_fmt_image_single():
     res = formatter.to_html("/a")
     dst = formatter.SPAN_TEMPLATE.format('<img src="/a.svg" style="vertical-align: middle;">')
 
-    assert res == dst
+    assert strip_windows_drive(res) == dst
 
 
 def test_fmt_image_missing():
@@ -1428,7 +1435,7 @@ def test_fmt_image_multiple():
         '<img src="/b.svg" style="vertical-align: middle;">'
     )
 
-    assert res == dst
+    assert strip_windows_drive(res) == dst
 
 
 def test_fmt_image_encode(tmpdir):
@@ -1446,7 +1453,7 @@ def test_fmt_image_encode(tmpdir):
     img_src = f"data: image/svg+xml; base64,{b64_content}"
     dst = formatter.SPAN_TEMPLATE.format(f'<img src="{img_src}" style="vertical-align: middle;">')
 
-    assert res == dst
+    assert strip_windows_drive(res) == dst
 
 
 def test_fmt_image_width_height_str():
@@ -1455,7 +1462,7 @@ def test_fmt_image_width_height_str():
     dst_img = '<img src="/a" style="height: 30px;width: 20px;vertical-align: middle;">'
     dst = formatter.SPAN_TEMPLATE.format(dst_img)
 
-    assert res == dst
+    assert strip_windows_drive(res) == dst
 
 
 def test_fmt_image_height_int():
@@ -1464,7 +1471,7 @@ def test_fmt_image_height_int():
     dst_img = '<img src="/a" style="height: 30px;vertical-align: middle;">'
     dst = formatter.SPAN_TEMPLATE.format(dst_img)
 
-    assert res == dst
+    assert strip_windows_drive(res) == dst
 
 
 def test_fmt_image_width_int():
@@ -1477,7 +1484,7 @@ def test_fmt_image_width_int():
 def test_fmt_image_path():
     formatter = FmtImage(encode=False, path="/a/b")
     res = formatter.to_html("c")
-    assert 'src="/a/b/c"' in res
+    assert 'src="/a/b/c"' in strip_windows_drive(res)
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -42,7 +42,7 @@ def strip_windows_drive(x):
     # this is a hacky approach to ensuring fmt_image path tests succeed
     # on our windows build. On linux root is just "/". On windows its a
     # drive name. Assumes our windows runner uses D:\
-    return x.replace('src="D:\\', 'src="')
+    return x.replace('src="D:\\', 'src="/')
 
 
 def test_format_fns():


### PR DESCRIPTION
This PR refactors the `GT.save()` function to be a bit more robust, by...

* Screenshotting table element directly (prev screenshotted full window, then cropped using PIL)
* Dumping images into _browser-tests.html in our CI, and uploading as an artifact
* Supporting two debugging modes
  - opening a debugging port (accessible via e.g. `chrome://inspect`)
  - optionally dumping full browser screenshots with elements highlighted w/ borders (supports dumping at 3 stages: zoom, width_resize, final_resize). 

This PR supercedes (aka cribs) the best parts of...

* #276
* #300 

This PR should resolve...

* https://github.com/posit-dev/great-tables/issues/234