### PR TITLE
Ci docs preview

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+      - docs-preview-*
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - main
-      - docs-preview-*
+      - 'docs-preview-**'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This PR enables branches named `docs-preview-*` on our repo to deploy preview docs. This enables us to push specific PR branches from forks to our repo, to quickly preview.