### PR TITLE
Support specifying a subset of rows in `GT.data_color()`

### DIFF
--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -21,7 +21,7 @@ RGBColor: TypeAlias = tuple[int, int, int]
 def data_color(
     self: GTSelf,
     columns: SelectExpr = None,
-    rows: RowSelectExpr = None,
+    include_last_row: bool = True,
     palette: str | list[str] | None = None,
     domain: list[str] | list[int] | list[float] | None = None,
     na_color: str | None = None,
@@ -49,10 +49,10 @@ def data_color(
     columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    rows
-        In conjunction with `columns=`, we can specify which rows should be colored. By default,
-        all rows in the targeted columns will be colored. Alternatively, we can provide a list
-        of row indices.
+    include_last_row
+        Whether to include the last row for color styling. The default is set to `True`, but it
+        can be useful to set it to `False` if the last row is a summary or subtotal row of the
+        table.
     palette
         The color palette to use. This should be a list of colors (e.g., `["#FF0000", "#00FF00",
         "#0000FF"]`). A ColorBrewer palette could also be used, just supply the name (reference
@@ -213,8 +213,12 @@ def data_color(
     else:
         columns_resolved = resolve_cols_c(data=self, expr=columns)
 
-    row_res = resolve_rows_i(self, rows)
+    row_res = resolve_rows_i(self)  # get all rows
     row_pos = [name_pos[1] for name_pos in row_res]
+    if not include_last_row:
+        # Excluding the last row for now;
+        # adjustments may be needed after implementing `summary_rows()`.
+        row_pos = row_pos[:-1]
 
     gt_obj = self
 
@@ -268,7 +272,7 @@ def data_color(
 
         # for every color value in color_vals, apply a fill to the corresponding cell
         # by using `tab_style()`
-        for i, color_val in zip(row_pos, color_vals):
+        for i, color_val in enumerate(color_vals):
             if autocolor_text:
                 fgnd_color = _ideal_fgnd_color(bgnd_color=color_val)
 

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -266,25 +266,21 @@ def data_color(
         # Replace 'None' and 'np.nan' values in `color_vals` with the `na_color=` color
         color_vals = [na_color if is_na(data_table, x) else x for x in color_vals]
 
-        # For each row, we check if the row index is selected, and then apply a fill to the
-        # corresponding cell using `tab_style()`
-        n_rows = len(resolve_rows_i(self))
-        iter_color_vals = iter(color_vals)
-        for i in range(n_rows):
-            if i in row_pos:
-                color_val = next(iter_color_vals)
-                if autocolor_text:
-                    fgnd_color = _ideal_fgnd_color(bgnd_color=color_val)
+        # for every color value in color_vals, apply a fill to the corresponding cell
+        # by using `tab_style()`
+        for i, color_val in zip(row_pos, color_vals):
+            if autocolor_text:
+                fgnd_color = _ideal_fgnd_color(bgnd_color=color_val)
 
-                    gt_obj = gt_obj.tab_style(
-                        style=[text(color=fgnd_color), fill(color=color_val)],
-                        locations=body(columns=col, rows=[i]),
-                    )
+                gt_obj = gt_obj.tab_style(
+                    style=[text(color=fgnd_color), fill(color=color_val)],
+                    locations=body(columns=col, rows=[i]),
+                )
 
-                else:
-                    gt_obj = gt_obj.tab_style(
-                        style=fill(color=color_val), locations=body(columns=col, rows=[i])
-                    )
+            else:
+                gt_obj = gt_obj.tab_style(
+                    style=fill(color=color_val), locations=body(columns=col, rows=[i])
+                )
     return gt_obj
 
 

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -21,7 +21,7 @@ RGBColor: TypeAlias = tuple[int, int, int]
 def data_color(
     self: GTSelf,
     columns: SelectExpr = None,
-    include_last_row: bool = True,
+    rows: RowSelectExpr = None,
     palette: str | list[str] | None = None,
     domain: list[str] | list[int] | list[float] | None = None,
     na_color: str | None = None,
@@ -49,10 +49,10 @@ def data_color(
     columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.
-    include_last_row
-        Whether to include the last row for color styling. The default is set to `True`, but it
-        can be useful to set it to `False` if the last row is a summary or subtotal row of the
-        table.
+    rows
+        In conjunction with `columns=`, we can specify which rows should be colored. By default,
+        all rows in the targeted columns will be colored. Alternatively, we can provide a list
+        of row indices.
     palette
         The color palette to use. This should be a list of colors (e.g., `["#FF0000", "#00FF00",
         "#0000FF"]`). A ColorBrewer palette could also be used, just supply the name (reference
@@ -213,12 +213,8 @@ def data_color(
     else:
         columns_resolved = resolve_cols_c(data=self, expr=columns)
 
-    row_res = resolve_rows_i(self)  # get all rows
+    row_res = resolve_rows_i(self, rows)
     row_pos = [name_pos[1] for name_pos in row_res]
-    if not include_last_row:
-        # Excluding the last row for now;
-        # adjustments may be needed after implementing `summary_rows()`.
-        row_pos = row_pos[:-1]
 
     gt_obj = self
 
@@ -272,7 +268,7 @@ def data_color(
 
         # for every color value in color_vals, apply a fill to the corresponding cell
         # by using `tab_style()`
-        for i, color_val in enumerate(color_vals):
+        for i, color_val in zip(row_pos, color_vals):
             if autocolor_text:
                 fgnd_color = _ideal_fgnd_color(bgnd_color=color_val)
 

--- a/tests/data_color/__snapshots__/test_data_color.ambr
+++ b/tests/data_color/__snapshots__/test_data_color.ambr
@@ -362,7 +362,7 @@
   </tbody>
   '''
 # ---
-# name: test_data_color_pd_cols_rows_snap[False]
+# name: test_data_color_pd_cols_rows_snap
   '''
   <tbody class="gt_table_body">
     <tr>
@@ -386,43 +386,13 @@
       <td class="gt_row gt_right">55</td>
     </tr>
     <tr>
-      <td class="gt_row gt_right">15</td>
-      <td class="gt_row gt_right">265</td>
+      <td class="gt_row gt_right">200</td>
+      <td class="gt_row gt_right">200</td>
     </tr>
   </tbody>
   '''
 # ---
-# name: test_data_color_pd_cols_rows_snap[True]
-  '''
-  <tbody class="gt_table_body">
-    <tr>
-      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1</td>
-      <td class="gt_row gt_right">51</td>
-    </tr>
-    <tr>
-      <td style="color: #FFFFFF; background-color: #702a36;" class="gt_row gt_right">2</td>
-      <td class="gt_row gt_right">52</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #df536b;" class="gt_row gt_right">3</td>
-      <td class="gt_row gt_right">53</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #a0925d;" class="gt_row gt_right">4</td>
-      <td class="gt_row gt_right">54</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #61d04f;" class="gt_row gt_right">5</td>
-      <td class="gt_row gt_right">55</td>
-    </tr>
-    <tr>
-      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">15</td>
-      <td class="gt_row gt_right">265</td>
-    </tr>
-  </tbody>
-  '''
-# ---
-# name: test_data_color_pl_cols_rows_snap[False]
+# name: test_data_color_pl_cols_rows_snap
   '''
   <tbody class="gt_table_body">
     <tr>
@@ -446,38 +416,8 @@
       <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">55</td>
     </tr>
     <tr>
-      <td class="gt_row gt_right">15</td>
-      <td class="gt_row gt_right">265</td>
-    </tr>
-  </tbody>
-  '''
-# ---
-# name: test_data_color_pl_cols_rows_snap[True]
-  '''
-  <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">1</td>
-      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">51</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2</td>
-      <td style="color: #FFFFFF; background-color: #070303;" class="gt_row gt_right">52</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">3</td>
-      <td style="color: #FFFFFF; background-color: #0f0507;" class="gt_row gt_right">53</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">4</td>
-      <td style="color: #FFFFFF; background-color: #16080a;" class="gt_row gt_right">54</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">5</td>
-      <td style="color: #FFFFFF; background-color: #1d0b0e;" class="gt_row gt_right">55</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">15</td>
-      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">265</td>
+      <td class="gt_row gt_right">200</td>
+      <td class="gt_row gt_right">200</td>
     </tr>
   </tbody>
   '''

--- a/tests/data_color/__snapshots__/test_data_color.ambr
+++ b/tests/data_color/__snapshots__/test_data_color.ambr
@@ -362,7 +362,7 @@
   </tbody>
   '''
 # ---
-# name: test_data_color_pd_cols_rows_snap
+# name: test_data_color_pd_cols_rows_snap[False]
   '''
   <tbody class="gt_table_body">
     <tr>
@@ -386,13 +386,43 @@
       <td class="gt_row gt_right">55</td>
     </tr>
     <tr>
-      <td class="gt_row gt_right">200</td>
-      <td class="gt_row gt_right">200</td>
+      <td class="gt_row gt_right">15</td>
+      <td class="gt_row gt_right">265</td>
     </tr>
   </tbody>
   '''
 # ---
-# name: test_data_color_pl_cols_rows_snap
+# name: test_data_color_pd_cols_rows_snap[True]
+  '''
+  <tbody class="gt_table_body">
+    <tr>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1</td>
+      <td class="gt_row gt_right">51</td>
+    </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #702a36;" class="gt_row gt_right">2</td>
+      <td class="gt_row gt_right">52</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #df536b;" class="gt_row gt_right">3</td>
+      <td class="gt_row gt_right">53</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #a0925d;" class="gt_row gt_right">4</td>
+      <td class="gt_row gt_right">54</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #61d04f;" class="gt_row gt_right">5</td>
+      <td class="gt_row gt_right">55</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">15</td>
+      <td class="gt_row gt_right">265</td>
+    </tr>
+  </tbody>
+  '''
+# ---
+# name: test_data_color_pl_cols_rows_snap[False]
   '''
   <tbody class="gt_table_body">
     <tr>
@@ -416,8 +446,38 @@
       <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">55</td>
     </tr>
     <tr>
-      <td class="gt_row gt_right">200</td>
-      <td class="gt_row gt_right">200</td>
+      <td class="gt_row gt_right">15</td>
+      <td class="gt_row gt_right">265</td>
+    </tr>
+  </tbody>
+  '''
+# ---
+# name: test_data_color_pl_cols_rows_snap[True]
+  '''
+  <tbody class="gt_table_body">
+    <tr>
+      <td class="gt_row gt_right">1</td>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">51</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2</td>
+      <td style="color: #FFFFFF; background-color: #070303;" class="gt_row gt_right">52</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">3</td>
+      <td style="color: #FFFFFF; background-color: #0f0507;" class="gt_row gt_right">53</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">4</td>
+      <td style="color: #FFFFFF; background-color: #16080a;" class="gt_row gt_right">54</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">5</td>
+      <td style="color: #FFFFFF; background-color: #1d0b0e;" class="gt_row gt_right">55</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">15</td>
+      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">265</td>
     </tr>
   </tbody>
   '''

--- a/tests/data_color/__snapshots__/test_data_color.ambr
+++ b/tests/data_color/__snapshots__/test_data_color.ambr
@@ -362,6 +362,66 @@
   </tbody>
   '''
 # ---
+# name: test_data_color_pd_cols_rows_snap
+  '''
+  <tbody class="gt_table_body">
+    <tr>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1</td>
+      <td class="gt_row gt_right">51</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #80b156;" class="gt_row gt_right">2</td>
+      <td class="gt_row gt_right">52</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_right">3</td>
+      <td class="gt_row gt_right">53</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #d73a91;" class="gt_row gt_right">4</td>
+      <td class="gt_row gt_right">54</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">5</td>
+      <td class="gt_row gt_right">55</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">200</td>
+      <td class="gt_row gt_right">200</td>
+    </tr>
+  </tbody>
+  '''
+# ---
+# name: test_data_color_pl_cols_rows_snap
+  '''
+  <tbody class="gt_table_body">
+    <tr>
+      <td class="gt_row gt_right">1</td>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">51</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2</td>
+      <td style="color: #000000; background-color: #80b156;" class="gt_row gt_right">52</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">3</td>
+      <td style="color: #000000; background-color: #25bce6;" class="gt_row gt_right">53</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">4</td>
+      <td style="color: #000000; background-color: #d73a91;" class="gt_row gt_right">54</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">5</td>
+      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">55</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">200</td>
+      <td class="gt_row gt_right">200</td>
+    </tr>
+  </tbody>
+  '''
+# ---
 # name: test_data_color_simple_df_snap
   '''
   <tbody class="gt_table_body">

--- a/tests/data_color/test_data_color.py
+++ b/tests/data_color/test_data_color.py
@@ -55,26 +55,30 @@ def test_data_color_simple_exibble_snap(snapshot: str, df: DataFrameLike):
     assert_rendered_body(snapshot, gt)
 
 
-def test_data_color_pd_cols_rows_snap(snapshot: str):
-    df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 200], "b": [51, 52, 53, 54, 55, 200]})
-    new_gt = GT(df).data_color(columns=["a"], rows=[0, 1, 2, 3, 4])
-    assert_rendered_body(snapshot, new_gt)
-    new_gt2 = GT(df).data_color(columns=["a"], rows=lambda df_: df_["a"].lt(60))
-    assert create_body_component_h(new_gt._build_data("html")) == create_body_component_h(
-        new_gt2._build_data("html")
+@pytest.mark.parametrize("include_last_row", [True, False])
+def test_data_color_pd_cols_rows_snap(snapshot: str, include_last_row: bool):
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 4, 5, sum([1, 2, 3, 4, 5])],
+            "b": [51, 52, 53, 54, 55, sum([51, 52, 53, 54, 55])],
+        }
     )
+    new_gt = GT(df).data_color(columns=["a"], include_last_row=include_last_row)
+    assert_rendered_body(snapshot, new_gt)
 
 
-def test_data_color_pl_cols_rows_snap(snapshot: str):
+@pytest.mark.parametrize("include_last_row", [True, False])
+def test_data_color_pl_cols_rows_snap(snapshot: str, include_last_row: bool):
     import polars.selectors as cs
 
-    df = pl.DataFrame({"a": [1, 2, 3, 4, 5, 200], "b": [51, 52, 53, 54, 55, 200]})
-    new_gt = GT(df).data_color(columns=["b"], rows=[0, 1, 2, 3, 4])
-    assert_rendered_body(snapshot, new_gt)
-    new_gt2 = GT(df).data_color(columns=cs.starts_with("b"), rows=pl.col("b").lt(60))
-    assert create_body_component_h(new_gt._build_data("html")) == create_body_component_h(
-        new_gt2._build_data("html")
+    df = pl.DataFrame(
+        {
+            "a": [1, 2, 3, 4, 5, sum([1, 2, 3, 4, 5])],
+            "b": [51, 52, 53, 54, 55, sum([51, 52, 53, 54, 55])],
+        }
     )
+    new_gt = GT(df).data_color(columns=cs.by_name("b"), include_last_row=include_last_row)
+    assert_rendered_body(snapshot, new_gt)
 
 
 @pytest.mark.parametrize("none_val", [None, np.nan, float("nan"), pd.NA])

--- a/tests/data_color/test_data_color.py
+++ b/tests/data_color/test_data_color.py
@@ -55,6 +55,28 @@ def test_data_color_simple_exibble_snap(snapshot: str, df: DataFrameLike):
     assert_rendered_body(snapshot, gt)
 
 
+def test_data_color_pd_cols_rows_snap(snapshot: str):
+    df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 200], "b": [51, 52, 53, 54, 55, 200]})
+    new_gt = GT(df).data_color(columns=["a"], rows=[0, 1, 2, 3, 4])
+    assert_rendered_body(snapshot, new_gt)
+    new_gt2 = GT(df).data_color(columns=["a"], rows=lambda df_: df_["a"].lt(60))
+    assert create_body_component_h(new_gt._build_data("html")) == create_body_component_h(
+        new_gt2._build_data("html")
+    )
+
+
+def test_data_color_pl_cols_rows_snap(snapshot: str):
+    import polars.selectors as cs
+
+    df = pl.DataFrame({"a": [1, 2, 3, 4, 5, 200], "b": [51, 52, 53, 54, 55, 200]})
+    new_gt = GT(df).data_color(columns=["b"], rows=[0, 1, 2, 3, 4])
+    assert_rendered_body(snapshot, new_gt)
+    new_gt2 = GT(df).data_color(columns=cs.starts_with("b"), rows=pl.col("b").lt(60))
+    assert create_body_component_h(new_gt._build_data("html")) == create_body_component_h(
+        new_gt2._build_data("html")
+    )
+
+
 @pytest.mark.parametrize("none_val", [None, np.nan, float("nan"), pd.NA])
 @pytest.mark.parametrize("df_cls", [pd.DataFrame, pl.DataFrame])
 def test_data_color_missing_value(df_cls, none_val):

--- a/tests/data_color/test_data_color.py
+++ b/tests/data_color/test_data_color.py
@@ -55,30 +55,26 @@ def test_data_color_simple_exibble_snap(snapshot: str, df: DataFrameLike):
     assert_rendered_body(snapshot, gt)
 
 
-@pytest.mark.parametrize("include_last_row", [True, False])
-def test_data_color_pd_cols_rows_snap(snapshot: str, include_last_row: bool):
-    df = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 4, 5, sum([1, 2, 3, 4, 5])],
-            "b": [51, 52, 53, 54, 55, sum([51, 52, 53, 54, 55])],
-        }
-    )
-    new_gt = GT(df).data_color(columns=["a"], include_last_row=include_last_row)
+def test_data_color_pd_cols_rows_snap(snapshot: str):
+    df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 200], "b": [51, 52, 53, 54, 55, 200]})
+    new_gt = GT(df).data_color(columns=["a"], rows=[0, 1, 2, 3, 4])
     assert_rendered_body(snapshot, new_gt)
+    new_gt2 = GT(df).data_color(columns=["a"], rows=lambda df_: df_["a"].lt(60))
+    assert create_body_component_h(new_gt._build_data("html")) == create_body_component_h(
+        new_gt2._build_data("html")
+    )
 
 
-@pytest.mark.parametrize("include_last_row", [True, False])
-def test_data_color_pl_cols_rows_snap(snapshot: str, include_last_row: bool):
+def test_data_color_pl_cols_rows_snap(snapshot: str):
     import polars.selectors as cs
 
-    df = pl.DataFrame(
-        {
-            "a": [1, 2, 3, 4, 5, sum([1, 2, 3, 4, 5])],
-            "b": [51, 52, 53, 54, 55, sum([51, 52, 53, 54, 55])],
-        }
-    )
-    new_gt = GT(df).data_color(columns=cs.by_name("b"), include_last_row=include_last_row)
+    df = pl.DataFrame({"a": [1, 2, 3, 4, 5, 200], "b": [51, 52, 53, 54, 55, 200]})
+    new_gt = GT(df).data_color(columns=["b"], rows=[0, 1, 2, 3, 4])
     assert_rendered_body(snapshot, new_gt)
+    new_gt2 = GT(df).data_color(columns=cs.starts_with("b"), rows=pl.col("b").lt(60))
+    assert create_body_component_h(new_gt._build_data("html")) == create_body_component_h(
+        new_gt2._build_data("html")
+    )
 
 
 @pytest.mark.parametrize("none_val", [None, np.nan, float("nan"), pd.NA])


### PR DESCRIPTION
Related to #248.

This PR aims to support specifying a subset of rows in `GT.data_color()`. Based on the discussions, it appears that the most common use case involves excluding the last row, which is typically the total row. Consequently, rows that are not selected should not be included in the color "calculation." In this PR, I first select only the specified columns and rows, then "re-map" the "calculated color" back to the original table.

A simple example might illustrate the concept well:
```python
import polars as pl
import polars.selectors as cs
from great_tables import GT

df = pl.DataFrame({"a": [1, 2, 3, 4, 5, 200], "b": [51, 52, 53, 54, 55, 200]})

GT(df).data_color(columns=cs.numeric(), rows=pl.col("a").lt(6), palette="PuBu")
```
![image](https://github.com/posit-dev/great-tables/assets/67060418/8334ee72-f24f-4e37-97ef-c08c1b72a2db)

```python
GT(df).data_color(columns=cs.numeric(), rows=pl.col("a").lt(300), palette="PuBu")
```
![image](https://github.com/posit-dev/great-tables/assets/67060418/3a48a57f-a7c2-4db4-b6c3-d79e42285c3c)

### Bonus
In addition, I have added support for using Polars-style column and row selection. This allows for more flexible operations, such as:
```python
GT(df).data_color(columns=cs.starts_with("b"), rows=pl.col("a").lt(6), palette="PuBu")
```
![image](https://github.com/posit-dev/great-tables/assets/67060418/b9bfb16d-f7c5-469a-a211-1907e08c5fcb)
