### PR TITLE
Refactor `seq_groups()` to accept `Iterable`

### DIFF
--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, Any
-
+from typing import TYPE_CHECKING, Any, Iterable
+from collections.abc import Generator
 from ._gt_data import SpannerInfo, Spanners
 from ._locations import resolve_cols_c
 from ._tbl_data import SelectExpr
@@ -565,26 +565,50 @@ def empty_spanner_matrix(
     return [{var: var for var in vars}], vars
 
 
-def seq_groups(seq: list[str]):
-    # TODO: 0-length sequence
-    if len(seq) == 0:
-        raise StopIteration
-    elif len(seq) == 1:
-        yield seq[0], 1
-    else:
-        crnt_ttl = 1
-        for crnt_el, next_el in zip(seq[:-1], seq[1:]):
-            if is_equal(crnt_el, next_el):
-                crnt_ttl += 1
-            else:
-                yield crnt_el, crnt_ttl
-                crnt_ttl = 1
+def pairwise(iterable: Iterable[Any]) -> Generator[tuple[Any, Any], None, None]:
+    """
+    https://docs.python.org/3/library/itertools.html#itertools.pairwise
+    pairwise('ABCDEFG') → AB BC CD DE EF FG
+    """
+    # This function can be replaced by `itertools.pairwise` if we only plan to support
+    # Python 3.10+ in the future.
+    iterator = iter(iterable)
+    a = next(iterator, None)
+    for b in iterator:
+        yield a, b
+        a = b
 
-        # final step has same elements, so we need to yield one last time
+
+def seq_groups(seq: Iterable[str]) -> Generator[tuple[str, int], None, None]:
+    iterator = iter(seq)
+
+    # TODO: 0-length sequence
+    a = next(iterator, None)
+    if a is None:
+        raise StopIteration
+
+    b = next(iterator, None)
+    if b is None:
+        yield a, 1
+        return
+
+    # We can confirm that we have two elements and both are not `None`,
+    # so we can chain them back together as the original seq.
+    seq = itertools.chain([a, b], iterator)
+
+    crnt_ttl = 1
+    for crnt_el, next_el in pairwise(seq):
         if is_equal(crnt_el, next_el):
-            yield crnt_el, crnt_ttl
+            crnt_ttl += 1
         else:
-            yield next_el, 1
+            yield crnt_el, crnt_ttl
+            crnt_ttl = 1
+
+    # final step has same elements, so we need to yield one last time
+    if is_equal(crnt_el, next_el):
+        yield crnt_el, crnt_ttl
+    else:
+        yield next_el, 1
 
 
 def is_equal(x: Any, y: Any) -> bool:

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -583,12 +583,11 @@ def seq_groups(seq: Iterable[str]) -> Generator[tuple[str, int], None, None]:
     iterator = iter(seq)
 
     # TODO: 0-length sequence
-    a = next(iterator, None)
-    if a is None:
-        raise StopIteration
+    a = next(iterator)  # will raise StopIteration if `seq` is empty
 
-    b = next(iterator, None)
-    if b is None:
+    try:
+        b = next(iterator)
+    except StopIteration:
         yield a, 1
         return
 

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -222,7 +222,7 @@ def create_columns_component_h(data: GTData) -> str:
         # words, each missing value starts a new run of length 1
 
         spanner_ids_level_1_index = list(spanner_ids[level_1_index].values())
-        spanners_rle = list(seq_groups(seq=list(spanner_ids_level_1_index)))
+        spanners_rle = seq_groups(seq=spanner_ids_level_1_index)
 
         # `colspans` matches `spanners` in length; each element is the number of columns that the
         # <th> at that position should span; if 0, then skip the <th> at that position
@@ -354,8 +354,8 @@ def create_columns_component_h(data: GTData) -> str:
                 if v is None:
                     spanners_row[k] = ""
 
-            spanner_ids_index = list(spanners_row.values())
-            spanners_rle = list(seq_groups(seq=list(spanner_ids_index)))
+            spanner_ids_index = spanners_row.values()
+            spanners_rle = seq_groups(seq=spanner_ids_index)
             group_spans = [[x[1]] + [0] * (x[1] - 1) for x in spanners_rle]
             colspans = list(chain(*group_spans))
             level_i_spanners = []

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -25,10 +25,16 @@ from great_tables._spanners import (
         ("abc", [("a", 1), ("b", 1), ("c", 1)]),
         ("aabbcc", [("a", 2), ("b", 2), ("c", 2)]),
         ("aabbccd", [("a", 2), ("b", 2), ("c", 2), ("d", 1)]),
+        (("a", "b", "c"), [("a", 1), ("b", 1), ("c", 1)]),
+        (("aa", "bb", "cc"), [("aa", 1), ("bb", 1), ("cc", 1)]),
         (iter("xyyzzz"), [("x", 1), ("y", 2), ("z", 3)]),
         ((i for i in "333221"), [("3", 3), ("2", 2), ("1", 1)]),
         (["a", "a", "b", None, "c"], [("a", 2), ("b", 1), (None, 1), ("c", 1)]),
         (["a", "a", "b", None, None, "c"], [("a", 2), ("b", 1), (None, 1), (None, 1), ("c", 1)]),
+        ([None, "a", "a", "b"], [(None, 1), ("a", 2), ("b", 1)]),
+        ([None, None, "a", "a", "b"], [(None, 1), (None, 1), ("a", 2), ("b", 1)]),
+        ([None, None, None, "a", "a", "b"], [(None, 1), (None, 1), (None, 1), ("a", 2), ("b", 1)]),
+        ([None, None, None], [(None, 1), (None, 1), (None, 1)]),
     ],
 )
 def test_seq_groups(seq, grouped):

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+
 import pandas as pd
 import polars as pl
 import polars.selectors as cs
@@ -11,8 +13,37 @@ from great_tables._spanners import (
     cols_move_to_start,
     empty_spanner_matrix,
     spanners_print_matrix,
+    seq_groups,
     tab_spanner,
 )
+
+
+@pytest.mark.parametrize(
+    "seq, grouped",
+    [
+        ("a", [("a", 1)]),
+        ("abc", [("a", 1), ("b", 1), ("c", 1)]),
+        ("aabbcc", [("a", 2), ("b", 2), ("c", 2)]),
+        ("aabbccd", [("a", 2), ("b", 2), ("c", 2), ("d", 1)]),
+        (iter("xyyzzz"), [("x", 1), ("y", 2), ("z", 3)]),
+        ((i for i in "333221"), [("3", 3), ("2", 2), ("1", 1)]),
+        (["a", "a", "b", None, "c"], [("a", 2), ("b", 1), (None, 1), ("c", 1)]),
+        (["a", "a", "b", None, None, "c"], [("a", 2), ("b", 1), (None, 1), (None, 1), ("c", 1)]),
+    ],
+)
+def test_seq_groups(seq, grouped):
+    g = seq_groups(seq)
+    assert isinstance(g, Generator)
+    assert list(g) == grouped
+
+
+def test_seq_groups_raises():
+    """
+    https://stackoverflow.com/questions/66566960/pytest-raises-does-not-catch-stopiteration-error
+    """
+    with pytest.raises(RuntimeError) as exc_info:
+        next(seq_groups([]))
+    assert "StopIteration" in str(exc_info.value)
 
 
 @pytest.fixture


### PR DESCRIPTION
Our project is progressing steadily, and it's been an enjoyable journey as one of the contributors. However, I've noticed that we might be overly reliant on the `list` type in the codebase. While `list` is excellent and suitable for prototyping, it can become problematic as the codebase grows. Therefore, I propose replacing `list` with `Generator` where possible.

I have chosen `seq_groups()` as a starting point since it is currently functioning as a kind of `Generator`. Currently, we request the input as a `list`, but I believe we can improve this by refactoring it to accept an `Iterable` as input. 

I hope this PR makes sense, and I welcome input from the team on this concept.