### PR TITLE
docs: add RSS feed to blog

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -20,6 +20,8 @@ website:
     right:
       - icon: github
         href: https://github.com/posit-dev/great-tables
+      - icon: rss
+        href: blog/index.xml
   sidebar:
     - id: examples
       contents: examples-qmd/*

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -3,6 +3,8 @@ project:
 
 website:
   title: great_tables
+  site-url: https://posit-dev.github.io/great-tables/
+  description: "Absolutely Delightful Table-making in Python"
   page-navigation: true
   google-analytics: "G-CN7Z82M6R7"
   navbar:

--- a/docs/blog/index.qmd
+++ b/docs/blog/index.qmd
@@ -3,6 +3,7 @@ title: "Great Blogposts"
 listing:
   type: table
   sort: "date desc"
+  feed: true
   contents:
     - "**.qmd"
     #- title: "Title"


### PR DESCRIPTION
This PR adds an RSS feed to the blog, following the instructions from [quarto](https://quarto.org/docs/websites/website-blog.html#rss-feed), and addresses the request in #115.