### PR TITLE
feat: support polars non-strict expand_selector

### DIFF
--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -215,7 +215,7 @@ def resolve_cols_i(
         group_var = data._boxhead.vars_from_type(ColInfoTypeEnum.row_group)
 
         # TODO: special handling of "stub()"
-        if isinstance(expr, list) and "stub()" in expr:
+        if isinstance(expr, list) and any(isinstance(x, str) and x == "stub()" for x in expr):
             if len(stub_var):
                 return [(stub_var[0], 1)]
 

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -283,6 +283,7 @@ def _(data: PlDataFrame, group_key: str) -> dict[Any, list[int]]:
 SelectExpr: TypeAlias = Union[
     list["str | int"],
     PlSelectExpr,
+    list[PlSelectExpr],
     str,
     int,
     Callable[[str], bool],
@@ -329,7 +330,7 @@ def _(data: PlDataFrame, expr: Union[list[str], _selector_proxy_], strict: bool 
     from polars import Expr
 
     pl_version = _re_version(version("polars"))
-    expand_opts = {"strict": False} if pl_version >= (0, 20, 3) else {}
+    expand_opts = {"strict": False} if pl_version >= (0, 20, 30) else {}
 
     # just in case _selector_proxy_ gets renamed or something
     # it inherits from Expr, so we can just use that in a pinch
@@ -383,7 +384,7 @@ def _validate_selector_list(selectors: list, strict=True):
             if strict:
                 raise TypeError(
                     f"Expected a list of selectors, but entry {ii} is a polars Expr, which is only "
-                    "supported for polars versions >= 0.20.3."
+                    "supported for polars versions >= 0.20.30."
                 )
         elif not is_selector(sel):
             raise TypeError(f"Expected a list of selectors, but entry {ii} is type: {type(sel)}.")

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -325,8 +325,6 @@ def _(data: PlDataFrame, expr: Union[list[str], _selector_proxy_], strict: bool 
     # Seems to be polars.selectors._selector_proxy_.
     import polars.selectors as cs
 
-    from functools import reduce
-    from operator import or_
     from polars import Expr
 
     pl_version = _re_version(version("polars"))
@@ -347,7 +345,7 @@ def _(data: PlDataFrame, expr: Union[list[str], _selector_proxy_], strict: bool 
         ]
 
         # validate all entries ----
-        _validate_selector_list(all_selectors, strict=False if expand_opts else True)
+        _validate_selector_list(all_selectors, **expand_opts)
 
         # perform selection ----
         # use a dictionary, with values set to True, as an ordered list.

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -33,6 +33,11 @@ def test_resolve_cols_i_gt_data():
     assert resolve_cols_i(gt, ["x", "a"]) == [("x", 2), ("a", 0)]
 
 
+def test_resolve_cols_i_polars_in_list():
+    gt = GT(pl.DataFrame({"a": [], "b": [], "x": []}))
+    assert resolve_cols_i(gt, [pl.col("x"), "a"]) == [("x", 2), ("a", 0)]
+
+
 def test_resolve_cols_i_strings():
     df = pd.DataFrame(columns=["a", "b", "x"])
     assert resolve_cols_i(df, ["x", "a"]) == [("x", 2), ("a", 0)]

--- a/tests/test_tbl_data.py
+++ b/tests/test_tbl_data.py
@@ -8,6 +8,7 @@ from great_tables._tbl_data import (
     _get_cell,
     _get_column_dtype,
     _set_cell,
+    _validate_selector_list,
     cast_frame_to_string,
     create_empty_frame,
     eval_select,
@@ -81,6 +82,10 @@ def test_eval_select_with_list(df: DataFrameLike, expr):
     [
         pl.selectors.exclude("col3"),
         pl.selectors.starts_with("col1") | pl.selectors.starts_with("col2"),
+        [pl.col("col1"), pl.col("col2")],
+        [pl.col("col1"), pl.selectors.by_name("col2")],
+        pl.col("col1", "col2"),
+        pl.all().exclude("col3"),
     ],
 )
 def test_eval_select_with_list_pl_selector(expr):
@@ -123,6 +128,14 @@ def test_eval_selector_polars_list_raises():
         eval_select(df, expr)
 
     assert "entry 1 is type: <class 'float'>" in str(exc_info.value.args[0])
+
+
+def test_validate_selector_list_strict_raises():
+    with pytest.raises(TypeError) as exc_info:
+        _validate_selector_list([pl.col("a")])
+
+    msg = "entry 0 is a polars Expr, which is only supported for polars versions >= 0.20.3."
+    assert msg in str(exc_info.value.args[0])
 
 
 def test_create_empty_frame(df: DataFrameLike):

--- a/tests/test_tbl_data.py
+++ b/tests/test_tbl_data.py
@@ -134,7 +134,7 @@ def test_validate_selector_list_strict_raises():
     with pytest.raises(TypeError) as exc_info:
         _validate_selector_list([pl.col("a")])
 
-    msg = "entry 0 is a polars Expr, which is only supported for polars versions >= 0.20.3."
+    msg = "entry 0 is a polars Expr, which is only supported for polars versions >= 0.20.30."
     assert msg in str(exc_info.value.args[0])
 
 


### PR DESCRIPTION
This PR adds support for polars expressions to be used in column selection in addition to polars selectors. It requires polars v0.20.30, but falls back to the old behavior (or requiring a selector object) otherwise.

Note that this is the result of a chain of things:

* https://github.com/posit-dev/great-tables/pull/360
* https://github.com/pola-rs/polars/issues/16448

Which resulted in polars super quickly adding broader support for accepting Expressions and selectors that only result in column selection (and not e.g. transformation, or aliasing; PR https://github.com/pola-rs/polars/pull/16479).

I tried to give reasonably helpful error messages for people who are not on v0.20.3 that use Expr, but also suspect people will upgrade polaras patch versions fairly quickly.

## Example


```python
from great_tables import exibble, GT

GT(pl.from_pandas(exibble)).tab_spanner("A", [pl.col("fctr"), pl.all().exclude("date")])
```

Note both that a list is supported along with the use of expressions (e.g. `pl.col("fctr")`) 