### PR TITLE
Feat init methods

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -155,6 +155,8 @@ quartodoc:
         [`tab_stubhead()`](`great_tables.GT.tab_stubhead`), and
         [`tab_source_note()`](`great_tables.GT.tab_source_note`) methods.
       contents:
+        - GT.with_id
+        - GT.with_locale
         - md
         - html
         - from_column

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -91,6 +91,7 @@ quartodoc:
       contents:
         - GT.tab_header
         - GT.tab_spanner
+        - GT.tab_stub
         - GT.tab_stubhead
         - GT.tab_source_note
         - GT.tab_style

--- a/docs/examples/index.qmd
+++ b/docs/examples/index.qmd
@@ -25,11 +25,12 @@ islands_mini = (
 )
 
 (
-    GT(islands_mini, rowname_col="name")
+    GT(islands_mini)
     .tab_header(
         title="Large Landmasses of the World",
         subtitle="The top ten largest are presented"
     )
+    .tab_stub(rowname_col="name")
     .tab_source_note(source_note="Source: The World Almanac and Book of Facts, 1975, page 406.")
     .tab_source_note(
         source_note=md("Reference: McNeil, D. R. (1977) *Interactive Data Analysis*. Wiley.")
@@ -108,9 +109,10 @@ wide_pops = (
 )
 
 (
-    GT(wide_pops, rowname_col="country_name", groupname_col="region")
+    GT(wide_pops)
     .tab_header(title="Populations of Oceania's Countries in 2000, 2010, and 2020")
     .tab_spanner(label="Total Population", columns=cs.all())
+    .tab_stub(rowname_col="country_name", groupname_col="region")
     .fmt_integer()
 )
 ```

--- a/docs/get-started/basic-stub.qmd
+++ b/docs/get-started/basic-stub.qmd
@@ -44,3 +44,13 @@ island_groups = islands.head(10).assign(group = ["subregion"] * 2 + ["country"] 
     .tab_stubhead(label="landmass")
 )
 ```
+
+## GT convenience arguments
+
+Rather than using the `GT.tab_stub()` method, the `GT(rowname_col=..., groupname_col=...)` arguments
+provide a quick way to specify row names and groups.
+
+
+```{python}
+GT(island_groups, rowname_col="name", groupname_col="group")
+```

--- a/docs/get-started/basic-stub.qmd
+++ b/docs/get-started/basic-stub.qmd
@@ -16,14 +16,15 @@ from great_tables.data import islands
 
 islands_mini = islands.head(10)
 
-GT(islands_mini, rowname_col="name")
+GT(islands_mini).tab_stub(rowname_col="name")
 ```
 
 Notice that the landmass names are now placed to the left? That's the **Stub**. Notably, there is a prominent border to the right of it but there's no label above the **Stub**. We can change this and apply what's known as a *stubhead label* through use of the [`tab_stubhead()`](`great_tables.GT.tab_stubhead`) method:
 
 ```{python}
 (
-    GT(islands_mini, rowname_col="name")
+    GT(islands_mini)
+    .tab_stub(rowname_col="name")
     .tab_stubhead(label="landmass")
 )
 ```
@@ -37,5 +38,9 @@ Let's incorporate row groups into the display table. This divides rows into grou
 ```{python}
 island_groups = islands.head(10).assign(group = ["subregion"] * 2 + ["country"] * 2 + ["continent"] * 6)
 
-GT(island_groups, rowname_col="name", groupname_col="group").tab_stubhead(label="landmass")
+(
+    GT(island_groups)
+    .tab_stub(rowname_col="name", groupname_col="group")
+    .tab_stubhead(label="landmass")
+)
 ```

--- a/great_tables/_body.py
+++ b/great_tables/_body.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from ._gt_data import Body, Boxhead, RowGroups, Stub
 
 
-def body_reassemble(body: Body, row_groups: RowGroups, stub_df: Stub, boxhead: Boxhead) -> Body:
+def body_reassemble(body: Body, stub_df: Stub, boxhead: Boxhead) -> Body:
     # Note that this used to order the body based on groupings, but now that occurs in the
     # renderer itself.
     return body.__class__(copy_data(body.body))

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -47,7 +47,6 @@ class GTData:
     _body: Body
     _boxhead: Boxhead
     _stub: Stub
-    _group_rows: GroupRows
     _spanners: Spanners
     _heading: Heading
     _stubhead: Stubhead
@@ -94,7 +93,6 @@ class GTData:
             _body=Body.from_empty(data),
             _boxhead=boxhead,  # uses get_tbl_data()
             _stub=stub,  # uses get_tbl_data
-            _group_rows=stub.group_rows,
             _spanners=Spanners([]),
             _heading=Heading(),
             _stubhead=None,
@@ -115,8 +113,8 @@ class GTData:
         id: str | None = None,
         locale: str | None = None,
     ):
-        stub, boxhead, group_rows = _prep_gt(self._tbl_data, rowname_col, groupname_col, auto_align)
-        row_groups = stub.group_ids
+        stub, boxhead = _prep_gt(self._tbl_data, rowname_col, groupname_col, auto_align)
+
         # set id if not None
         # self._options
         locale = Locale(locale) if locale is not None else self._locale
@@ -129,8 +127,6 @@ class GTData:
         return res._replace(
             _stub=stub,
             _boxhead=boxhead,
-            _group_rows=group_rows,
-            _row_groups=row_groups,
             _locale=locale,
         )
 
@@ -599,6 +595,9 @@ class Stub:
         new_rows = [self.rows[ii] for ii in indices]
 
         return self.__class__(new_rows, self.group_rows)
+
+    def group_indices_map(self) -> list[tuple[int, str | None]]:
+        return self.group_rows.indices_map(len(self.rows))
 
     def __iter__(self):
         return iter(self.rows)

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -33,6 +33,10 @@ T = TypeVar("T")
 
 
 def _prep_gt(data, rowname_col, groupname_col, auto_align) -> Tuple[Stub, Boxhead, GroupRows]:
+    # this function is similar to Stub._set_cols, except it differs in two ways.
+    #   * it supports auto-alignment (an expensive operation)
+    #   * it assumes its run on data initialization, whereas _set_cols may be run after
+
     stub = Stub.from_data(data, rowname_col=rowname_col, groupname_col=groupname_col)
     boxhead = Boxhead(
         data, auto_align=auto_align, rowname_col=rowname_col, groupname_col=groupname_col
@@ -103,31 +107,6 @@ class GTData:
             _formats=[],
             _substitutions=[],
             _options=options,
-        )
-
-    def init(
-        self,
-        rowname_col: str | None = None,
-        groupname_col: str | None = None,
-        auto_align: bool = True,
-        id: str | None = None,
-        locale: str | None = None,
-    ):
-        stub, boxhead = _prep_gt(self._tbl_data, rowname_col, groupname_col, auto_align)
-
-        # set id if not None
-        # self._options
-        locale = Locale(locale) if locale is not None else self._locale
-
-        if id is not None:
-            res = tab_options(self)
-        else:
-            res = self
-
-        return res._replace(
-            _stub=stub,
-            _boxhead=boxhead,
-            _locale=locale,
         )
 
 

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -586,15 +586,14 @@ class Stub:
     def group_ids(self) -> RowGroups:
         return [group.group_id for group in self.group_rows]
 
-    @property
-    def final_group_ids(self) -> list[str]:
-        # Note: re-ordered groups is currently unsupported, but should set this attribute.
-        return self.group_ids
-
     def reorder_rows(self, indices) -> Self:
         new_rows = [self.rows[ii] for ii in indices]
 
         return self.__class__(new_rows, self.group_rows)
+
+    def order_groups(self, group_order: RowGroups):
+        # TODO: validate
+        return self.__class__(self.rows, self.group_rows.reorder(group_order))
 
     def group_indices_map(self) -> list[tuple[int, str | None]]:
         return self.group_rows.indices_map(len(self.rows))

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -141,7 +141,6 @@ class _Sequence(Sequence[T]):
 
 
 # Body ----
-__Body = None
 
 
 # TODO: it seems like this could just be a DataFrameLike object?
@@ -182,7 +181,6 @@ class Body:
 
 
 # Boxhead ----
-__Boxhead = None
 
 
 class ColumnAlignment(Enum):
@@ -494,7 +492,6 @@ class Boxhead(_Sequence[ColInfo]):
 
 
 # Stub ----
-__Stub = None
 
 
 @dataclass(frozen=True)
@@ -614,12 +611,9 @@ class Stub(_Sequence[RowInfo]):
 
 
 # Row groups ----
-__RowGroups = None
-
 RowGroups: TypeAlias = list[str]
 
 # Group rows ----
-__GroupRows = None
 
 
 @dataclass(frozen=True)
@@ -689,7 +683,6 @@ class GroupRows(_Sequence[GroupRowInfo]):
 
 
 # Spanners ----
-__Spanners = None
 
 
 @dataclass(frozen=True)
@@ -749,7 +742,6 @@ class Spanners(_Sequence[SpannerInfo]):
 
 
 # Heading ---
-__Heading = None
 
 
 @dataclass(frozen=True)
@@ -760,18 +752,13 @@ class Heading:
 
 
 # Stubhead ----
-__Stubhead = None
-
 Stubhead: TypeAlias = "str | None"
 
 
 # Sourcenotes ----
-__Sourcenotes = None
-
 SourceNotes = list[str]
 
 # Footnotes ----
-__Footnotes = None
 
 
 class FootnotePlacement(Enum):
@@ -795,7 +782,6 @@ class FootnoteInfo:
 Footnotes: TypeAlias = list[FootnoteInfo]
 
 # Styles ----
-__Styles = None
 
 
 @dataclass(frozen=True)
@@ -812,7 +798,6 @@ class StyleInfo:
 Styles: TypeAlias = list[StyleInfo]
 
 # Locale ----
-__Locale = None
 
 
 class Locale:
@@ -823,7 +808,6 @@ class Locale:
 
 
 # Formats ----
-__Formats = None
 
 
 class FormatterSkipElement:
@@ -885,8 +869,6 @@ Formats = list
 
 
 # Options ----
-__Options = None
-
 
 default_fonts_list = [
     "-apple-system",

--- a/great_tables/_modify_rows.py
+++ b/great_tables/_modify_rows.py
@@ -58,46 +58,6 @@ def tab_stub(self: GTSelf, rowname_col: str | None = None, groupname_col: str | 
     return self._replace(_stub=stub, _boxhead=boxhead)
 
 
-def with_rowname_col(self: GTSelf, column: str | None = None):
-    """Set a column to be the rownames in the table stub."""
-
-    # in case it was the groupname_col, need to remove group styles ----
-    if column is not None:
-        self = self._replace(_styles=_remove_from_group_styles(self._styles, column))
-
-    # remove from spanners ----
-    if column is not None:
-        self = self._replace(_spanners=self._spanners.remove_column(column))
-
-    # get existing groupname column ----
-    _info = self._boxhead._get_row_group_column()
-    groupname_col = _info.var if _info is not None else None
-
-    stub, boxhead = self._stub._set_cols(self._tbl_data, self._boxhead, column, groupname_col)
-
-    return self._replace(_stub=stub, _boxhead=boxhead)
-
-
-def with_groupname_col(self: GTSelf, column: str = None):
-    """Set a column to be the groupnames in the table stub."""
-
-    # remove any table body styles ----
-    if column is not None:
-        self = self._replace(_styles=_remove_from_body_styles(self._styles, column))
-
-    # remove from spanners ----
-    if column is not None:
-        self = self._replace(_spanners=self._spanners.remove_column(column))
-
-    # get existing rowname column ----
-    _info = self._boxhead._get_stub_column()
-    rowname_col = _info.var if _info is not None else None
-
-    stub, boxhead = self._stub._set_cols(self._tbl_data, self._boxhead, rowname_col, column)
-
-    return self._replace(_stub=stub, _boxhead=boxhead)
-
-
 def with_locale(self: GTSelf, locale: str | None = None):
     """Set a column to be the locale."""
 

--- a/great_tables/_modify_rows.py
+++ b/great_tables/_modify_rows.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, TypedDict, TypeVar, cast
+
+from ._gt_data import GTData, RowGroups
+
+if TYPE_CHECKING:
+    from ._types import GTSelf
+
+
+def row_group_order(self: GTSelf, groups: RowGroups):
+    new_stub = self._stub.order_groups(groups)
+
+    return self._replace(_stub=new_stub)

--- a/great_tables/_modify_rows.py
+++ b/great_tables/_modify_rows.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, TypedDict, TypeVar, cast
 
-from ._gt_data import GTData, RowGroups
+from ._gt_data import GTData, Locale, Options, RowGroups, Spanners, Stub, Boxhead, Styles
 
 if TYPE_CHECKING:
     from ._types import GTSelf
@@ -12,3 +12,66 @@ def row_group_order(self: GTSelf, groups: RowGroups):
     new_stub = self._stub.order_groups(groups)
 
     return self._replace(_stub=new_stub)
+
+
+def _remove_from_body_styles(styles: Styles, column: str) -> Styles:
+    new_styles = [
+        info for info in styles if not (info.locname == "data" and info.colname == column)
+    ]
+
+    return new_styles
+
+
+def _remove_from_group_styles(styles: Styles, column: str):
+    # TODO(#341): once group styles are supported, will need to wire this up.
+    return list(styles)
+
+
+def with_rowname_col(self: GTSelf, column: str | None = None):
+    """Set a column to be the rownames in the table stub."""
+
+    # in case it was the groupname_col, need to remove group styles ----
+    if column is not None:
+        self = self._replace(_styles=_remove_from_group_styles(self._styles, column))
+
+    # remove from spanners ----
+    if column is not None:
+        self = self._replace(_spanners=self._spanners.remove_column(column))
+
+    # get existing groupname column ----
+    _info = self._boxhead._get_row_group_column()
+    groupname_col = _info.var if _info is not None else None
+
+    stub, boxhead = self._stub._set_cols(self._tbl_data, self._boxhead, column, groupname_col)
+
+    return self._replace(_stub=stub, _boxhead=boxhead)
+
+
+def with_groupname_col(self: GTSelf, column: str = None):
+    """Set a column to be the groupnames in the table stub."""
+
+    # remove any table body styles ----
+    if column is not None:
+        self = self._replace(_styles=_remove_from_body_styles(self._styles, column))
+
+    # remove from spanners ----
+    if column is not None:
+        self = self._replace(_spanners=self._spanners.remove_column(column))
+
+    # get existing rowname column ----
+    _info = self._boxhead._get_stub_column()
+    rowname_col = _info.var if _info is not None else None
+
+    stub, boxhead = self._stub._set_cols(self._tbl_data, self._boxhead, rowname_col, column)
+
+    return self._replace(_stub=stub, _boxhead=boxhead)
+
+
+def with_locale(self: GTSelf, locale: str | None = None):
+    """Set a column to be the locale."""
+
+    return self._replace(_locale=Locale(locale))
+
+
+def with_id(self: GTSelf, id: str | None = None):
+    return self._replace(_options=self._options._set_option_value("table_id", id))

--- a/great_tables/_modify_rows.py
+++ b/great_tables/_modify_rows.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from ._types import GTSelf
 
 
-def row_group_order(self: GTSelf, groups: RowGroups):
+def row_group_order(self: GTSelf, groups: RowGroups) -> GTSelf:
     new_stub = self._stub.order_groups(groups)
 
     return self._replace(_stub=new_stub)
@@ -87,7 +87,7 @@ def tab_stub(
     return self._replace(_stub=stub, _boxhead=boxhead)
 
 
-def with_locale(self: GTSelf, locale: str | None = None):
+def with_locale(self: GTSelf, locale: str | None = None) -> GTSelf:
     """Set a column to be the default locale.
 
     Setting a default locale affects formatters like .fmt_number, and .fmt_date,
@@ -98,7 +98,7 @@ def with_locale(self: GTSelf, locale: str | None = None):
     return self._replace(_locale=Locale(locale))
 
 
-def with_id(self: GTSelf, id: str | None = None):
+def with_id(self: GTSelf, id: str | None = None) -> GTSelf:
     """Set the id for this table.
 
     Note that this is a shortcut for the `table_id=` argument in `GT.tab_options()`.

--- a/great_tables/_modify_rows.py
+++ b/great_tables/_modify_rows.py
@@ -88,10 +88,19 @@ def tab_stub(
 
 
 def with_locale(self: GTSelf, locale: str | None = None):
-    """Set a column to be the locale."""
+    """Set a column to be the default locale.
+
+    Setting a default locale affects formatters like .fmt_number, and .fmt_date,
+    by having them default to locale-specific features (e.g. representing one thousand
+    as 1.000,00)
+    """
 
     return self._replace(_locale=Locale(locale))
 
 
 def with_id(self: GTSelf, id: str | None = None):
+    """Set the id for this table.
+
+    Note that this is a shortcut for the `table_id=` argument in `GT.tab_options()`.
+    """
     return self._replace(_options=self._options._set_option_value("table_id", id))

--- a/great_tables/_modify_rows.py
+++ b/great_tables/_modify_rows.py
@@ -27,6 +27,37 @@ def _remove_from_group_styles(styles: Styles, column: str):
     return list(styles)
 
 
+def tab_stub(self: GTSelf, rowname_col: str | None = None, groupname_col: str | None = None):
+    # old columns ----
+    _info = self._boxhead._get_row_group_column()
+    old_groupname_col = _info.var if _info is not None else None
+
+    styles = self._styles
+
+    # remove group styles ----
+    if old_groupname_col is not None and old_groupname_col != groupname_col:
+        styles = _remove_from_group_styles(styles, old_groupname_col)
+
+    # remove table body styles ----
+    # they no longer apply to groupname_col
+    if groupname_col is not None:
+        styles = _remove_from_body_styles(self._styles, groupname_col)
+
+    self = self._replace(_styles=styles)
+
+    # remove from spanners ----
+    if groupname_col is not None:
+        self = self._replace(_spanners=self._spanners.remove_column(groupname_col))
+
+    if rowname_col is not None:
+        self = self._replace(_spanners=self._spanners.remove_column(rowname_col))
+
+    # set new row and group name cols ----
+    stub, boxhead = self._stub._set_cols(self._tbl_data, self._boxhead, rowname_col, groupname_col)
+
+    return self._replace(_stub=stub, _boxhead=boxhead)
+
+
 def with_rowname_col(self: GTSelf, column: str | None = None):
     """Set a column to be the rownames in the table stub."""
 

--- a/great_tables/_modify_rows.py
+++ b/great_tables/_modify_rows.py
@@ -27,7 +27,36 @@ def _remove_from_group_styles(styles: Styles, column: str):
     return list(styles)
 
 
-def tab_stub(self: GTSelf, rowname_col: str | None = None, groupname_col: str | None = None):
+def tab_stub(
+    self: GTSelf, rowname_col: str | None = None, groupname_col: str | None = None
+) -> GTSelf:
+    """Add a table stub, to emphasize row and group information.
+
+    Parameters
+    ----------
+    rowname_col:
+        The column to use for row names. By default, no row names added.
+    groupname_col:
+        The column to use for group names. By default no group names added.
+
+    Examples
+    --------
+
+    By default, all data is together in the body of the table.
+
+    ```{python}
+    from great_tables import GT, exibble
+
+    GT(exibble)
+    ```
+
+    The table stub separates row names with a vertical line, and puts group names
+    on their own line.
+
+    ```{python}
+    GT(exibble).tab_stub(rowname_col="row", groupname_col="group")
+    ```
+    """
     # old columns ----
     _info = self._boxhead._get_row_group_column()
     old_groupname_col = _info.var if _info is not None else None

--- a/great_tables/_stub.py
+++ b/great_tables/_stub.py
@@ -15,7 +15,12 @@ def reorder_stub_df(stub_df: Stub) -> Stub:
     Returns:
         Stub: The reordered stub object.
     """
-    start_final = get_row_reorder_df(stub_df)
-    stub_df = stub_df.reorder_rows([final for _, final in start_final])
+
+    # NOTE: the original R package reordered stub rows, and returned a new GT object.
+    # However, since the final order is determined by the groups, we use those to
+    # determine the final order, just before rendering
+
+    # start_final = get_row_reorder_df(stub_df)
+    # stub_df = stub_df.reorder_rows([final for _, final in start_final])
 
     return stub_df

--- a/great_tables/_stub.py
+++ b/great_tables/_stub.py
@@ -17,6 +17,6 @@ def reorder_stub_df(stub_df: Stub, row_groups: RowGroups) -> Stub:
     """
     start_final = get_row_reorder_df(row_groups, stub_df)
 
-    stub_df = stub_df[[final for _, final in start_final]]
+    stub_df = stub_df.reorder_rows([final for _, final in start_final])
 
     return stub_df

--- a/great_tables/_stub.py
+++ b/great_tables/_stub.py
@@ -4,7 +4,7 @@ from ._gt_data import RowGroups, Stub
 from .utils_render_common import get_row_reorder_df
 
 
-def reorder_stub_df(stub_df: Stub, row_groups: RowGroups) -> Stub:
+def reorder_stub_df(stub_df: Stub) -> Stub:
     """
     Reorders the components of the stub object based on the given row groups.
 
@@ -15,8 +15,7 @@ def reorder_stub_df(stub_df: Stub, row_groups: RowGroups) -> Stub:
     Returns:
         Stub: The reordered stub object.
     """
-    start_final = get_row_reorder_df(row_groups, stub_df)
-
+    start_final = get_row_reorder_df(stub_df)
     stub_df = stub_df.reorder_rows([final for _, final in start_final])
 
     return stub_df

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -258,7 +258,7 @@ def group_splits(data: DataFrameLike, group_key: str) -> dict[Any, list[int]]:
 
 @group_splits.register
 def _(data: PdDataFrame, group_key: str) -> dict[Any, list[int]]:
-    g_df = data.groupby(group_key)
+    g_df = data.groupby(group_key, dropna=False)
     return {k: list(v) for k, v in g_df.indices.items()}
 
 

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -35,7 +35,7 @@ def create_heading_component_h(data: GTData) -> StringBuilder:
     # Get the effective number of columns, which is number of columns
     # that will finally be rendered accounting for the stub layout
     n_cols_total = data._boxhead._get_effective_number_of_columns(
-        stub=data._stub, row_groups=data._row_groups, options=data._options
+        stub=data._stub, options=data._options
     )
 
     if has_subtitle:
@@ -79,7 +79,7 @@ def create_columns_component_h(data: GTData) -> str:
     # body = data._body
 
     # Get vector representation of stub layout
-    stub_layout = data._stub._get_stub_layout(row_groups=data._row_groups, options=data._options)
+    stub_layout = data._stub._get_stub_layout(options=data._options)
 
     # Determine the finalized number of spanner rows
     spanner_row_count = _get_spanners_matrix_height(data=data, omit_columns_row=True)
@@ -437,11 +437,11 @@ def create_body_component_h(data: GTData) -> str:
 
     stub_var = data._boxhead._get_stub_column()
 
-    stub_layout = data._stub._get_stub_layout(row_groups=data._row_groups, options=data._options)
+    stub_layout = data._stub._get_stub_layout(options=data._options)
 
     has_stub_column = "rowname" in stub_layout
     has_two_col_stub = "group_label" in stub_layout
-    has_groups = data._row_groups is not None and len(data._row_groups) > 0
+    has_groups = data._stub.group_ids is not None and len(data._stub.group_ids) > 0
 
     # If there is a stub, then prepend that to the `column_vars` list
     if stub_var is not None:
@@ -459,7 +459,7 @@ def create_body_component_h(data: GTData) -> str:
 
         if has_stub_column and has_groups and not has_two_col_stub:
             colspan_value = data._boxhead._get_effective_number_of_columns(
-                stub=data._stub, row_groups=data._row_groups, options=data._options
+                stub=data._stub, options=data._options
             )
 
             # Generate a row that contains the row group label (this spans the entire row) but
@@ -536,7 +536,7 @@ def create_source_notes_component_h(data: GTData) -> str:
     # Get the effective number of columns, which is number of columns
     # that will finally be rendered accounting for the stub layout
     n_cols_total = data._boxhead._get_effective_number_of_columns(
-        stub=data._stub, row_groups=data._row_groups, options=data._options
+        stub=data._stub, options=data._options
     )
 
     # Handle the multiline source notes case (each note takes up one line)

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -452,7 +452,7 @@ def create_body_component_h(data: GTData) -> str:
     # iterate over rows (ordered by groupings)
     prev_group_label = None
 
-    ordered_index = data._group_rows.indices_map(n_rows(data._tbl_data))
+    ordered_index = data._stub.group_indices_map()
 
     for i, group_label in ordered_index:
         body_cells: list[str] = []

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -289,11 +289,11 @@ class GT(
         # built._body = _migrate_unformatted_to_output(body)
 
         # built._perform_col_merge()
-        final_body = body_reassemble(built._body, built._row_groups, built._stub, built._boxhead)
+        final_body = body_reassemble(built._body, built._stub, built._boxhead)
 
         # Reordering of the metadata elements of the table
 
-        final_stub = reorder_stub_df(built._stub, built._row_groups)
+        final_stub = reorder_stub_df(built._stub)
         # self = self.reorder_footnotes()
         # self = self.reorder_styles()
 

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -29,6 +29,7 @@ from great_tables._formats import (
 )
 from great_tables._heading import tab_header
 from great_tables._helpers import random_id
+from great_tables._modify_rows import row_group_order
 from great_tables._options import (
     opt_align_table_header,
     opt_all_caps,
@@ -251,6 +252,8 @@ class GT(
     tab_stubhead = tab_stubhead
     tab_style = tab_style
     tab_options = tab_options
+
+    row_group_order = row_group_order
 
     save = save
     as_raw_html = as_raw_html

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -32,8 +32,6 @@ from great_tables._helpers import random_id
 from great_tables._modify_rows import (
     row_group_order,
     tab_stub,
-    with_groupname_col,
-    with_rowname_col,
     with_id,
     with_locale,
 )
@@ -262,8 +260,6 @@ class GT(
 
     row_group_order = row_group_order
     tab_stub = tab_stub
-    with_groupname_col = with_groupname_col
-    with_rowname_col = with_rowname_col
     with_id = with_id
     with_locale = with_locale
 

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -29,7 +29,13 @@ from great_tables._formats import (
 )
 from great_tables._heading import tab_header
 from great_tables._helpers import random_id
-from great_tables._modify_rows import row_group_order
+from great_tables._modify_rows import (
+    row_group_order,
+    with_groupname_col,
+    with_rowname_col,
+    with_id,
+    with_locale,
+)
 from great_tables._options import (
     opt_align_table_header,
     opt_all_caps,
@@ -254,6 +260,10 @@ class GT(
     tab_options = tab_options
 
     row_group_order = row_group_order
+    with_groupname_col = with_groupname_col
+    with_rowname_col = with_rowname_col
+    with_id = with_id
+    with_locale = with_locale
 
     save = save
     as_raw_html = as_raw_html

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -31,6 +31,7 @@ from great_tables._heading import tab_header
 from great_tables._helpers import random_id
 from great_tables._modify_rows import (
     row_group_order,
+    tab_stub,
     with_groupname_col,
     with_rowname_col,
     with_id,
@@ -260,6 +261,7 @@ class GT(
     tab_options = tab_options
 
     row_group_order = row_group_order
+    tab_stub = tab_stub
     with_groupname_col = with_groupname_col
     with_rowname_col = with_rowname_col
     with_id = with_id

--- a/great_tables/utils_render_common.py
+++ b/great_tables/utils_render_common.py
@@ -13,7 +13,7 @@ TupleStartFinal: TypeAlias = tuple[int, int]
 
 def get_row_reorder_df(stub_df: Stub, groups: RowGroups | None = None) -> list[TupleStartFinal]:
     if groups is None:
-        groups = stub_df.final_group_ids
+        groups = stub_df.group_ids
 
     # Get the number of non-None entries in the `groupname_col`
     n_stub_entries = len([entry for entry in stub_df.rows if entry.group_id is not None])

--- a/great_tables/utils_render_common.py
+++ b/great_tables/utils_render_common.py
@@ -12,6 +12,8 @@ TupleStartFinal: TypeAlias = tuple[int, int]
 
 
 def get_row_reorder_df(stub_df: Stub, groups: RowGroups | None = None) -> list[TupleStartFinal]:
+    # TODO: this function should be removed, since the stub generates indices directly.
+
     if groups is None:
         groups = stub_df.group_ids
 

--- a/great_tables/utils_render_common.py
+++ b/great_tables/utils_render_common.py
@@ -11,7 +11,10 @@ if TYPE_CHECKING:
 TupleStartFinal: TypeAlias = tuple[int, int]
 
 
-def get_row_reorder_df(groups: RowGroups, stub_df: Stub) -> list[TupleStartFinal]:
+def get_row_reorder_df(stub_df: Stub, groups: RowGroups | None = None) -> list[TupleStartFinal]:
+    if groups is None:
+        groups = stub_df.final_group_ids
+
     # Get the number of non-None entries in the `groupname_col`
     n_stub_entries = len([entry for entry in stub_df.rows if entry.group_id is not None])
 

--- a/great_tables/utils_render_common.py
+++ b/great_tables/utils_render_common.py
@@ -13,7 +13,7 @@ TupleStartFinal: TypeAlias = tuple[int, int]
 
 def get_row_reorder_df(groups: RowGroups, stub_df: Stub) -> list[TupleStartFinal]:
     # Get the number of non-None entries in the `groupname_col`
-    n_stub_entries = len([entry for entry in stub_df if entry.group_id is not None])
+    n_stub_entries = len([entry for entry in stub_df.rows if entry.group_id is not None])
 
     # Raise a ValueError if there are row group entries but no RowGroups
     if n_stub_entries and not len(groups):
@@ -22,7 +22,7 @@ def get_row_reorder_df(groups: RowGroups, stub_df: Stub) -> list[TupleStartFinal
     # If there aren't any row groups then return a list of tuples that don't lead
     # to any resorting later on (e.g., `[(0, 0), (1, 1), (2, 2) ... (n, n)]`)
     if not len(groups):
-        indices = range(len(stub_df))
+        indices = range(len(stub_df.rows))
 
         # TODO: is this used in indexing? If so, we may need to use
         # ii + 1 for the final part?
@@ -30,7 +30,9 @@ def get_row_reorder_df(groups: RowGroups, stub_df: Stub) -> list[TupleStartFinal
 
     # where in the group each element is
     # TODO: this doesn't yield consistent values
-    groups_pos = [groups.index(row.group_id) if row.group_id is not None else -1 for row in stub_df]
+    groups_pos = [
+        groups.index(row.group_id) if row.group_id is not None else -1 for row in stub_df.rows
+    ]
 
     # From running test_body_reassemble():
     # print(groups_pos)

--- a/tests/__snapshots__/test_modify_rows.ambr
+++ b/tests/__snapshots__/test_modify_rows.ambr
@@ -1,0 +1,17 @@
+# serializer version: 1
+# name: test_row_group_order
+  '''
+  <tbody class="gt_table_body">
+    <tr>
+      <td class="gt_row gt_left">b</td>
+      <td class="gt_row gt_right">1</td>
+      <td class="gt_row gt_right">3</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_left">a</td>
+      <td class="gt_row gt_right">2</td>
+      <td class="gt_row gt_right">4</td>
+    </tr>
+  </tbody>
+  '''
+# ---

--- a/tests/__snapshots__/test_modify_rows.ambr
+++ b/tests/__snapshots__/test_modify_rows.ambr
@@ -3,14 +3,12 @@
   '''
   <tbody class="gt_table_body">
     <tr>
-      <td class="gt_row gt_left">b</td>
-      <td class="gt_row gt_right">1</td>
-      <td class="gt_row gt_right">3</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_left">a</td>
       <td class="gt_row gt_right">2</td>
       <td class="gt_row gt_right">4</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">1</td>
+      <td class="gt_row gt_right">3</td>
     </tr>
   </tbody>
   '''

--- a/tests/test_gt.py
+++ b/tests/test_gt.py
@@ -19,6 +19,13 @@ def test_gt_replace(gt_tbl: GT):
     assert new_gt_tbl._has_built
 
 
+def test_gt_groupname_and_rowname_col_equal_raises():
+    with pytest.raises(ValueError) as exc_info:
+        GT(pd.DataFrame({"g": [1], "row": [1]}), rowname_col="g", groupname_col="g")
+
+    assert "may not be set to the same column." in exc_info.value.args[0]
+
+
 def test_gt_object_prerender(gt_tbl: GT):
     assert type(gt_tbl).__name__ == "GT"
 

--- a/tests/test_gt.py
+++ b/tests/test_gt.py
@@ -14,10 +14,9 @@ def gt_tbl():
 
 
 def test_gt_replace(gt_tbl: GT):
-    row_groups = ["x"]
-    new_gt_tbl = gt_tbl._replace(_row_groups=row_groups)
+    new_gt_tbl = gt_tbl._replace(_has_built=True)
 
-    assert new_gt_tbl._row_groups is row_groups
+    assert new_gt_tbl._has_built
 
 
 def test_gt_object_prerender(gt_tbl: GT):
@@ -32,7 +31,6 @@ def test_gt_object_prerender(gt_tbl: GT):
     assert isinstance(gt_tbl._source_notes, list)
     assert isinstance(gt_tbl._footnotes, list)
     assert isinstance(gt_tbl._styles, list)
-    assert isinstance(gt_tbl._row_groups, list)
     assert type(gt_tbl._locale).__name__ == "Locale"
 
 

--- a/tests/test_gt_data.py
+++ b/tests/test_gt_data.py
@@ -2,22 +2,26 @@ import pandas as pd
 from great_tables._gt_data import Boxhead, ColInfo, RowInfo, Stub
 
 
-def test_stub_construct_manual():
-    stub = Stub([RowInfo(0), RowInfo(1)])
-    assert stub[0] == RowInfo(0)
-
-
 def test_stub_construct_df():
-    stub = Stub(pd.DataFrame({"x": [8, 9]}))
+    stub = Stub.from_data(pd.DataFrame({"x": [8, 9]}))
 
     assert len(stub) == 2
     assert stub[0] == RowInfo(0)
     assert stub[1] == RowInfo(1)
 
 
+def test_stub_construct_manual():
+    stub = Stub.from_data(pd.DataFrame({"x": [8, 9]}))
+
+    stub2 = Stub(stub.rows, stub.group_rows)
+    assert stub2[0] == RowInfo(0)
+
+
 def test_stub_construct_df_rowname():
     # TODO: remove groupname_col from here
-    stub = Stub(pd.DataFrame({"x": [8, 9], "y": [1, 2]}), rowname_col="x", groupname_col=None)
+    stub = Stub.from_data(
+        pd.DataFrame({"x": [8, 9], "y": [1, 2]}), rowname_col="x", groupname_col=None
+    )
 
 
 def test_boxhead_reorder():

--- a/tests/test_gt_data.py
+++ b/tests/test_gt_data.py
@@ -24,6 +24,16 @@ def test_stub_construct_df_rowname():
     )
 
 
+def test_stub_order_groups():
+    stub = Stub.from_data(pd.DataFrame({"g": ["b", "a", "b", "c"]}), groupname_col="g")
+    assert stub.group_ids == ["b", "a", "c"]
+
+    stub2 = stub.order_groups(["c", "a", "b"])
+    assert stub2.group_ids == ["c", "a", "b"]
+
+    assert stub2.group_indices_map() == [(3, "c"), (1, "a"), (0, "b"), (2, "b")]
+
+
 def test_boxhead_reorder():
     boxh = Boxhead([ColInfo("a"), ColInfo("b"), ColInfo("c")])
     new_boxh = boxh.reorder(["b", "a", "c"])

--- a/tests/test_modify_rows.py
+++ b/tests/test_modify_rows.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from great_tables import GT
+from great_tables import GT, loc, style
 from great_tables._utils_render_html import create_body_component_h
 
 
@@ -15,3 +15,157 @@ def test_row_group_order(snapshot):
     gt = GT(pd.DataFrame({"g": ["b", "a"], "x": [1, 2], "y": [3, 4]}))
 
     assert_rendered_body(snapshot, gt)
+
+
+def test_with_groupname_col():
+    gt = GT(pd.DataFrame({"g": ["b", "a"], "x": [1, 2], "y": [3, 4]}))
+
+    new_gt = gt.with_groupname_col("g")
+    group_rows = new_gt._stub.group_rows
+
+    assert list(grp.group_id for grp in group_rows) == ["b", "a"]
+    assert [grp.indices for grp in group_rows] == [[0], [1]]
+
+
+def test_with_groupname_col_undo_spanner_style():
+    SPAN_COLS = ["g", "x"]
+    STYLE_COLS = ["g", "y"]
+
+    gt = (
+        GT(pd.DataFrame({"g": ["b"], "x": [1], "y": [3]}))
+        .tab_spanner("A", SPAN_COLS)
+        .tab_style(style.fill("red"), loc.body(columns=STYLE_COLS))
+    )
+
+    assert gt._spanners[0].vars == SPAN_COLS
+    assert len(gt._styles) == 2
+    assert {style.colname for style in gt._styles} == set(STYLE_COLS)
+
+    new_gt = gt.with_groupname_col("g")
+
+    # grouping col dropped from spanner vars
+    assert len(new_gt._spanners) == 1
+    assert new_gt._spanners[0].vars == ["x"]
+
+    # grouping col dropped from body styles
+    assert len(new_gt._styles) == 1
+    assert new_gt._styles[0].colname == "y"
+
+
+def test_with_groupname_col_unset():
+
+    gt = GT(
+        pd.DataFrame({"g": ["b"], "row": ["one"], "x": [1], "y": [3]}),
+        rowname_col="row",
+        groupname_col="g",
+    )
+
+    assert gt._boxhead._get_row_group_column().var == "g"
+    assert len(gt._stub.group_rows) == 1
+
+    new_gt = gt.with_groupname_col()
+
+    # check row unchanged ----
+    assert new_gt._boxhead._get_stub_column().var == "row"
+    assert new_gt._stub.rows[0].rowname == "one"
+
+    # check group col removed ----
+    assert new_gt._boxhead._get_row_group_column() is None
+    assert len(new_gt._stub.group_rows) == 0
+
+
+def test_with_rowname_col():
+    gt = GT(pd.DataFrame({"g": ["b", "a"], "x": [1, 2], "y": [3, 4]}))
+
+    new_gt = gt.with_rowname_col("g")
+    rows = new_gt._stub.rows
+
+    assert [row.rowname for row in rows] == ["b", "a"]
+
+
+def test_with_rowname_col_undo_spanner_style():
+    SPAN_COLS = ["g", "x"]
+    STYLE_COLS = ["g", "y"]
+
+    gt = (
+        GT(pd.DataFrame({"g": ["b"], "x": [1], "y": [3]}))
+        .tab_spanner("A", SPAN_COLS)
+        .tab_style(style.fill("red"), loc.body(columns=STYLE_COLS))
+    )
+
+    assert gt._spanners[0].vars == SPAN_COLS
+    assert len(gt._styles) == 2
+    assert {style.colname for style in gt._styles} == set(STYLE_COLS)
+
+    new_gt = gt.with_rowname_col("g")
+
+    # rowname col dropped from spanner vars
+    assert len(new_gt._spanners) == 1
+    assert new_gt._spanners[0].vars == ["x"]
+
+    # rowname col *kept* in body styles
+    assert len(new_gt._styles) == 2
+
+
+def test_with_rowname_col_unset():
+
+    gt = GT(
+        pd.DataFrame({"g": ["b"], "row": ["one"], "x": [1], "y": [3]}),
+        rowname_col="row",
+        groupname_col="g",
+    )
+
+    assert gt._boxhead._get_stub_column().var == "row"
+    assert gt._stub.rows[0].rowname == "one"
+
+    new_gt = gt.with_rowname_col()
+
+    # check row removed ----
+    assert new_gt._boxhead._get_stub_column() is None
+    assert new_gt._stub.rows[0].rowname is None
+
+    # check group col unchanged ----
+    assert new_gt._boxhead._get_row_group_column().var == "g"
+    assert len(new_gt._stub.group_rows) == 1
+
+
+def test_with_locale():
+    gt = GT(pd.DataFrame({"x": [1]}), locale="es")
+
+    assert gt._locale._locale == "es"
+
+    assert gt.with_locale("de")._locale._locale == "de"
+
+
+def test_with_locale_unset():
+    gt = GT(pd.DataFrame({"x": [1]}), locale="es")
+
+    assert gt._locale._locale == "es"
+
+    assert gt.with_locale()._locale._locale is None
+
+
+def test_with_id():
+    gt = GT(pd.DataFrame({"x": [1]}), id="abc")
+
+    assert gt._options.table_id.value == "abc"
+
+    assert gt.with_id("zzz")._options.table_id.value == "zzz"
+
+
+def test_with_id_unset():
+    gt = GT(pd.DataFrame({"x": [1]}), id="abc")
+
+    assert gt._options.table_id.value == "abc"
+
+    assert gt.with_id()._options.table_id.value is None
+
+
+def test_with_id_preserves_other_options():
+    gt = GT(pd.DataFrame({"x": [1]})).tab_options(container_width="20px")
+
+    assert gt._options.container_width.value == "20px"
+
+    new_gt = gt.with_id("zzz")
+    assert new_gt._options.table_id.value == "zzz"
+    assert new_gt._options.container_width.value == "20px"

--- a/tests/test_modify_rows.py
+++ b/tests/test_modify_rows.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+from great_tables import GT
+from great_tables._utils_render_html import create_body_component_h
+
+
+def assert_rendered_body(snapshot, gt):
+    built = gt._build_data("html")
+    body = create_body_component_h(built)
+
+    assert snapshot == body
+
+
+def test_row_group_order(snapshot):
+    gt = GT(pd.DataFrame({"g": ["b", "a"], "x": [1, 2], "y": [3, 4]}))
+
+    assert_rendered_body(snapshot, gt)

--- a/tests/test_modify_rows.py
+++ b/tests/test_modify_rows.py
@@ -12,9 +12,9 @@ def assert_rendered_body(snapshot, gt):
 
 
 def test_row_group_order(snapshot):
-    gt = GT(pd.DataFrame({"g": ["b", "a"], "x": [1, 2], "y": [3, 4]}))
+    gt = GT(pd.DataFrame({"g": ["a", "b"], "x": [1, 2], "y": [3, 4]}), groupname_col="g")
 
-    assert_rendered_body(snapshot, gt)
+    assert_rendered_body(snapshot, gt.row_group_order(["b", "a"]))
 
 
 def test_with_groupname_col():

--- a/tests/test_modify_rows.py
+++ b/tests/test_modify_rows.py
@@ -20,7 +20,7 @@ def test_row_group_order(snapshot):
 def test_with_groupname_col():
     gt = GT(pd.DataFrame({"g": ["b", "a"], "x": [1, 2], "y": [3, 4]}))
 
-    new_gt = gt.with_groupname_col("g")
+    new_gt = gt.tab_stub(groupname_col="g")
     group_rows = new_gt._stub.group_rows
 
     assert list(grp.group_id for grp in group_rows) == ["b", "a"]
@@ -41,7 +41,7 @@ def test_with_groupname_col_undo_spanner_style():
     assert len(gt._styles) == 2
     assert {style.colname for style in gt._styles} == set(STYLE_COLS)
 
-    new_gt = gt.with_groupname_col("g")
+    new_gt = gt.tab_stub(groupname_col="g")
 
     # grouping col dropped from spanner vars
     assert len(new_gt._spanners) == 1
@@ -63,7 +63,7 @@ def test_with_groupname_col_unset():
     assert gt._boxhead._get_row_group_column().var == "g"
     assert len(gt._stub.group_rows) == 1
 
-    new_gt = gt.with_groupname_col()
+    new_gt = gt.tab_stub(rowname_col="row")
 
     # check row unchanged ----
     assert new_gt._boxhead._get_stub_column().var == "row"
@@ -77,7 +77,7 @@ def test_with_groupname_col_unset():
 def test_with_rowname_col():
     gt = GT(pd.DataFrame({"g": ["b", "a"], "x": [1, 2], "y": [3, 4]}))
 
-    new_gt = gt.with_rowname_col("g")
+    new_gt = gt.tab_stub(rowname_col="g")
     rows = new_gt._stub.rows
 
     assert [row.rowname for row in rows] == ["b", "a"]
@@ -97,7 +97,7 @@ def test_with_rowname_col_undo_spanner_style():
     assert len(gt._styles) == 2
     assert {style.colname for style in gt._styles} == set(STYLE_COLS)
 
-    new_gt = gt.with_rowname_col("g")
+    new_gt = gt.tab_stub(rowname_col="g")
 
     # rowname col dropped from spanner vars
     assert len(new_gt._spanners) == 1
@@ -118,7 +118,7 @@ def test_with_rowname_col_unset():
     assert gt._boxhead._get_stub_column().var == "row"
     assert gt._stub.rows[0].rowname == "one"
 
-    new_gt = gt.with_rowname_col()
+    new_gt = gt.tab_stub(groupname_col="g")
 
     # check row removed ----
     assert new_gt._boxhead._get_stub_column() is None

--- a/tests/test_utils_render_common.py
+++ b/tests/test_utils_render_common.py
@@ -1,11 +1,14 @@
 import pytest
-from great_tables._gt_data import RowInfo, Stub
+from great_tables._gt_data import RowInfo, Stub, GroupRowInfo
 from great_tables.utils_render_common import get_row_reorder_df
 
 
 def test_get_row_reorder_df_simple():
     groups = ["b", "a"]
-    stub = Stub([RowInfo(0, "a"), RowInfo(1, "b"), RowInfo(2, "a")])
+    stub = Stub(
+        [RowInfo(0, "a"), RowInfo(1, "b"), RowInfo(2, "a")],
+        [GroupRowInfo("a", indices=[0, 2]), GroupRowInfo("b", indices=[1])],
+    )
 
     start_end = get_row_reorder_df(groups, stub)
 
@@ -14,7 +17,10 @@ def test_get_row_reorder_df_simple():
 
 def test_get_row_reorder_df_no_groups():
     groups = []
-    stub = Stub([RowInfo(0, "a"), RowInfo(1, "b")])
+    stub = Stub(
+        [RowInfo(0, "a"), RowInfo(1, "b")],
+        [GroupRowInfo("a", indices=[0]), GroupRowInfo("b", indices=[1])],
+    )
 
     with pytest.raises(ValueError):
         get_row_reorder_df(groups, stub)

--- a/tests/test_utils_render_common.py
+++ b/tests/test_utils_render_common.py
@@ -10,7 +10,7 @@ def test_get_row_reorder_df_simple():
         [GroupRowInfo("a", indices=[0, 2]), GroupRowInfo("b", indices=[1])],
     )
 
-    start_end = get_row_reorder_df(groups, stub)
+    start_end = get_row_reorder_df(stub, groups)
 
     assert start_end == [(0, 1), (1, 0), (2, 2)]
 
@@ -23,4 +23,4 @@ def test_get_row_reorder_df_no_groups():
     )
 
     with pytest.raises(ValueError):
-        get_row_reorder_df(groups, stub)
+        get_row_reorder_df(stub, groups)


### PR DESCRIPTION
This WIP PR will enable options that currently must be set on construction of GT() to be set with methods.

The options are...

* rowname_col
* groupname_col
* auto_align
* id
* locale

The most challenging options are `rowname_col` and `groupname_col`, since setting these options means checking, and potentially undoing a number of things.

For example, a column that is being set to `rowname_col`, should:

* remove itself from any Spanner variable lists
* change its type in the Boxhead
* update the names in Stub.rows

Similarly, a new `groupname_col` will need to remove any styles that were set on it (when it was in the body).

## Main changes

This PR required a dive into components like Stub. While I was there, it seemed like a good idea to consolidate things into it, so that GT can't get into funky states, and it's clear which class drives things like final row order. This makes things a bit less noodly when updating things like groupname_cols(), since the Stub and Boxhead can now handle the whole task!

Big items:

* Refactor Stub to contain what were prevoiusly RowGroups and GroupRows
  - these classes were tightly coupled, and it's important they don't get out of sync
  - previously, the Stub was reordered but this was never used, and the GroupRows ended up determining order. Now, the Stub doesn't reorder rows and ultimate handles final display order (through its control of GroupRows).
* Feat: add `.row_group_order()` method
* Fix: support missing values in the grouping column for pandas
* ~add `.with_rowname_col()`, `with_groupname_col()`, `with_locale()`, and `.with_id()`~
* feat: add `.tab_stub()`, `.with_locale()`, `.with_id()`
* ~TODO: handle auto_align~