### PR TITLE
Feat gt show

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -58,6 +58,7 @@ filters:
   - interlinks
 
 interlinks:
+  fast: true
   sources:
     numpy:
       url: https://numpy.org/doc/stable/
@@ -182,6 +183,7 @@ quartodoc:
         also get the table code as an HTML fragment with the `as_raw_html()` method.
       contents:
         - GT.save
+        - GT.show
         - GT.as_raw_html
     - title: Value formatting functions
       desc: >

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -10,7 +10,7 @@ from great_tables._gt_data import GTData
 from great_tables._body import body_reassemble
 from great_tables._boxhead import cols_align, cols_label
 from great_tables._data_color import data_color
-from great_tables._export import as_raw_html, save
+from great_tables._export import as_raw_html, save, show
 from great_tables._formats import (
     fmt,
     fmt_bytes,
@@ -266,6 +266,7 @@ class GT(
     with_locale = with_locale
 
     save = save
+    show = show
     as_raw_html = as_raw_html
 
     # -----


### PR DESCRIPTION
This PR addresses #100 by adding a `GT.show()` method, which does the following:

* notebook-like environment: display table in cell output
* repl environment (e.g. ipython shell, python repl): open a browser with table

Fixes: #100 