### PR TITLE
Feat: Allow spanners to use units notation in `.tab_spanner()`

### DIFF
--- a/docs/examples/index.qmd
+++ b/docs/examples/index.qmd
@@ -361,7 +361,7 @@ import polars as pl
 import polars.selectors as cs
 from great_tables import GT, loc, style
 
-coffee_sales = pl.read_json("./_data/coffee-sales.json")
+coffee_sales = pl.DataFrame.deserialize("./_data/coffee-sales.json", format="json")
 
 sel_rev = cs.starts_with("revenue")
 sel_prof = cs.starts_with("profit")

--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -141,6 +141,11 @@ def cols_label(self: GTSelf, **kwargs: str | Text) -> GTSelf:
         elif isinstance(v, Text):
             new_kwargs[k] = v
 
+        else:
+            raise ValueError(
+                "Column labels must be strings or Text objects. Use `md()` or `html()` for formatting."
+            )
+
     boxhead = self._boxhead._set_column_labels(new_kwargs)
 
     return self._replace(_boxhead=boxhead)

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -759,7 +759,7 @@ class GroupRows(_Sequence[GroupRowInfo]):
 class SpannerInfo:
     spanner_id: str
     spanner_level: int
-    spanner_label: str | None = None
+    spanner_label: str | Md | Html | UnitStr | None = None
     spanner_units: str | None = None
     spanner_pattern: str | None = None
     vars: list[str] = field(default_factory=list)

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -759,7 +759,7 @@ class GroupRows(_Sequence[GroupRowInfo]):
 class SpannerInfo:
     spanner_id: str
     spanner_level: int
-    spanner_label: str | Md | Html | UnitStr | None = None
+    spanner_label: str | Text | UnitStr | None = None
     spanner_units: str | None = None
     spanner_pattern: str | None = None
     vars: list[str] = field(default_factory=list)

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -199,6 +199,11 @@ def tab_spanner(
     elif isinstance(label, Text):
         new_label = label
 
+    else:
+        raise ValueError(
+            "Spanner labels must be strings or Text objects. Use `md()` or `html()` for formatting."
+        )
+
     new_span = SpannerInfo(
         spanner_id=id,
         spanner_level=level,

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from ._gt_data import SpannerInfo, Spanners
 from ._locations import resolve_cols_c
 from ._tbl_data import SelectExpr
+from ._text import Text
 
 if TYPE_CHECKING:
     from ._gt_data import Boxhead
@@ -17,7 +18,7 @@ SpannerMatrix = "list[dict[str, str | None]]"
 
 def tab_spanner(
     data: GTSelf,
-    label: str,
+    label: str | Text,
     columns: SelectExpr = None,
     spanners: str | list[str] | None = None,
     level: int | None = None,
@@ -122,6 +123,7 @@ def tab_spanner(
     )
     ```
     """
+    from great_tables._helpers import UnitStr
 
     crnt_spanner_ids = set([span.spanner_id for span in data._spanners])
 
@@ -184,13 +186,26 @@ def tab_spanner(
     spanner_units = None
     spanner_pattern = None
 
+    # Handle units syntax in the label (e.g., "Density ({{ppl / mi^2}})")
+    if isinstance(label, str):
+
+        unitstr = UnitStr.from_str(label)
+
+        if len(unitstr.units_str) == 1 and isinstance(unitstr.units_str[0], str):
+            new_label = unitstr.units_str[0]
+        else:
+            new_label = unitstr
+
+    elif isinstance(label, Text):
+        new_label = label
+
     new_span = SpannerInfo(
         spanner_id=id,
         spanner_level=level,
         vars=column_names,
         spanner_units=spanner_units,
         spanner_pattern=spanner_pattern,
-        spanner_label=label,
+        spanner_label=new_label,
     )
 
     spanners = data._spanners.append_entry(new_span)

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -4,6 +4,7 @@ import polars.selectors as cs
 import pytest
 from great_tables import GT, exibble
 from great_tables._gt_data import Boxhead, ColInfo, ColInfoTypeEnum, SpannerInfo, Spanners
+from great_tables._helpers import UnitStr
 from great_tables._spanners import (
     _validate_sel_cols,
     cols_hide,
@@ -128,6 +129,16 @@ def test_tab_spanners_with_spanner_ids():
 
     assert len(new_gt._spanners) == 2
     assert new_gt._spanners[1] == dst_span
+
+
+def test_tab_spanner_units_text():
+    df = pd.DataFrame({"x": [1.234, 2.345], "y": [3.456, 4.567], "z": [5.678, 6.789]})
+
+    gt = GT(df).tab_spanner(label="Area ({{m^2}})", columns=["x", "y"])
+
+    spanner = gt._spanners[0]
+
+    assert isinstance(spanner.spanner_label, UnitStr)
 
 
 def test_tab_spanners_overlap():


### PR DESCRIPTION
This PR allows for the use of units notation text in spanner labels (through `.tab_spanner()`). Here is an example of the intended usage:

```python
from great_tables import GT, md, system_fonts
from great_tables.data import reactions
import polars as pl
import polars.selectors as ps

reactions_mini = (
    pl.from_pandas(reactions)
    .filter(pl.col("cmpd_type") == "mercaptan")
    .select([
        "cmpd_name",
        "cmpd_formula",
        ps.ends_with("k298")
    ])
    .with_columns(
        cmpd_formula=pl.concat_str(
            "%" + pl.col("cmpd_formula") + "%"
        )
    )
)

(
    GT(reactions_mini, rowname_col="cmpd_name")
    .tab_header(title="Gas-phase reactions \
    of selected mercaptan compounds")
    .tab_spanner(
        columns=ps.ends_with("k298"),
        label = "Reaction Rate Constant (298 K),<br>{{cm^3 molecules^–1 s^–1}}"
    )
    .fmt_units(columns="cmpd_formula")
    .fmt_scientific(columns=ps.ends_with("k298"))
    .sub_missing()
    .cols_hide(columns="O3_k298")
    .cols_label(
        cmpd_formula="",
        OH_k298="OH",
        NO3_k298="{{%NO3%}}",
        Cl_k298="Cl",
    )
    .opt_stylize(style=1, color="blue")
    .opt_horizontal_padding(scale=3)
    .tab_options(
        table_font_names=system_fonts("humanist"),
    )
)

```

<img width="995" alt="image" src="https://github.com/posit-dev/great-tables/assets/5612024/177a9c55-2c8a-4146-874a-308da049707f">
