### PR TITLE
Update polars examples for deprecated arg

### DIFF
--- a/docs/examples/index.qmd
+++ b/docs/examples/index.qmd
@@ -104,7 +104,7 @@ wide_pops = (
         & pl.col("year").is_in([2000, 2010, 2020])
     )
     .with_columns(pl.col("country_code_2").replace(country_to_region).alias("region"))
-    .pivot(index=["country_name", "region"], columns="year", values="population")
+    .pivot(index=["country_name", "region"], on="year", values="population")
     .sort("2020", descending=True)
 )
 
@@ -175,7 +175,7 @@ sza_pivot = (
     .filter((pl.col("latitude") == "20") & (pl.col("tst") <= "1200"))
     .select(pl.col("*").exclude("latitude"))
     .drop_nulls()
-    .pivot(values="sza", index="month", columns="tst", sort_columns=True)
+    .pivot(values="sza", index="month", on="tst", sort_columns=True)
 )
 
 (


### PR DESCRIPTION
# Summary

Made a change to the example tables in the docs. The latest version of Polars deprecates the **columns** argument in the pivot method, throwing an error in the docs. Changing the argument name to **on** should fix the error.

# Related GitHub Issues and PRs

- Ref: #399 

# Checklist

- [X] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [X] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [X] I have added **pytest** unit tests for any new functionality.
