### PR TITLE
Consolidate ordered list code using new `_create_ordered_list()` function

### DIFF
--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -577,7 +577,7 @@ class Stub:
         row_info = [RowInfo(*i) for i in zip(row_indices, group_id, row_names)]
 
         # create groups, and ensure they're ordered by first observed
-        group_names = OrderedSet(row.group_id for row in row_info if row.group_id is not None)
+        group_names = list(OrderedSet(row.group_id for row in row_info if row.group_id is not None))
         group_rows = GroupRows(data, group_key=groupname_col).reorder(group_names)
 
         return cls(row_info, group_rows)

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -24,7 +24,7 @@ from ._tbl_data import (
     to_list,
     validate_frame,
 )
-from ._utils import _str_detect
+from ._utils import _str_detect, _create_ordered_list
 
 if TYPE_CHECKING:
     from ._helpers import Md, Html, UnitStr, Text
@@ -577,7 +577,9 @@ class Stub:
         row_info = [RowInfo(*i) for i in zip(row_indices, group_id, row_names)]
 
         # create groups, and ensure they're ordered by first observed
-        group_names = list({row.group_id: True for row in row_info if row.group_id is not None})
+        group_names = _create_ordered_list(
+            row.group_id for row in row_info if row.group_id is not None
+        )
         group_rows = GroupRows(data, group_key=groupname_col).reorder(group_names)
 
         return cls(row_info, group_rows)

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -24,7 +24,7 @@ from ._tbl_data import (
     to_list,
     validate_frame,
 )
-from ._utils import _str_detect, _create_ordered_list
+from ._utils import _str_detect, OrderedSet
 
 if TYPE_CHECKING:
     from ._helpers import Md, Html, UnitStr, Text
@@ -577,9 +577,7 @@ class Stub:
         row_info = [RowInfo(*i) for i in zip(row_indices, group_id, row_names)]
 
         # create groups, and ensure they're ordered by first observed
-        group_names = _create_ordered_list(
-            row.group_id for row in row_info if row.group_id is not None
-        )
+        group_names = OrderedSet(row.group_id for row in row_info if row.group_id is not None)
         group_rows = GroupRows(data, group_key=groupname_col).reorder(group_names)
 
         return cls(row_info, group_rows)

--- a/great_tables/_scss.py
+++ b/great_tables/_scss.py
@@ -10,7 +10,7 @@ from importlib_resources import files
 from ._data_color.base import _html_color, _ideal_fgnd_color
 from ._gt_data import GTData
 from ._helpers import pct, px
-from ._utils import _as_css_font_family_attr, _unique_set
+from ._utils import _as_css_font_family_attr, OrderedSet
 
 DEFAULTS_TABLE_BACKGROUND = (
     "heading_background_color",
@@ -126,7 +126,11 @@ def compile_scss(
 
     # Handle fonts ----
     # Get the unique list of fonts from `gt_options_dict`
-    font_list = _unique_set(data._options.table_font_names.value)
+    _font_names = data._options.table_font_names.value
+    if _font_names is not None:
+        font_list = OrderedSet(_font_names).as_list()
+    else:
+        font_list = None
 
     # Generate a `font-family` string
     if font_list is not None:

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -7,7 +7,7 @@ from ._gt_data import SpannerInfo, Spanners
 from ._locations import resolve_cols_c
 from ._tbl_data import SelectExpr
 from ._text import Text
-from ._utils import _create_ordered_list
+from ._utils import OrderedSet
 
 if TYPE_CHECKING:
     from ._gt_data import Boxhead
@@ -172,14 +172,14 @@ def tab_spanner(
 
     # get column names associated with selected spanners ----
     _vars = [span.vars for span in data._spanners if span.spanner_id in spanner_ids]
-    spanner_column_names = _create_ordered_list(itertools.chain(*_vars))
+    spanner_column_names = OrderedSet(itertools.chain(*_vars))
 
-    column_names = _create_ordered_list([*selected_column_names, *spanner_column_names])
+    column_names = list(OrderedSet([*selected_column_names, *spanner_column_names]))
     # combine columns names and those from spanners ----
 
     # get spanner level ----
     if level is None:
-        level = data._spanners.next_level(column_names)
+        level = data._spanners.next_level(list(column_names))
 
     # get spanner units and labels ----
     # TODO: grep units from {{.*}}, may need to switch delimiters

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -171,7 +171,7 @@ def tab_spanner(
         raise NotImplementedError("columns/spanners must be specified")
 
     # get column names associated with selected spanners ----
-    _vars = [span.vars for span in data._spanners if span.spanner_id in spanner_ids]
+    _vars = [span.vars for span in self._spanners if span.spanner_id in spanner_ids]
     spanner_column_names = OrderedSet(itertools.chain(*_vars))
 
     column_names = list(OrderedSet([*selected_column_names, *spanner_column_names]))
@@ -179,7 +179,7 @@ def tab_spanner(
 
     # get spanner level ----
     if level is None:
-        level = data._spanners.next_level(list(column_names))
+        level = self._spanners.next_level(list(column_names))
 
     # get spanner units and labels ----
     # TODO: grep units from {{.*}}, may need to switch delimiters

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -7,6 +7,7 @@ from ._gt_data import SpannerInfo, Spanners
 from ._locations import resolve_cols_c
 from ._tbl_data import SelectExpr
 from ._text import Text
+from ._utils import _create_ordered_list
 
 if TYPE_CHECKING:
     from ._gt_data import Boxhead
@@ -171,10 +172,9 @@ def tab_spanner(
 
     # get column names associated with selected spanners ----
     _vars = [span.vars for span in data._spanners if span.spanner_id in spanner_ids]
-    spanner_column_names = list({k: True for k in itertools.chain(*_vars)})
+    spanner_column_names = _create_ordered_list(itertools.chain(*_vars))
 
-    column_names = list({k: True for k in [*selected_column_names, *spanner_column_names]})
-
+    column_names = _create_ordered_list([*selected_column_names, *spanner_column_names])
     # combine columns names and those from spanners ----
 
     # get spanner level ----

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -323,7 +323,7 @@ def _(
 def _(data: PlDataFrame, expr: Union[list[str], _selector_proxy_], strict: bool = True) -> _NamePos:
     # TODO: how to annotate type of a polars selector?
     # Seems to be polars.selectors._selector_proxy_.
-    from ._utils import _create_ordered_list
+    from ._utils import OrderedSet
     import polars.selectors as cs
 
     from polars import Expr
@@ -356,11 +356,11 @@ def _(data: PlDataFrame, expr: Union[list[str], _selector_proxy_], strict: bool 
         # this should be equivalent to reducing selectors using an "or" operator,
         # which isn't possible when there are selectors mixed with expressions
         # like pl.col("some_col")
-        final_columns = _create_ordered_list(
+        final_columns = OrderedSet(
             col_name
             for sel in all_selectors
             for col_name in cs.expand_selector(data, sel, **expand_opts)
-        )
+        ).as_list()
     else:
         if not isinstance(expr, (cls_selector, Expr)):
             raise TypeError(f"Unsupported selection expr type: {type(expr)}")

--- a/great_tables/_utils.py
+++ b/great_tables/_utils.py
@@ -83,16 +83,6 @@ def _str_scalar_to_list(x: str) -> list[str]:
     return [x]
 
 
-def _unique_set(x: list[Any] | None) -> list[Any] | None:
-    if x is None:
-        return None
-    return _create_ordered_list(x)
-
-
-def _create_ordered_list(x: Iterable[Any]) -> list[Any]:
-    return OrderedSet(x).as_list()
-
-
 class OrderedSet(Set):
     def __init__(self, d: Iterable = ()):
         self._d = self._create(d)

--- a/great_tables/_utils.py
+++ b/great_tables/_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Set
 import importlib
 import itertools
 import json
@@ -89,7 +90,38 @@ def _unique_set(x: list[Any] | None) -> list[Any] | None:
 
 
 def _create_ordered_list(x: Iterable[Any]) -> list[Any]:
-    return list(dict.fromkeys(x).keys())
+    return OrderedSet(x).as_list()
+
+
+class OrderedSet(Set):
+    def __init__(self, d: Iterable = ()):
+        self._d = self._create(d)
+
+    def _create(self, d: Iterable):
+        return {k: True for k in d}
+
+    def as_set(self):
+        return set(self._d)
+
+    def as_list(self):
+        return list(self._d)
+
+    def as_dict(self):
+        return dict(self._d)
+
+    def __contains__(self, k):
+        return k in self._d
+
+    def __iter__(self):
+        return iter(self._d)
+
+    def __len__(self):
+        return len(self._d)
+
+    def __repr__(self):
+        cls_name = type(self).__name__
+        lst = self.as_list()
+        return f"{cls_name}({lst!r})"
 
 
 def _as_css_font_family_attr(fonts: list[str], value_only: bool = False) -> str:

--- a/great_tables/_utils.py
+++ b/great_tables/_utils.py
@@ -85,7 +85,11 @@ def _str_scalar_to_list(x: str) -> list[str]:
 def _unique_set(x: list[Any] | None) -> list[Any] | None:
     if x is None:
         return None
-    return list({k: True for k in x})
+    return _create_ordered_list(x)
+
+
+def _create_ordered_list(x: Iterable[Any]) -> list[Any]:
+    return list(dict.fromkeys(x).keys())
 
 
 def _as_css_font_family_attr(fonts: list[str], value_only: bool = False) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from great_tables._utils import (
     _assert_str_list,
     _assert_str_scalar,
     _collapse_list_elements,
+    _create_ordered_list,
     _insert_into_list,
     _match_arg,
     _str_scalar_to_list,
@@ -116,6 +117,19 @@ def test_unique_set():
     result = _unique_set(x)
     assert isinstance(result, list)
     assert len(result) == 2
+
+
+@pytest.mark.parametrize(
+    "iterable, ordered_list",
+    [
+        (["1", "2", "3"], ["1", "2", "3"]),
+        (["1", "3", "2", "3", "1"], ["1", "3", "2"]),
+        ((1, 3, 2, 3, 1, 1, 3, 2, 2), [1, 3, 2]),
+        (iter("223311"), ["2", "3", "1"]),
+    ],
+)
+def test_create_ordered_list(iterable, ordered_list):
+    assert _create_ordered_list(iterable) == ordered_list
 
 
 def test_collapse_list_elements():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from great_tables._utils import (
     _create_ordered_list,
     _insert_into_list,
     _match_arg,
+    OrderedSet,
     _str_scalar_to_list,
     _unique_set,
     heading_has_subtitle,
@@ -117,6 +118,18 @@ def test_unique_set():
     result = _unique_set(x)
     assert isinstance(result, list)
     assert len(result) == 2
+
+
+def test_orderedSet():
+    o = OrderedSet([1, 2, "x", "y", 1, 2])
+
+    assert all(x in o for x in [1, 2, "x", "y"])
+    assert len(o) == 4
+    assert list(o) == [1, 2, "x", "y"]
+    assert o.as_list() == [1, 2, "x", "y"]
+    assert o.as_set() == {1, 2, "x", "y"}
+    assert o.as_dict() == {1: True, 2: True, "x": True, "y": True}
+    assert repr(o) == "OrderedSet([1, 2, 'x', 'y'])"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,12 +6,10 @@ from great_tables._utils import (
     _assert_str_list,
     _assert_str_scalar,
     _collapse_list_elements,
-    _create_ordered_list,
     _insert_into_list,
     _match_arg,
     OrderedSet,
     _str_scalar_to_list,
-    _unique_set,
     heading_has_subtitle,
     heading_has_title,
     seq_groups,
@@ -109,17 +107,6 @@ def test_str_scalar_to_list():
     assert x[0] == "x"
 
 
-def test_unique_set_None():
-    assert _unique_set(None) is None
-
-
-def test_unique_set():
-    x = ["a", "a", "b"]
-    result = _unique_set(x)
-    assert isinstance(result, list)
-    assert len(result) == 2
-
-
 def test_orderedSet():
     o = OrderedSet([1, 2, "x", "y", 1, 2])
 
@@ -142,7 +129,7 @@ def test_orderedSet():
     ],
 )
 def test_create_ordered_list(iterable, ordered_list):
-    assert _create_ordered_list(iterable) == ordered_list
+    assert OrderedSet(iterable).as_list() == ordered_list
 
 
 def test_collapse_list_elements():


### PR DESCRIPTION
Hello team,

I would like to propose consolidating the ordered list-related code using a new function, `_create_ordered_list()`.

Our current logic works well, such as `list({k: True for k in x})` in the `_unique_set()` function. However, even after working on the project for a while, I find it confusing to understand why the `True` is needed. It makes me question whether we need this Boolean value for some if-else logic. Eventually, I realize it's just a placeholder—a nice trick but not very intuitive.

A few hours ago, I came across [a post from Michael Driscoll on LinkedIn](https://www.linkedin.com/posts/driscollis_python-activity-7222631803080097792-XFrm/) and found that `list(dict.fromkeys(x).keys())` is more readable and neat, with a functional programming style. What do you think about this modification?