### PR TITLE
docs: Mention support for `Polars` in the `get-started` section

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -203,7 +203,7 @@ quartodoc:
         - vals.fmt_markdown
     - title: Built in datasets
       desc: >
-        The **Great Tables** package is equipped with ten datasets that come in all shapes and
+        The **Great Tables** package is equipped with sixteen datasets that come in all shapes and
         sizes. Many examples thoughout the help docs use these datasets to quickly demonstrate the
         awesome features of the package!
       contents:

--- a/docs/get-started/index.qmd
+++ b/docs/get-started/index.qmd
@@ -41,6 +41,32 @@ gt_tbl
 
 That doesn't look too bad! Sure, it's basic but we really didn't really ask for much. We did receive a proper table with column labels and the data. Oftentimes however, you'll want a bit more: a **Table header**, a **Stub**, and sometimes *source notes* in the **Table Footer** component.
 
+## **Polars** DataFrame is supported
+`GT` not only accepts **Pandas** DataFrames but also **Polars** DataFrames. You can pass a **Polars** DataFrame to `GT` like this:
+
+```{python}
+import polars as pl
+
+
+# pl.from_pandas(islands_mini) is a Polars DataFrame
+gt_tbl = GT(pl.from_pandas(islands_mini))
+
+# Show the output table
+gt_tbl
+```
+
+During the development of **Great Tables**, we received a lot of support from the developers of **Polars**. After **Polars v1**, you can also get a `GT` object using `DataFrame.style`, like this:
+
+```{python}
+# pl.from_pandas(islands_mini).style returns a `GT` object
+gt_tbl = pl.from_pandas(islands_mini).style
+
+# Show the output table
+gt_tbl
+```
+
+Please note that this feature is considered [unstable](https://docs.pola.rs/api/python/stable/reference/dataframe/style.html#polars.DataFrame.style) and should be used with caution.
+
 ## Some Beautiful Examples
 
 In the following pages we'll use **Great Tables** to turn DataFrames into beautiful tables, like the ones below.

--- a/docs/get-started/index.qmd
+++ b/docs/get-started/index.qmd
@@ -41,31 +41,26 @@ gt_tbl
 
 That doesn't look too bad! Sure, it's basic but we really didn't really ask for much. We did receive a proper table with column labels and the data. Oftentimes however, you'll want a bit more: a **Table header**, a **Stub**, and sometimes *source notes* in the **Table Footer** component.
 
-## **Polars** DataFrame is supported
-`GT` not only accepts **Pandas** DataFrames but also **Polars** DataFrames. You can pass a **Polars** DataFrame to `GT` like this:
+## **Polars** DataFrame support
+
+`GT` accepts both **Pandas** and **Polars** DataFrames. You can pass a **Polars** DataFrame to `GT`, or use its `DataFrame.style` property.
 
 ```{python}
 import polars as pl
 
+df_polars = pl.from_pandas(islands_mini)
 
-# pl.from_pandas(islands_mini) is a Polars DataFrame
-gt_tbl = GT(pl.from_pandas(islands_mini))
+# Approach 1: call GT ----
+GT(df_polars)
 
-# Show the output table
-gt_tbl
+# Approach 2: Polars style property ----
+df_polars.style
 ```
 
-During the development of **Great Tables**, we received a lot of support from the developers of **Polars**. After **Polars v1**, you can also get a `GT` object using `DataFrame.style`, like this:
+:::{.callout-note}
+The `polars.DataFrame.style` property is currently considered [unstable](https://docs.pola.rs/api/python/stable/reference/dataframe/style.html#polars.DataFrame.style), and may change in the future. Using `GT` on a **Polars** DataFrame will always work.
+:::
 
-```{python}
-# pl.from_pandas(islands_mini).style returns a `GT` object
-gt_tbl = pl.from_pandas(islands_mini).style
-
-# Show the output table
-gt_tbl
-```
-
-Please note that this feature is considered [unstable](https://docs.pola.rs/api/python/stable/reference/dataframe/style.html#polars.DataFrame.style) and should be used with caution.
 
 ## Some Beautiful Examples
 


### PR DESCRIPTION
I suggest mentioning that `Polars` DataFrame is supported in the `get-started` section. This should be an attractive point for users.