### PR TITLE
Feat: DataFrame functions subset_frame and to_column_dict

### DIFF
--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -446,18 +446,6 @@ class Boxhead(_Sequence[ColInfo]):
             return None
         return column[0]
 
-    # Get a list of visible column labels
-    def _get_default_column_labels(self) -> list[str | None]:
-        default_column_labels = [
-            x.column_label for x in self._d if x.type == ColInfoTypeEnum.default
-        ]
-        return default_column_labels
-
-    def _get_default_alignments(self) -> list[str]:
-        # Extract alignment strings to only include 'default'-type columns
-        alignments = [str(x.column_align) for x in self._d if x.type == ColInfoTypeEnum.default]
-        return alignments
-
     # Get the alignment for a specific var value
     def _get_boxhead_get_alignment_by_var(self, var: str) -> str:
         # Get the column alignments and also the alignment class names

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -819,6 +819,9 @@ class Heading:
     subtitle: str | None = None
     preheader: str | list[str] | None = None
 
+    def is_empty(self):
+        return self.title is None and self.subtitle is None and self.preheader is None
+
 
 # Stubhead ----
 Stubhead: TypeAlias = "str | None"

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -1186,3 +1186,6 @@ class Options:
         new_info = replace(old_info, value=value)
 
         return replace(self, **{option: new_info})
+
+    def __getitem__(self, k: str) -> Any:
+        return getattr(self, k).value

--- a/tests/test_tbl_data.py
+++ b/tests/test_tbl_data.py
@@ -17,6 +17,7 @@ from great_tables._tbl_data import (
     group_splits,
     is_series,
     reorder,
+    subset_frame,
     to_frame,
     validate_frame,
 )
@@ -35,8 +36,11 @@ def ser(request) -> SeriesLike:
     return request.param([1.0, 2.0, None])
 
 
-def assert_frame_equal(src, target):
+def assert_frame_equal(src, target, include_index=True):
     if isinstance(src, pd.DataFrame):
+        if not include_index:
+            src = src.reset_index(drop=True)
+            target = target.reset_index(drop=True)
         pd.testing.assert_frame_equal(src, target)
     elif isinstance(src, pl.DataFrame):
         pl.testing.assert_frame_equal(src, target)
@@ -246,3 +250,12 @@ def test_cast_frame_to_string_polars_list_col():
     assert new_df["x"].dtype.is_(pl.String)
     assert new_df["y"].dtype.is_(pl.String)
     assert new_df["z"].dtype.is_(pl.String)
+
+
+def test_subset_frame(df):
+    res = subset_frame(df, rows=[0, 2], cols=["col1", "col3"])
+    assert_frame_equal(
+        res,
+        df.__class__({"col1": [1, 3], "col3": [4.0, 6.0]}),
+        include_index=False,
+    )


### PR DESCRIPTION
This PR adds two new DataFrame generic functions:

* subset_frame: return a new DataFrame that is a subset of `rows=` and `cols=`.
* to_column_dict: convert dataframe to a dictionary, where each column is an entry.

These functions were used in prototyping rendering GT as an interactive table in https://github.com/machow/reactable-py/blob/main/reactable/render_gt.py, but I suspect they'll be useful here.

(Alternatively, we could implement them in reactable-py, which also has a `_tbl_data.py` file?!)