### PR TITLE
Remove mentions of `accounting` in `force_sign=` argument

### DIFF
--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -231,8 +231,7 @@ def fmt_number(
     force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
-        negative numbers will display a minus sign. This option is disregarded when using accounting
-        notation with `accounting = True`.
+        negative numbers will display a minus sign.
     locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
@@ -412,8 +411,7 @@ def fmt_integer(
     force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
-        negative numbers will display a minus sign. This option is disregarded when using accounting
-        notation with `accounting = True`.
+        negative numbers will display a minus sign.
     locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
@@ -865,8 +863,7 @@ def fmt_percent(
     force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
-        negative numbers will display a minus sign. This option is disregarded when using accounting
-        notation with `accounting = True`.
+        negative numbers will display a minus sign.
     placement
         This option governs the placement of the percent sign. This can be either be `"right"` (the
         default) or `"left"`.
@@ -1089,8 +1086,7 @@ def fmt_currency(
     force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
-        negative numbers will display a minus sign. This option is disregarded when using accounting
-        notation with `accounting = True`.
+        negative numbers will display a minus sign.
     placement
         The placement of the currency symbol. This can be either be `"left"` (as in `"$450"`) or
         `"right"` (which yields `"450$"`).
@@ -1437,8 +1433,7 @@ def fmt_bytes(
     force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
-        negative numbers will display a minus sign. This option is disregarded when using accounting
-        notation with `accounting = True`.
+        negative numbers will display a minus sign.
     incl_space
         An option for whether to include a space between the value and the currency symbol. The
         default is to not introduce a space character.

--- a/great_tables/_formats_vals.py
+++ b/great_tables/_formats_vals.py
@@ -130,8 +130,7 @@ def val_fmt_number(
     force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
-        negative numbers will display a minus sign. This option is disregarded when using accounting
-        notation with `accounting = True`.
+        negative numbers will display a minus sign.
     locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
@@ -219,8 +218,7 @@ def val_fmt_integer(
     force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
-        negative numbers will display a minus sign. This option is disregarded when using accounting
-        notation with `accounting = True`.
+        negative numbers will display a minus sign.
     locale
         An optional locale identifier that can be used for formatting values according the locale's
         rules. Examples include `"en"` for English (United States) and `"fr"` for French (France).
@@ -447,8 +445,7 @@ def val_fmt_percent(
     force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
-        negative numbers will display a minus sign. This option is disregarded when using accounting
-        notation with `accounting = True`.
+        negative numbers will display a minus sign.
     placement
         This option governs the placement of the percent sign. This can be either be `"right"` (the
         default) or `"left"`.
@@ -568,8 +565,7 @@ def val_fmt_currency(
     force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
-        negative numbers will display a minus sign. This option is disregarded when using accounting
-        notation with `accounting = True`.
+        negative numbers will display a minus sign.
     placement
         The placement of the currency symbol. This can be either be `"left"` (as in `"$450"`) or
         `"right"` (which yields `"450$"`).
@@ -726,8 +722,7 @@ def val_fmt_bytes(
     force_sign
         Should the positive sign be shown for positive values (effectively showing a sign for all
         values except zero)? If so, use `True` for this option. The default is `False`, where only
-        negative numbers will display a minus sign. This option is disregarded when using accounting
-        notation with `accounting = True`.
+        negative numbers will display a minus sign.
     incl_space
         An option for whether to include a space between the value and the currency symbol. The
         default is to not introduce a space character.


### PR DESCRIPTION
In several of the formatting methods, the common argument `force_sign=` erroneously mentions accounting notation. That feature does not yet exist in Great Tables so this text is removed here.

Fixes: https://github.com/posit-dev/great-tables/issues/241