### PR TITLE
fix: save with latest google chrome

### DIFF
--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -360,7 +360,7 @@ def _save_screenshot(
     # the window can be bigger than the table, but smaller risks pushing text
     # onto new lines. this pads width and height for a little slack.
     # note that this is mostly to account for body, div padding, and table borders.
-    crud_factor = 200
+    crud_factor = 100
 
     offset_left, offset_top = driver.execute_script(
         "var div = document.body.childNodes[0]; return [div.offsetLeft, div.offsetTop];"
@@ -372,6 +372,8 @@ def _save_screenshot(
 
     # set to our required_width first, in case it changes the height of the table
     driver.set_window_size(required_width, original_size["height"])
+
+    time.sleep(0.05)
 
     if debug == "width_resize":
         return _dump_debug_screenshot(driver, path)

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -360,15 +360,17 @@ def _save_screenshot(
     # the window can be bigger than the table, but smaller risks pushing text
     # onto new lines. this pads width and height for a little slack.
     # note that this is mostly to account for body, div padding, and table borders.
-    crud_factor = 100
-
+    crud_factor = 10
+    outer_width, outer_height = driver.execute_script(
+        "var w = window; return [w.outerWidth - w.innerWidth, w.outerHeight - w.innerHeight]"
+    )
     offset_left, offset_top = driver.execute_script(
         "var div = document.body.childNodes[0]; return [div.offsetLeft, div.offsetTop];"
     )
     reported_width = driver.execute_script(
         "var el = document.getElementsByTagName('table')[0]; return el.clientWidth;"
     )
-    required_width = (reported_width + offset_left * 2 + crud_factor) * scale
+    required_width = (reported_width + offset_left * 2) * scale + crud_factor + outer_width
 
     # set to our required_width first, in case it changes the height of the table
     driver.set_window_size(required_width, original_size["height"])
@@ -382,7 +384,7 @@ def _save_screenshot(
     div_height = driver.execute_script(
         "var div = document.body.childNodes[0]; return div.scrollHeight;"
     )
-    required_height = div_height + crud_factor + offset_top * 2
+    required_height = div_height + offset_top * 2 + crud_factor + outer_height
 
     # final resize window and capture image ----
     driver.set_window_size(required_width, required_height)

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -384,7 +384,7 @@ def _save_screenshot(
     div_height = driver.execute_script(
         "var div = document.body.childNodes[0]; return div.scrollHeight;"
     )
-    required_height = div_height + offset_top * 2 + crud_factor + outer_height
+    required_height = div_height + offset_top * 2 + outer_height
 
     # final resize window and capture image ----
     driver.set_window_size(required_width, required_height)
@@ -414,8 +414,8 @@ def _save_screenshot(
 
 def _dump_debug_screenshot(driver, path):
     driver.execute_script(
-        "document.body.style.border = '5px solid blue'; "
-        "document.body.childNodes[0].style.border = '5px solid orange'; "
-        "document.getElementsByTagName('table')[0].style.border = '5px solid green'; "
+        "document.body.style.border = '3px solid blue'; "
+        "document.body.childNodes[0].style.border = '3px solid orange'; "
+        "document.getElementsByTagName('table')[0].style.border = '3px solid green'; "
     )
     driver.save_screenshot(path)

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -360,7 +360,7 @@ def _save_screenshot(
     # the window can be bigger than the table, but smaller risks pushing text
     # onto new lines. this pads width and height for a little slack.
     # note that this is mostly to account for body, div padding, and table borders.
-    crud_factor = 100
+    crud_factor = 200
 
     offset_left, offset_top = driver.execute_script(
         "var div = document.body.childNodes[0]; return [div.offsetLeft, div.offsetTop];"

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -360,7 +360,7 @@ def _save_screenshot(
     # the window can be bigger than the table, but smaller risks pushing text
     # onto new lines. this pads width and height for a little slack.
     # note that this is mostly to account for body, div padding, and table borders.
-    crud_factor = 10
+    crud_factor = 20
     outer_width, outer_height = driver.execute_script(
         "var w = window; return [w.outerWidth - w.innerWidth, w.outerHeight - w.innerHeight]"
     )


### PR DESCRIPTION
This PR is to address #424 

The challenge was that our resizing set the browser outer dimensions, but this does not account for space taken up by browser UI elements (which vary by browser). We had a "crud factor" set that basically accounted for this space by blissful accident.

`.save()` now explicitly tries to calculate the space between outer and inner browser dimensions, with a much smaller crud factor (to create some small padding around the table. This is important because table borders without crud factor might cause issues).