### PR TITLE
docs: indicate that `tab_spanner()` allows for use of units notation in its `label=` arg

### DIFF
--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -40,6 +40,16 @@ def tab_spanner(
     `level` as space permits) and with `replace`, which allows for full or partial spanner
     replacement.
 
+    Labels may use either of three types of input:
+
+    1. plain text
+    2. Markdown or HTML text through use of the [`md()`](`great_tables.md`) or
+    [`html()`](`great_tables.html`) helpers, respectively.
+    3. Text set in curly braces for applying special formatting, called unit notation. For example,
+    "area ({{ft^2}})" would appear as "area (ft²)".
+
+    See [`define_units()`](`great_tables.define_units`) for details on unit notation.
+
     Parameters
     ----------
     label

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -40,22 +40,13 @@ def tab_spanner(
     `level` as space permits) and with `replace`, which allows for full or partial spanner
     replacement.
 
-    Labels may use either of three types of input:
-
-    1. plain text
-    2. Markdown or HTML text through use of the [`md()`](`great_tables.md`) or
-    [`html()`](`great_tables.html`) helpers, respectively.
-    3. Text set in curly braces for applying special formatting, called unit notation. For example,
-    "area ({{ft^2}})" would appear as "area (ft²)".
-
-    See [`define_units()`](`great_tables.define_units`) for details on unit notation.
-
     Parameters
     ----------
     label
         The text to use for the spanner label. We can optionally use the [`md()`](`great_tables.md`)
         and [`html()`](`great_tables.html`) helper functions to style the text as Markdown or to
-        retain HTML elements in the text.
+        retain HTML elements in the text. Alternatively, units notation can be used (see
+        [`define_units()`](`great_tables.define_units`) for details.)
     columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -46,7 +46,7 @@ def tab_spanner(
         The text to use for the spanner label. We can optionally use the [`md()`](`great_tables.md`)
         and [`html()`](`great_tables.html`) helper functions to style the text as Markdown or to
         retain HTML elements in the text. Alternatively, units notation can be used (see
-        [`define_units()`](`great_tables.define_units`) for details.)
+        [`define_units()`](`great_tables.define_units`) for details).
     columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list.


### PR DESCRIPTION
This is a simple documentation improvement for the `tab_spanner()` method. The `cols_label()` allows for the use of units notation syntax and has documentation to explain that. This was missing for `tab_spanner()` though it has equivalent functionality. This PR explains that units notation can be used in `tab_spanner()`

Fixes: https://github.com/posit-dev/great-tables/issues/395