### PR TITLE
Standardize the `GTSelf` signature

### DIFF
--- a/great_tables/_source_notes.py
+++ b/great_tables/_source_notes.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from ._types import GTSelf
 
 
-def tab_source_note(data: GTSelf, source_note: str | Text) -> GTSelf:
+def tab_source_note(self: GTSelf, source_note: str | Text) -> GTSelf:
     """
     Add a source note citation.
 
@@ -51,4 +51,4 @@ def tab_source_note(data: GTSelf, source_note: str | Text) -> GTSelf:
     ```
     """
 
-    return data._replace(_source_notes=data._source_notes + [source_note])
+    return self._replace(_source_notes=self._source_notes + [source_note])

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -17,7 +17,7 @@ SpannerMatrix = "list[dict[str, str | None]]"
 
 
 def tab_spanner(
-    data: GTSelf,
+    self: GTSelf,
     label: str | Text,
     columns: SelectExpr = None,
     spanners: str | list[str] | None = None,
@@ -125,7 +125,7 @@ def tab_spanner(
     """
     from great_tables._helpers import UnitStr
 
-    crnt_spanner_ids = set([span.spanner_id for span in data._spanners])
+    crnt_spanner_ids = set([span.spanner_id for span in self._spanners])
 
     if id is None:
         # The label may contain HTML or Markdown, so we need to extract
@@ -153,7 +153,7 @@ def tab_spanner(
 
     # select columns ----
 
-    selected_column_names = resolve_cols_c(data=data, expr=columns, null_means="nothing") or []
+    selected_column_names = resolve_cols_c(data=self, expr=columns, null_means="nothing") or []
 
     # select spanner ids ----
     # TODO: this supports tidyselect
@@ -170,7 +170,7 @@ def tab_spanner(
         raise NotImplementedError("columns/spanners must be specified")
 
     # get column names associated with selected spanners ----
-    _vars = [span.vars for span in data._spanners if span.spanner_id in spanner_ids]
+    _vars = [span.vars for span in self._spanners if span.spanner_id in spanner_ids]
     spanner_column_names = list({k: True for k in itertools.chain(*_vars)})
 
     column_names = list({k: True for k in [*selected_column_names, *spanner_column_names]})
@@ -179,7 +179,7 @@ def tab_spanner(
 
     # get spanner level ----
     if level is None:
-        level = data._spanners.next_level(column_names)
+        level = self._spanners.next_level(column_names)
 
     # get spanner units and labels ----
     # TODO: grep units from {{.*}}, may need to switch delimiters
@@ -213,8 +213,8 @@ def tab_spanner(
         spanner_label=new_label,
     )
 
-    spanners = data._spanners.append_entry(new_span)
-    new_data = data._replace(_spanners=spanners)
+    spanners = self._spanners.append_entry(new_span)
+    new_data = self._replace(_spanners=spanners)
 
     if gather and not len(spanner_ids) and level == 0 and column_names:
         return cols_move(new_data, columns=column_names, after=column_names[0])
@@ -229,7 +229,7 @@ def _validate_sel_cols(sel_cols: list[str], col_vars: list[str]) -> None:
         raise ValueError("All `columns` must exist and be visible in the input `data` table.")
 
 
-def cols_move(data: GTSelf, columns: SelectExpr, after: str) -> GTSelf:
+def cols_move(self: GTSelf, columns: SelectExpr, after: str) -> GTSelf:
     """Move one or more columns.
 
     On those occasions where you need to move columns this way or that way, we can make use of the
@@ -287,11 +287,11 @@ def cols_move(data: GTSelf, columns: SelectExpr, after: str) -> GTSelf:
     if isinstance(columns, str):
         columns = [columns]
 
-    sel_cols = resolve_cols_c(data=data, expr=columns)
+    sel_cols = resolve_cols_c(data=self, expr=columns)
 
-    sel_after = resolve_cols_c(data=data, expr=[after])
+    sel_after = resolve_cols_c(data=self, expr=[after])
 
-    col_vars = [col.var for col in data._boxhead]
+    col_vars = [col.var for col in self._boxhead]
 
     if not len(sel_after):
         raise ValueError(f"Column {after} not found in table.")
@@ -308,11 +308,11 @@ def cols_move(data: GTSelf, columns: SelectExpr, after: str) -> GTSelf:
     indx = other_columns.index(after)
     final_vars = [*other_columns[: indx + 1], *moving_columns, *other_columns[indx + 1 :]]
 
-    new_boxhead = data._boxhead.reorder(final_vars)
-    return data._replace(_boxhead=new_boxhead)
+    new_boxhead = self._boxhead.reorder(final_vars)
+    return self._replace(_boxhead=new_boxhead)
 
 
-def cols_move_to_start(data: GTSelf, columns: SelectExpr) -> GTSelf:
+def cols_move_to_start(self: GTSelf, columns: SelectExpr) -> GTSelf:
     """Move one or more columns to the start.
 
     We can easily move set of columns to the beginning of the column series and we only need to
@@ -368,9 +368,9 @@ def cols_move_to_start(data: GTSelf, columns: SelectExpr) -> GTSelf:
     if isinstance(columns, str):
         columns = [columns]
 
-    sel_cols = resolve_cols_c(data=data, expr=columns)
+    sel_cols = resolve_cols_c(data=self, expr=columns)
 
-    col_vars = [col.var for col in data._boxhead]
+    col_vars = [col.var for col in self._boxhead]
 
     _validate_sel_cols(sel_cols, col_vars)
 
@@ -379,11 +379,11 @@ def cols_move_to_start(data: GTSelf, columns: SelectExpr) -> GTSelf:
 
     final_vars = [*moving_columns, *other_columns]
 
-    new_boxhead = data._boxhead.reorder(final_vars)
-    return data._replace(_boxhead=new_boxhead)
+    new_boxhead = self._boxhead.reorder(final_vars)
+    return self._replace(_boxhead=new_boxhead)
 
 
-def cols_move_to_end(data: GTSelf, columns: SelectExpr) -> GTSelf:
+def cols_move_to_end(self: GTSelf, columns: SelectExpr) -> GTSelf:
     """Move one or more columns to the end.
 
     We can easily move set of columns to the beginning of the column series and we only need to
@@ -434,9 +434,9 @@ def cols_move_to_end(data: GTSelf, columns: SelectExpr) -> GTSelf:
     if isinstance(columns, str):
         columns = [columns]
 
-    sel_cols = resolve_cols_c(data=data, expr=columns)
+    sel_cols = resolve_cols_c(data=self, expr=columns)
 
-    col_vars = [col.var for col in data._boxhead]
+    col_vars = [col.var for col in self._boxhead]
 
     _validate_sel_cols(sel_cols, col_vars)
 
@@ -445,11 +445,11 @@ def cols_move_to_end(data: GTSelf, columns: SelectExpr) -> GTSelf:
 
     final_vars = [*other_columns, *moving_columns]
 
-    new_boxhead = data._boxhead.reorder(final_vars)
-    return data._replace(_boxhead=new_boxhead)
+    new_boxhead = self._boxhead.reorder(final_vars)
+    return self._replace(_boxhead=new_boxhead)
 
 
-def cols_hide(data: GTSelf, columns: SelectExpr) -> GTSelf:
+def cols_hide(self: GTSelf, columns: SelectExpr) -> GTSelf:
     """Hide one or more columns.
 
     The `cols_hide()` method allows us to hide one or more columns from appearing in the final
@@ -502,16 +502,16 @@ def cols_hide(data: GTSelf, columns: SelectExpr) -> GTSelf:
     if isinstance(columns, str):
         columns = [columns]
 
-    sel_cols = resolve_cols_c(data=data, expr=columns)
+    sel_cols = resolve_cols_c(data=self, expr=columns)
 
-    col_vars = [col.var for col in data._boxhead]
+    col_vars = [col.var for col in self._boxhead]
 
     _validate_sel_cols(sel_cols, col_vars)
 
     # New boxhead with hidden columns
-    new_boxhead = data._boxhead.set_cols_hidden(sel_cols)
+    new_boxhead = self._boxhead.set_cols_hidden(sel_cols)
 
-    return data._replace(_boxhead=new_boxhead)
+    return self._replace(_boxhead=new_boxhead)
 
 
 def spanners_print_matrix(
@@ -580,7 +580,7 @@ def empty_spanner_matrix(
     return [{var: var for var in vars}], vars
 
 
-def cols_width(data: GTSelf, cases: dict[str, str]) -> GTSelf:
+def cols_width(self: GTSelf, cases: dict[str, str]) -> GTSelf:
     """Set the widths of columns.
 
     Manual specifications of column widths can be performed using the `cols_width()` method. We
@@ -684,9 +684,9 @@ def cols_width(data: GTSelf, cases: dict[str, str]) -> GTSelf:
     previous example).
     """
 
-    curr_boxhead = data._boxhead
+    curr_boxhead = self._boxhead
 
     for col, width in cases.items():
         curr_boxhead = curr_boxhead._set_column_width(col, width)
 
-    return data._replace(_boxhead=curr_boxhead)
+    return self._replace(_boxhead=curr_boxhead)


### PR DESCRIPTION
It seems we have two different signatures, `data: GTSelf` and `self: GTSelf`, to describe `GTSelf`. I propose we standardize the signature to `self: GTSelf`, as it is more commonly used in the repo.