### PR TITLE
fix: use `isinstance()` instead of `hasattr()`

### DIFF
--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -130,7 +130,7 @@ def tab_spanner(
     if id is None:
         # The label may contain HTML or Markdown, so we need to extract
         # it from the Text object
-        if hasattr(label, "text"):
+        if isinstance(label, Text):
             id = label.text
         else:
             id = label


### PR DESCRIPTION
In https://github.com/posit-dev/great-tables/issues/348 we wanted to ensure that the signature of `tab_spanner()` has been updated with types that indicate `md()` and `html()` could be used in the `label=` argument. This was done in a previous PR.

A second requirement was update the logic to use `isinstance()` checks rather than `hasattr()`. That change was made in this PR.

Fixes: https://github.com/posit-dev/great-tables/issues/348