### PR TITLE
Update `FmtImage.to_html()`

### DIFF
--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -3492,7 +3492,6 @@ class FmtImage:
     SPAN_TEMPLATE: ClassVar = '<span style="white-space:nowrap;">{}</span>'
 
     def to_html(self, val: Any):
-        import re
         from pathlib import Path
 
         # TODO: are we assuming val is a string? (or coercing?)
@@ -3526,9 +3525,8 @@ class FmtImage:
         for file in full_files:
             # Case 1: from url
             if self.path and (self.path.startswith("http://") or self.path.startswith("https://")):
-                norm_path = re.sub(r"/\s+$", self.path)
+                norm_path = self.path.rstrip().removesuffix("/")
                 uri = f"{norm_path}/{file}"
-
             # Case 2:
             else:
                 filename = (Path(self.path or "") / file).expanduser().absolute()

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1490,6 +1490,20 @@ def test_fmt_image_path():
 
 
 @pytest.mark.parametrize(
+    "url", ["http://posit.co/", "http://posit.co", "https://posit.co/", "https://posit.co"]
+)
+def test_fmt_image_path_http(url: str):
+    formatter = FmtImage(encode=False, height=30, path=url)
+    res = formatter.to_html("c")
+    dst_img = '<img src="{}/c" style="height: 30px;vertical-align: middle;">'.format(
+        url.removesuffix("/")
+    )
+    dst = formatter.SPAN_TEMPLATE.format(dst_img)
+
+    assert strip_windows_drive(res) == dst
+
+
+@pytest.mark.parametrize(
     "src,dst",
     [
         # 1. unit with superscript


### PR DESCRIPTION
Hello team,

I'd like to format the column by providing an HTTP/HTTPS URL to the `path` parameter in `GT.fmt_image()` like so:

```python
import polars as pl
from great_tables import GT

df = pl.DataFrame({"logo": ["GT_logo.svg"]})
GT(df).fmt_image(
    "logo",
    path="https://raw.githubusercontent.com/posit-dev/great-tables/main/docs/assets/",
)
```
I was expecting this outcome:
![image](https://github.com/user-attachments/assets/7c5f36c6-28a1-4f52-9219-969743da49c3)

However, I'm encountering a `TypeError: sub() missing 1 required positional argument: 'string'`.

It appears that the error originates from this line:
https://github.com/posit-dev/great-tables/blob/016c67f7cf75272ac4bff0b678383a8f8993c985/great_tables/_formats.py#L3529

If I understand correctly, this line is intended to do two things: (1) remove trailing spaces, if any, and (2) remove the trailing `/`, if present. To fix this, the line could be updated as follows:

```python
norm_path = re.sub(r"/\s*$", "", self.path)
```
This would:
- Pass all three required arguments to `re.sub()`.
- Change the `+` modifier to `*` to allow for zero or more spaces.

That said, I believe using `self.path.rstrip().removesuffix("/")` as proposed in this PR is more straightforward and easier to understand.