### PR TITLE
docs: provide updates to PyCon- and SciPy-related blog posts

### DIFF
--- a/docs/blog/pycon-2024-great-tables-are-possible/index.qmd
+++ b/docs/blog/pycon-2024-great-tables-are-possible/index.qmd
@@ -42,31 +42,25 @@ Note three important pieces:
 3. **The nanoplot** on the right shows a tiny bargraph for monthly sales over the past year.  This makes
    it easy to spot trends, and can be hovered over to get exact values.
 
-Critically, the code for this table used the DataFrame library [Polars](https://pola.rs/), which
-makes it really [easy to select rows and columns for styling](../polars-styling).
+Critically, the code for this table used the DataFrame library [Polars](https://pola.rs/), which makes it really [easy to select rows and columns for styling](../polars-styling/index.qmd).
 
 
 ## What's next?
 
 ### The 2024 Table Contest
 
-The world's premier display table contest---the [4th annual Table Contest](https://posit.co/blog/announcing-the-2024-table-contest/) draws competitors from near and far,
-to showcase the latest and greatest examples in table presentation.
-The contest is happening now, with **submissions due by May 31st, 2024**.
+The world's premier display table contest---the [4th annual Table Contest](https://posit.co/blog/announcing-the-2024-table-contest/) draws competitors from near and far, to showcase the latest and greatest examples in table presentation.
 
-For inspiration, see these resources:
-
-* [Contest announcement](https://posit.co/blog/announcing-the-2024-table-contest/)
-* [2022 winners and honorable mentions](https://posit.co/blog/winners-of-the-2022-table-contest/)
+The contest was a great success! On July 1, 2024 we announced the [2024 winners and honorable mentions](https://posit.co/blog/2024-table-contest-winners/). Check 'em out!
 
 
 ### posit::conf() workshop
 
-We're planning a posit::conf() 2024 workshop in August, called [Making Tables with gt and Great Tables](https://reg.conf.posit.co/flow/posit/positconf24/publiccatalog/page/publiccatalog/session/1707334049004001S0l2).
+We held a posit::conf() 2024 workshop, and you can find the materials at the [Making Tables with gt and Great Tables repo](https://github.com/posit-conf-2024/tables).
 
-If you're curious about making beautiful, publication quality tables in Python or R, we'd love to have you!
+If you're curious about making beautiful, publication quality tables in Python or R, do have a look at the resources at that GitHub repository.
 
-We’ll cover the following:
+We covered the following table topics:
 
 * Create table components and put them together (e.g., header, footer, stub, etc.)
 * Format cell values (numeric/scientific, date/datetime, etc.)
@@ -79,13 +73,11 @@ We’ll cover the following:
 
 Check out these resources to learn more about the wild and beautiful life of display tables:
 
-* [Great Tables example gallery](../examples/index.html)
-* [The Design Philosophy of Great Tables (blog post)](blog/design-philosophy/)
+* [Great Tables example gallery](../../examples/index.qmd)
+* [The Design Philosophy of Great Tables (blog post)](../design-philosophy/index.qmd)
 * [20 Minute Table Tutorial by Albert Rapp](https://youtu.be/ESyWcOFuMQc?si=1_bBRZEKENFKVNpB)
 * [PyCon talk: Making Beautiful, Publication Quality Tables is Possible in 2024](https://youtu.be/08yLWPpFdo4?si=vBK9h-ObXNKp9tHH)
 
 ## Hope all your tables are great!
 
-A huge thanks to all the people who have contributed to Great Tables over the past year.
-It's been a really incredible journey.
-Hope to see you at PyCon 2024!
+A huge thanks to all the people who have contributed to Great Tables over the past year. It's been a really incredible journey!

--- a/docs/blog/pycon-2024-great-tables-are-possible/index.qmd
+++ b/docs/blog/pycon-2024-great-tables-are-possible/index.qmd
@@ -9,7 +9,7 @@ freeze: true
 The Great Tables crew is excited to share that we'll be presenting on tables at PyCon 2024!
 If you're around and want to meet, be sure to stop by the Posit Booth, or reach out on linkedin to [Rich](https://www.linkedin.com/in/richard-iannone-a5640017/) or [Michael](https://www.linkedin.com/in/michael-a-chow/)!
 
-The talk, Making Beautiful, Publication Quality Tables is Possible in 2024 is [10:45am Friday](https://us.pycon.org/2024/schedule/presentation/65/).
+The talk, Making Beautiful, Publication Quality Tables is Possible in 2024 happened on [May 17, 2024](https://us.pycon.org/2024/schedule/presentation/65/). You can watch the [recording on YouTube](https://youtu.be/08yLWPpFdo4?si=vBK9h-ObXNKp9tHH).
 
 In addition to the talk, there are two other events worth mentioning:
 
@@ -79,9 +79,10 @@ We’ll cover the following:
 
 Check out these resources to learn more about the wild and beautiful life of display tables:
 
-* [Great Tables example gallery](/docs/examples)
-* [The Design Philosophy of Great Tables (blog post)](http://localhost:6877/blog/design-philosophy/)
+* [Great Tables example gallery](../examples/index.html)
+* [The Design Philosophy of Great Tables (blog post)](blog/design-philosophy/)
 * [20 Minute Table Tutorial by Albert Rapp](https://youtu.be/ESyWcOFuMQc?si=1_bBRZEKENFKVNpB)
+* [PyCon talk: Making Beautiful, Publication Quality Tables is Possible in 2024](https://youtu.be/08yLWPpFdo4?si=vBK9h-ObXNKp9tHH)
 
 ## Hope all your tables are great!
 

--- a/docs/blog/tables-for-scientific-publishing/index.qmd
+++ b/docs/blog/tables-for-scientific-publishing/index.qmd
@@ -23,7 +23,7 @@ We've added **six new datasets**, to help quickly show off scientific publishing
 :::{.callout-tip}
 Rich presented on this topic at SciPy 2024!
 
-At SciPy 2024 (July 11, 2024, Tacoma, WA), Rich delivered a talk called *Great Tables for Everyone* and it presented some of the tables shown in this post. If you weren't in attendence that's okay, you can [watch the recorded talk](https://youtu.be/uvH-Z39ZUj0?si=3NVipMteXaeO3vb1) and the materials are available [in GitHub](https://github.com/rich-iannone/presentations/tree/main/2024-07-11-SciPy-talk-GT).
+At SciPy 2024 (on July 11, 2024), Rich delivered a talk called *Great Tables for Everyone* and it presented some of the tables shown in this post. If you weren't in attendence that's okay, you can [watch the recorded talk](https://youtu.be/uvH-Z39ZUj0?si=3NVipMteXaeO3vb1) and the materials are available [in GitHub](https://github.com/rich-iannone/presentations/tree/main/2024-07-11-SciPy-talk-GT).
 :::
 
 ## Unit and scientific notation

--- a/docs/blog/tables-for-scientific-publishing/index.qmd
+++ b/docs/blog/tables-for-scientific-publishing/index.qmd
@@ -21,9 +21,9 @@ In this post, we'll review the big pieces that scientific tables need:
 We've added **six new datasets**, to help quickly show off scientific publishing! We'll use the new `reactions` and `gibraltar` datasets to create examples in the fields of Atmospheric Chemistry and Meteorology, respectively.
 
 :::{.callout-tip}
-Rich will be speaking on this at SciPy!
+Rich presented on this topic at SciPy 2024!
 
-If you're at SciPy 2024 in Tacoma, WA, Rich's talk is scheduled for July 11, 2024 (16:30–17:00 PT). The talk is called *Great Tables for Everyone* and it's sure to be both exciting and educational. If you're not attending that's okay, the talk is available [in GitHub](https://github.com/rich-iannone/presentations/tree/main/2024-07-11-SciPy-talk-GT).
+At SciPy 2024 (July 11, 2024, Tacoma, WA), Rich delivered a talk called *Great Tables for Everyone* and it presented some of the tables shown in this post. If you weren't in attendence that's okay, you can [watch the recorded talk](https://youtu.be/uvH-Z39ZUj0?si=3NVipMteXaeO3vb1) and the materials are available [in GitHub](https://github.com/rich-iannone/presentations/tree/main/2024-07-11-SciPy-talk-GT).
 :::
 
 ## Unit and scientific notation
@@ -160,5 +160,3 @@ Units notation is ever useful and it is applied in one of the column labels of t
 ## Hope all your (science-y) tables are great!
 
 We did scientific work pretty heavily in the past and so we understand that great tables in the realm of science publication is something that could and should be possible. We'll keep doing more to make this even better in upcoming releases.
-
-Hope to see you at SciPy 2024!


### PR DESCRIPTION
This updates two blogposts focused on PyCon 2024 and SciPy 2024 events. Some dead/non-working links are updated here. Additional links to new resources (recorded videos) are provided here.

Fixes: https://github.com/posit-dev/great-tables/issues/180 