### PR TITLE
Add an example demonstrating `define_units()` usage

### DIFF
--- a/great_tables/_helpers.py
+++ b/great_tables/_helpers.py
@@ -1051,6 +1051,71 @@ def define_units(units_notation: str) -> UnitDefinitionList:
         )
     )
     ```
+
+    Examples
+    --------
+
+    Let’s demonstrate a use case where we utilize `define_units()` to render an equation as
+    the subtitle in the table header, which currently doesn’t accept unit notation as input.
+
+    We'll start by creating a Polars DataFrame representing the calculations of the equation
+    $y= a_2x^2 + a_1x + a_0$.
+
+    ```{python}
+    #| code-fold: true
+
+    import polars as pl
+    from great_tables import GT, html, define_units
+
+    df = pl.DataFrame(
+        {"x": [1, 2, 3], "a2": [2, 3, 4], "a1": [3, 4, 5], "a0": [4, 5, 6]}
+    ).with_columns(
+        y=(
+            pl.col("a2").mul(pl.col("x").pow(2))
+            + pl.col("a1").mul(pl.col("x"))
+            + pl.col("a0")
+        )
+    )
+
+    df
+    ```
+
+    If we try to use unit annotations to format the equation as the subtitle in the header, it
+    won’t work as expected:
+
+    ```{python}
+    (
+        GT(df).tab_header(
+            title="Linear Algebra", subtitle="y={{a_2}}{{x^2}}+{{a_1}}x+{{a_0}}"
+        )
+    )
+    ```
+
+    To address this, we can create a small helper function, `u2html()`, which wraps a given string
+    in `define_units()` and emits the units to HTML. Next, we can build the subtitle by applying
+    `u2html()` to the string with unit annotations. Finally, we pass the assembled subtitle string
+    through `html()` to ensure it renders correctly.
+
+    ```{python}
+    def u2html(x: str) -> str:
+        return define_units(x).to_html()
+
+
+    subtitle = (
+        "y"
+        + "="
+        + u2html("{{a_2}}")
+        + u2html("{{x^2}}")
+        + "+"
+        + u2html("{{a_1}}")
+        + "x"
+        + "+"
+        + u2html("{{a_0}}")
+    )
+
+    (GT(df).tab_header(title="Linear Algebra", subtitle=html(subtitle)))
+    ```
+
     """
 
     # Get a list of raw tokens


### PR DESCRIPTION
Hello team,

As we know, `define_units()` powers `GT.fmt_units()` behind the scenes, but it seems to lack a clear example for users to quickly grasp its usage. 

I’d like to propose an example that demonstrates how to use `define_units()` to render a string with unit annotations as a subtitle in the table header. This example highlights that `define_units()` can be used independently and within components that don’t yet support unit annotations (such as the table header). 

Below is the final table for reference.
![image](https://github.com/user-attachments/assets/b03222bc-7e42-4be1-91df-79b551ebcba0)

