### PR TITLE
Favor `OrderedSet().as_list()`

### DIFF
--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -577,7 +577,9 @@ class Stub:
         row_info = [RowInfo(*i) for i in zip(row_indices, group_id, row_names)]
 
         # create groups, and ensure they're ordered by first observed
-        group_names = list(OrderedSet(row.group_id for row in row_info if row.group_id is not None))
+        group_names = OrderedSet(
+            row.group_id for row in row_info if row.group_id is not None
+        ).as_list()
         group_rows = GroupRows(data, group_key=groupname_col).reorder(group_names)
 
         return cls(row_info, group_rows)

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -173,9 +173,9 @@ def tab_spanner(
 
     # get column names associated with selected spanners ----
     _vars = [span.vars for span in self._spanners if span.spanner_id in spanner_ids]
-    spanner_column_names = OrderedSet(itertools.chain(*_vars))
+    spanner_column_names = OrderedSet(itertools.chain(*_vars)).as_list()
 
-    column_names = list(OrderedSet([*selected_column_names, *spanner_column_names]))
+    column_names = OrderedSet([*selected_column_names, *spanner_column_names]).as_list()
     # combine columns names and those from spanners ----
 
     # get spanner level ----


### PR DESCRIPTION
Related to #407.

It appears that both `list(OrderedSet())` and unpacking `OrderedSet()` rely on the `__iter__()` method. I’d like to suggest using `OrderedSet().as_list()` instead of depending on the dunder method, as this approach is clearer and more stable, even though the implementation is unlikely to change.