### PR TITLE
Add `val_fmt_image()` to enable image rendering in various components

### DIFF
--- a/great_tables/_formats_vals.py
+++ b/great_tables/_formats_vals.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from pathlib import Path
 
 from great_tables import GT
 from great_tables.gt import GT, _get_column_of_values
@@ -926,6 +927,70 @@ def val_fmt_markdown(
 
     gt_obj_fmt = gt_obj.fmt_markdown(
         columns="x",
+    )
+
+    vals_fmt = _get_column_of_values(gt=gt_obj_fmt, column_name="x", context="html")
+
+    return vals_fmt
+
+
+def val_fmt_image(
+    x: X,
+    height: str | int | None = None,
+    width: str | int | None = None,
+    sep: str = " ",
+    path: str | Path | None = None,
+    file_pattern: str = "{}",
+    encode: bool = True,
+) -> list[str]:
+    """Format image paths to generate images in cells.
+
+    To more easily insert graphics into body cells, we can use the `fmt_image()` method. This allows
+    for one or more images to be placed in the targeted cells. The cells need to contain some
+    reference to an image file, either: (1) complete http/https or local paths to the files; (2) the
+    file names, where a common path can be provided via `path=`; or (3) a fragment of the file name,
+    where the `file_pattern=` argument helps to compose the entire file name and `path=` provides
+    the path information. This should be expressly used on columns that contain *only* references to
+    image files (i.e., no image references as part of a larger block of text). Multiple images can
+    be included per cell by separating image references by commas. The `sep=` argument allows for a
+    common separator to be applied between images.
+
+    Parameters
+    ----------
+    x
+        A list of values to be formatted.
+    height
+        The height of the rendered images.
+    width
+        The width of the rendered images.
+    sep
+        In the output of images within a body cell, `sep=` provides the separator between each
+        image.
+    path
+        An optional path to local image files (this is combined with all filenames).
+    file_pattern
+        The pattern to use for mapping input values in the body cells to the names of the graphics
+        files. The string supplied should use `"{}"` in the pattern to map filename fragments to
+        input strings.
+    encode
+        The option to always use Base64 encoding for image paths that are determined to be local. By
+        default, this is `True`.
+
+    Returns
+    -------
+    list[str]
+        A list of formatted values is returned.
+    """
+    gt_obj: GTData = _make_one_col_table(vals=x)
+
+    gt_obj_fmt = gt_obj.fmt_image(
+        columns="x",
+        height=height,
+        width=width,
+        sep=sep,
+        path=path,
+        file_pattern=file_pattern,
+        encode=encode,
     )
 
     vals_fmt = _get_column_of_values(gt=gt_obj_fmt, column_name="x", context="html")

--- a/great_tables/vals.py
+++ b/great_tables/vals.py
@@ -11,4 +11,5 @@ from ._formats_vals import (
     val_fmt_date as fmt_date,
     val_fmt_time as fmt_time,
     val_fmt_markdown as fmt_markdown,
+    val_fmt_image as fmt_image,
 )


### PR DESCRIPTION
Related to #418.

It seems that users are interested in rendering images across different components. To support this, I'd like to propose introducing a `val_fmt_image()` function. With this function, we can achieve more flexibility, such as:
```python
import polars as pl
from polars import selectors as cs
from great_tables import GT, vals, html
from importlib_resources import files


img_paths = files("great_tables") / "data/metro_images"

df = pl.DataFrame(
    {
        "col1": list("123"),
        "col2": list("123"),
        "col3": list("123"),
        "group": ["grp_a", "grp_a", "grp_b"],
        "row": ["row_1", "row_2", "row_3"],
    }
)

img1, img2, img3, img4, img5, img6 = vals.fmt_image(
    list("123456"), path=img_paths, file_pattern="metro_{}.svg"
)

(
    GT(df)
    .cols_label(**{"col1": html(img1), "col2": html(img2), "col3": html(img3)})
    .tab_stub(groupname_col="group", rowname_col="row")
    .tab_stubhead(html(img4))
    .tab_header(title=html(img5))
    .tab_source_note(html(img6))
    .fmt_image(cs.starts_with("col"), path=img_paths, file_pattern="metro_{}.svg")
)
```
![image](https://github.com/user-attachments/assets/98a19f6c-448b-4324-a470-bba70936d1cd)

The idea is to wrap the output from `val_fmt_image()` in the `html()` function.