### PR TITLE
Unify `GT.cols_label()` and `GT.cols_width()` to accept both `cases` and `**kwargs`

### DIFF
--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -11,7 +11,9 @@ if TYPE_CHECKING:
     from ._types import GTSelf
 
 
-def cols_label(self: GTSelf, **kwargs: str | Text) -> GTSelf:
+def cols_label(
+    self: GTSelf, cases: dict[str, str | Text] | None = None, **kwargs: str | Text
+) -> GTSelf:
     """
     Relabel one or more columns.
 
@@ -26,10 +28,13 @@ def cols_label(self: GTSelf, **kwargs: str | Text) -> GTSelf:
 
     Parameters
     ----------
+    cases
+        A dictionary where the keys are column names and the values are the labels. Labels may use
+        [`md()`](`great_tables.md`) or [`html()`](`great_tables.html`) helpers for formatting.
+
     **kwargs
-        New labels expressed as keyword arguments. Column names should be the keyword (left-hand side).
-        Labels may use [`md()`](`great_tables.md`) or [`html()`](`great_tables.html`) helpers for
-        formatting.
+        Keyword arguments to specify column labels. Each keyword corresponds to a column name, with
+        its value indicating the new label.
 
     Returns
     -------
@@ -111,14 +116,16 @@ def cols_label(self: GTSelf, **kwargs: str | Text) -> GTSelf:
     """
     from great_tables._helpers import UnitStr
 
-    # If nothing is provided, return `data` unchanged
-    if len(kwargs) == 0:
-        return self
+    cases = cases if cases is not None else {}
+    new_cases = cases | kwargs
 
-    mod_columns = list(kwargs.keys())
+    # If nothing is provided, return `data` unchanged
+    if len(new_cases) == 0:
+        return self
 
     # Get the full list of column names for the data
     column_names = self._boxhead._get_columns()
+    mod_columns = list(new_cases.keys())
 
     # Stop function if any of the column names specified are not in `cols_labels`
     # msg: "All column names provided must exist in the input `.data` table."
@@ -127,7 +134,7 @@ def cols_label(self: GTSelf, **kwargs: str | Text) -> GTSelf:
     # Handle units syntax in labels (e.g., "Density ({{ppl / mi^2}})")
     new_kwargs: dict[str, UnitStr | str | Text] = {}
 
-    for k, v in kwargs.items():
+    for k, v in new_cases.items():
 
         if isinstance(v, str):
 

--- a/tests/test_boxhead.py
+++ b/tests/test_boxhead.py
@@ -13,6 +13,15 @@ def test_cols_label():
     assert x == y
 
 
+def test_cols_label_mix_cases_kwargs():
+    df = pd.DataFrame({"x": [1.234, 2.345], "y": [3.456, 4.567], "z": [5.678, 6.789]})
+    gt = GT(df).cols_label({"x": "ex"}, **{"y": "why"}, z="Zee")
+
+    x = _get_column_labels(gt=gt, context="html")
+    y = ["ex", "why", "Zee"]
+    assert x == y
+
+
 def test_cols_label_units_text():
     df = pd.DataFrame({"x": [1.234, 2.345], "y": [3.456, 4.567], "z": [5.678, 6.789]})
     gt = GT(df).cols_label(x="Area ({{m^2}})", y="Density ({{kg / m^3}})", z="Zee")

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -207,6 +207,15 @@ def test_cols_width_fully_set():
     assert gt_tbl._boxhead[2].column_width == "30px"
 
 
+def test_cols_width_mix_cases_kwargs():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    gt_tbl = GT(df).cols_width({"a": "10px"}, **{"b": "20px"}, c="30px")
+
+    assert gt_tbl._boxhead[0].column_width == "10px"
+    assert gt_tbl._boxhead[1].column_width == "20px"
+    assert gt_tbl._boxhead[2].column_width == "30px"
+
+
 def test_cols_width_partial_set_pct():
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
     gt_tbl = GT(df).cols_width({"a": "20%"})


### PR DESCRIPTION
This PR unifies `GT.cols_label()` and `GT.cols_width()` to accept both `cases` and `**kwargs`. 

Currently, these two functions have different parameter structures, which can be confusing and often requires consulting the documentation. I hope this change simplifies their usage :) 