### PR TITLE
Update `_save_screenshot()` to use `WebElement.screenshot_as_png`

### DIFF
--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -404,12 +404,7 @@ def _save_screenshot(
         from PIL import Image
 
         # convert to other formats (e.g. pdf, bmp) using PIL
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            fname = f"{tmp_dir}/image.png"
-            el.screenshot(fname)
-
-            with open(fname, "rb") as f:
-                Image.open(fp=BytesIO(f.read())).save(fp=path)
+        Image.open(fp=BytesIO(el.screenshot_as_png)).save(fp=path)
 
 
 def _dump_debug_screenshot(driver, path):


### PR DESCRIPTION
I was wondering if `_save_screenshot()` could be improved by directly utilizing [`WebElement.screenshot_as_png`](https://selenium-python.readthedocs.io/api.html#selenium.webdriver.remote.webelement.WebElement.screenshot_as_png).