### PR TITLE
feat: implement row striping options

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -171,6 +171,7 @@ quartodoc:
         having to use `tab_options()` directly.
       contents:
         - GT.opt_align_table_header
+        - GT.opt_row_striping
         - GT.opt_all_caps
         - GT.opt_vertical_padding
         - GT.opt_horizontal_padding

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -1160,11 +1160,11 @@ class Options:
     )
     source_notes_multiline: OptionsInfo = OptionsInfo(False, "source_notes", "boolean", True)
     source_notes_sep: OptionsInfo = OptionsInfo(False, "source_notes", "value", " ")
-    # row_striping_background_color: OptionsInfo = OptionsInfo(
-    #     True, "row", "value", "rgba(128,128,128,0.05)"
-    # )
-    # row_striping_include_stub: OptionsInfo = OptionsInfo(False, "row", "boolean", False)
-    # row_striping_include_table_body: OptionsInfo = OptionsInfo(False, "row", "boolean", False)
+    row_striping_background_color: OptionsInfo = OptionsInfo(
+        True, "row", "value", "rgba(128,128,128,0.05)"
+    )
+    row_striping_include_stub: OptionsInfo = OptionsInfo(False, "row", "boolean", False)
+    row_striping_include_table_body: OptionsInfo = OptionsInfo(False, "row", "boolean", False)
     container_width: OptionsInfo = OptionsInfo(False, "container", "px", "auto")
     container_height: OptionsInfo = OptionsInfo(False, "container", "px", "auto")
     container_padding_x: OptionsInfo = OptionsInfo(False, "container", "px", "0px")

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -608,11 +608,11 @@ def opt_footnote_marks(self: GTSelf, marks: str | list[str] = "numbers") -> GTSe
 
 def opt_row_striping(self: GTSelf, row_striping: bool = True) -> GTSelf:
     """
-    Option to add or remove row striping.1
+    Option to add or remove row striping.
 
-    By default, a gt*table does not have row striping enabled. However, this method allows us to
-    easily enable or disable striped rows in the table body. It's a convenient shortcut for
-    `gt.tab_options(row_striping_include_table_body=<True|False>)`.
+    By default, a table does not have row striping enabled. However, this method allows us to easily
+    enable or disable striped rows in the table body. It's a convenient shortcut for
+    `tab_options(row_striping_include_table_body=<True|False>)`.
 
     Parameters
     ----------

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -625,7 +625,34 @@ def opt_row_striping(self: GTSelf, row_striping: bool = True) -> GTSelf:
     GT
         The GT object is returned. This is the same object that the method is called on so that we
         can facilitate method chaining.
+
+    Examples
+    --------
+    Using only a few columns from the `exibble` dataset, let's create a table with a number of
+    components added. Following that, we'll add row striping to every second row with the
+    `opt_row_striping()` method.
+
+    ```{python}
+    from great_tables import GT, exibble, md
+
+    (
+        GT(
+            exibble[["num", "char", "currency", "row", "group"]],
+            rowname_col="row",
+            groupname_col="group"
+        )
+        .tab_header(
+            title=md("Data listing from **exibble**"),
+            subtitle=md("`exibble` is a **Great Tables** dataset.")
+        )
+        .fmt_number(columns="num")
+        .fmt_currency(columns="currency")
+        .tab_source_note(source_note="This is only a subset of the dataset.")
+        .opt_row_striping()
+    )
+    ```
     """
+
     return tab_options(self, row_striping_include_table_body=row_striping)
 
 

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -161,9 +161,9 @@ def tab_options(
     source_notes_border_lr_color: str | None = None,
     source_notes_multiline: bool | None = None,
     source_notes_sep: str | None = None,
-    # row_striping_background_color: str | None = None,
-    # row_striping_include_stub: bool | None = None,
-    # row_striping_include_table_body: bool | None = None,
+    row_striping_background_color: str | None = None,
+    row_striping_include_stub: bool | None = None,
+    row_striping_include_table_body: bool | None = None,
 ) -> GTSelf:
     """
     Modify the table output options.
@@ -466,6 +466,13 @@ def tab_options(
         this border is larger, then it will be the visible border.
     source_notes_border_lr_color
         The color of the left and right borders of the `source_notes` location.
+    row_striping_background_color
+        The background color for striped table body rows. A color name or a hexadecimal color code
+        should be provided.
+    row_striping_include_stub
+        An option for whether to include the stub when striping rows.
+    row_striping_include_table_body
+        An option for whether to include the table body when striping rows.
 
     Returns
     -------
@@ -601,7 +608,7 @@ def opt_footnote_marks(self: GTSelf, marks: str | list[str] = "numbers") -> GTSe
 
 def opt_row_striping(self: GTSelf, row_striping: bool = True) -> GTSelf:
     """
-    Option to add or remove row striping.
+    Option to add or remove row striping.1
 
     By default, a gt*table does not have row striping enabled. However, this method allows us to
     easily enable or disable striped rows in the table body. It's a convenient shortcut for

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -516,30 +516,28 @@ def create_body_component_h(data: GTData) -> str:
 
             if is_stub_cell:
 
-                th_classes = ["gt_row", "gt_left", "gt_stub"]
+                el_name = "th"
+
+                classes = ["gt_row", "gt_left", "gt_stub"]
 
                 if table_stub_striped and odd_i_row:
-                    th_classes.append("gt_striped")
-
-                # Ensure that th_classes becomes a space-separated string
-                th_classes_str = " ".join(th_classes)
-
-                body_cells.append(
-                    f"""    <th {cell_styles}class="{th_classes_str}">{cell_str}</th>"""
-                )
+                    classes.append("gt_striped")
 
             else:
 
-                td_classes = ["gt_row", f"gt_{cell_alignment}"]
+                el_name = "td"
+
+                classes = ["gt_row", f"gt_{cell_alignment}"]
 
                 if table_body_striped and odd_i_row:
-                    td_classes.append("gt_striped")
+                    classes.append("gt_striped")
 
-                td_classes_str = " ".join(td_classes)
+            # Ensure that `classes` becomes a space-separated string
+            classes = " ".join(classes)
 
-                body_cells.append(
-                    f"""    <td {cell_styles}class="{td_classes_str}">{cell_str}</td>"""
-                )
+            body_cells.append(
+                f"""    <{el_name} {cell_styles}class="{classes}">{cell_str}</{el_name}>"""
+            )
 
         prev_group_label = group_label
         body_rows.append("  <tr>\n" + "\n".join(body_cells) + "\n  </tr>")

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -444,6 +444,12 @@ def create_body_component_h(data: GTData) -> str:
     if stub_var is not None:
         column_vars = [stub_var] + column_vars
 
+    # Is the stub to be striped?
+    table_stub_striped = data._options.row_striping_include_stub.value
+
+    # Are the rows in the table body to be striped?
+    table_body_striped = data._options.row_striping_include_table_body.value
+
     body_rows: list[str] = []
 
     # iterate over rows (ordered by groupings)
@@ -452,6 +458,12 @@ def create_body_component_h(data: GTData) -> str:
     ordered_index = data._stub.group_indices_map()
 
     for i, group_label in ordered_index:
+
+        # For table striping we want to add a striping CSS class to the even-numbered
+        # rows in the rendered table; to target these rows, determine if `i` in the current
+        # row render is an odd number
+        odd_i_row = i % 2 == 1
+
         body_cells: list[str] = []
 
         if has_stub_column and has_groups and not has_two_col_stub:
@@ -503,10 +515,30 @@ def create_body_component_h(data: GTData) -> str:
                 cell_styles = ""
 
             if is_stub_cell:
-                body_cells.append(f"""    <th class="gt_row gt_left gt_stub">{cell_str}</th>""")
-            else:
+
+                th_classes = ["gt_row", "gt_left", "gt_stub"]
+
+                if table_stub_striped and odd_i_row:
+                    th_classes.append("gt_striped")
+
+                # Ensure that th_classes becomes a space-separated string
+                th_classes_str = " ".join(th_classes)
+
                 body_cells.append(
-                    f"""    <td {cell_styles}class="gt_row gt_{cell_alignment}">{cell_str}</td>"""
+                    f"""    <th {cell_styles}class="{th_classes_str}">{cell_str}</th>"""
+                )
+
+            else:
+
+                td_classes = ["gt_row", f"gt_{cell_alignment}"]
+
+                if table_body_striped and odd_i_row:
+                    td_classes.append("gt_striped")
+
+                td_classes_str = " ".join(td_classes)
+
+                body_cells.append(
+                    f"""    <td {cell_styles}class="{td_classes_str}">{cell_str}</td>"""
                 )
 
         prev_group_label = group_label

--- a/great_tables/css/gt_styles_default.scss
+++ b/great_tables/css/gt_styles_default.scss
@@ -263,6 +263,10 @@ p {
   border-top-width: $row_group_border_top_width;
 }
 
+.gt_striped {
+  background-color: $row_striping_background_color;
+}
+
 .gt_table_body {
   border-top-style: $table_body_border_top_style;
   border-top-width: $table_body_border_top_width;

--- a/tests/__snapshots__/test_export.ambr
+++ b/tests/__snapshots__/test_export.ambr
@@ -34,6 +34,7 @@
    #test_table .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
    #test_table .gt_row_group_first td { border-top-width: 2px; }
    #test_table .gt_row_group_first th { border-top-width: 2px; }
+   #test_table .gt_striped { background-color: rgba(128,128,128,0.05); }
    #test_table .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
    #test_table .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
    #test_table .gt_sourcenote { font-size: 90%; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }

--- a/tests/__snapshots__/test_options.ambr
+++ b/tests/__snapshots__/test_options.ambr
@@ -703,161 +703,26 @@
 # ---
 # name: test_tab_options_striping_snap
   '''
-  <div id="test" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
-  <style>
-  #test table {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-          }
-  
-  #test thead, tbody, tfoot, tr, td, th { border-style: none; }
-   tr { background-color: transparent; }
-  #test p { margin: 0; padding: 0; }
-   #test .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
-   #test .gt_caption { padding-top: 4px; padding-bottom: 4px; }
-   #test .gt_title { color: #333333; font-size: 125%; font-weight: initial; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
-   #test .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 3px; padding-bottom: 5px; padding-left: 5px; padding-right: 5px; border-top-color: #FFFFFF; border-top-width: 0; }
-   #test .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
-   #test .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
-   #test .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
-   #test .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: bottom; padding-top: 5px; padding-bottom: 5px; padding-left: 5px; padding-right: 5px; overflow-x: hidden; }
-   #test .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
-   #test .gt_column_spanner_outer:first-child { padding-left: 0; }
-   #test .gt_column_spanner_outer:last-child { padding-right: 0; }
-   #test .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: bottom; padding-top: 5px; padding-bottom: 5px; overflow-x: hidden; display: inline-block; width: 100%; }
-   #test .gt_spanner_row { border-bottom-style: hidden; }
-   #test .gt_group_heading { padding-top: 8px; padding-bottom: 8px; padding-left: 5px; padding-right: 5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; text-align: left; }
-   #test .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: middle; }
-   #test .gt_from_md> :first-child { margin-top: 0; }
-   #test .gt_from_md> :last-child { margin-bottom: 0; }
-   #test .gt_row { padding-top: 8px; padding-bottom: 8px; padding-left: 5px; padding-right: 5px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
-   #test .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; }
-   #test .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
-   #test .gt_row_group_first td { border-top-width: 2px; }
-   #test .gt_row_group_first th { border-top-width: 2px; }
-   #test .gt_striped { background-color: lightblue; }
-   #test .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
-   #test .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
-   #test .gt_sourcenote { font-size: 90%; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
-   #test .gt_left { text-align: left; }
-   #test .gt_center { text-align: center; }
-   #test .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
-   #test .gt_font_normal { font-weight: normal; }
-   #test .gt_font_bold { font-weight: bold; }
-   #test .gt_font_italic { font-style: italic; }
-   #test .gt_super { font-size: 65%; }
-   #test .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
-   #test .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
-  </style>
-  <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
-  <thead>
-  
-  <tr class="gt_col_headings">
-    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id=""></th>
-    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="num">num</th>
-    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="char">char</th>
-    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="fctr">fctr</th>
-    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="date">date</th>
-    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="time">time</th>
-    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="datetime">datetime</th>
-    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="currency">currency</th>
-  </tr>
-  </thead>
   <tbody class="gt_table_body">
     <tr class="gt_group_heading_row">
-      <th class="gt_group_heading" colspan="8">grp_a</th>
+      <th class="gt_group_heading" colspan="2">grp_a</th>
     </tr>
     <tr>
       <th class="gt_row gt_left gt_stub">row_1</th>
-      <td class="gt_row gt_right">0.1111</td>
       <td class="gt_row gt_left">apricot</td>
-      <td class="gt_row gt_left">one</td>
-      <td class="gt_row gt_right">2015-01-15</td>
-      <td class="gt_row gt_right">13:35</td>
-      <td class="gt_row gt_right">2018-01-01 02:22</td>
-      <td class="gt_row gt_right">49.95</td>
     </tr>
     <tr>
       <th class="gt_row gt_left gt_stub gt_striped">row_2</th>
-      <td class="gt_row gt_right gt_striped">2.222</td>
       <td class="gt_row gt_left gt_striped">banana</td>
-      <td class="gt_row gt_left gt_striped">two</td>
-      <td class="gt_row gt_right gt_striped">2015-02-15</td>
-      <td class="gt_row gt_right gt_striped">14:40</td>
-      <td class="gt_row gt_right gt_striped">2018-02-02 14:33</td>
-      <td class="gt_row gt_right gt_striped">17.95</td>
     </tr>
     <tr>
       <th class="gt_row gt_left gt_stub">row_3</th>
-      <td class="gt_row gt_right">33.33</td>
       <td class="gt_row gt_left">coconut</td>
-      <td class="gt_row gt_left">three</td>
-      <td class="gt_row gt_right">2015-03-15</td>
-      <td class="gt_row gt_right">15:45</td>
-      <td class="gt_row gt_right">2018-03-03 03:44</td>
-      <td class="gt_row gt_right">1.39</td>
     </tr>
     <tr>
       <th class="gt_row gt_left gt_stub gt_striped">row_4</th>
-      <td class="gt_row gt_right gt_striped">444.4</td>
       <td class="gt_row gt_left gt_striped">durian</td>
-      <td class="gt_row gt_left gt_striped">four</td>
-      <td class="gt_row gt_right gt_striped">2015-04-15</td>
-      <td class="gt_row gt_right gt_striped">16:50</td>
-      <td class="gt_row gt_right gt_striped">2018-04-04 15:55</td>
-      <td class="gt_row gt_right gt_striped">65100.0</td>
-    </tr>
-    <tr class="gt_group_heading_row">
-      <th class="gt_group_heading" colspan="8">grp_b</th>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">row_5</th>
-      <td class="gt_row gt_right">5550.0</td>
-      <td class="gt_row gt_left"><NA></td>
-      <td class="gt_row gt_left">five</td>
-      <td class="gt_row gt_right">2015-05-15</td>
-      <td class="gt_row gt_right">17:55</td>
-      <td class="gt_row gt_right">2018-05-05 04:00</td>
-      <td class="gt_row gt_right">1325.81</td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub gt_striped">row_6</th>
-      <td class="gt_row gt_right gt_striped"><NA></td>
-      <td class="gt_row gt_left gt_striped">fig</td>
-      <td class="gt_row gt_left gt_striped">six</td>
-      <td class="gt_row gt_right gt_striped">2015-06-15</td>
-      <td class="gt_row gt_right gt_striped"><NA></td>
-      <td class="gt_row gt_right gt_striped">2018-06-06 16:11</td>
-      <td class="gt_row gt_right gt_striped">13.255</td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub">row_7</th>
-      <td class="gt_row gt_right">777000.0</td>
-      <td class="gt_row gt_left">grapefruit</td>
-      <td class="gt_row gt_left">seven</td>
-      <td class="gt_row gt_right"><NA></td>
-      <td class="gt_row gt_right">19:10</td>
-      <td class="gt_row gt_right">2018-07-07 05:22</td>
-      <td class="gt_row gt_right"><NA></td>
-    </tr>
-    <tr>
-      <th class="gt_row gt_left gt_stub gt_striped">row_8</th>
-      <td class="gt_row gt_right gt_striped">8880000.0</td>
-      <td class="gt_row gt_left gt_striped">honeydew</td>
-      <td class="gt_row gt_left gt_striped">eight</td>
-      <td class="gt_row gt_right gt_striped">2015-08-15</td>
-      <td class="gt_row gt_right gt_striped">20:20</td>
-      <td class="gt_row gt_right gt_striped"><NA></td>
-      <td class="gt_row gt_right gt_striped">0.44</td>
     </tr>
   </tbody>
-  
-  
-  </table>
-  
-  </div>
-          
   '''
 # ---

--- a/tests/__snapshots__/test_options.ambr
+++ b/tests/__snapshots__/test_options.ambr
@@ -272,6 +272,10 @@
     border-top-width: 5px;
   }
   
+  #abc .gt_striped {
+    background-color: rgba(128,128,128,0.05);
+  }
+  
   #abc .gt_table_body {
     border-top-style: solid;
     border-top-width: 5px;
@@ -617,6 +621,10 @@
   
   #abc .gt_row_group_first th {
     border-top-width: 2px;
+  }
+  
+  #abc .gt_striped {
+    background-color: rgba(128,128,128,0.05);
   }
   
   #abc .gt_table_body {

--- a/tests/__snapshots__/test_options.ambr
+++ b/tests/__snapshots__/test_options.ambr
@@ -701,3 +701,163 @@
   
   '''
 # ---
+# name: test_tab_options_striping_snap
+  '''
+  <div id="test" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+  <style>
+  #test table {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+          }
+  
+  #test thead, tbody, tfoot, tr, td, th { border-style: none; }
+   tr { background-color: transparent; }
+  #test p { margin: 0; padding: 0; }
+   #test .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
+   #test .gt_caption { padding-top: 4px; padding-bottom: 4px; }
+   #test .gt_title { color: #333333; font-size: 125%; font-weight: initial; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
+   #test .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 3px; padding-bottom: 5px; padding-left: 5px; padding-right: 5px; border-top-color: #FFFFFF; border-top-width: 0; }
+   #test .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+   #test .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+   #test .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+   #test .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: bottom; padding-top: 5px; padding-bottom: 5px; padding-left: 5px; padding-right: 5px; overflow-x: hidden; }
+   #test .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
+   #test .gt_column_spanner_outer:first-child { padding-left: 0; }
+   #test .gt_column_spanner_outer:last-child { padding-right: 0; }
+   #test .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: bottom; padding-top: 5px; padding-bottom: 5px; overflow-x: hidden; display: inline-block; width: 100%; }
+   #test .gt_spanner_row { border-bottom-style: hidden; }
+   #test .gt_group_heading { padding-top: 8px; padding-bottom: 8px; padding-left: 5px; padding-right: 5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; text-align: left; }
+   #test .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: middle; }
+   #test .gt_from_md> :first-child { margin-top: 0; }
+   #test .gt_from_md> :last-child { margin-bottom: 0; }
+   #test .gt_row { padding-top: 8px; padding-bottom: 8px; padding-left: 5px; padding-right: 5px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
+   #test .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; }
+   #test .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
+   #test .gt_row_group_first td { border-top-width: 2px; }
+   #test .gt_row_group_first th { border-top-width: 2px; }
+   #test .gt_striped { background-color: lightblue; }
+   #test .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+   #test .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
+   #test .gt_sourcenote { font-size: 90%; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
+   #test .gt_left { text-align: left; }
+   #test .gt_center { text-align: center; }
+   #test .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
+   #test .gt_font_normal { font-weight: normal; }
+   #test .gt_font_bold { font-weight: bold; }
+   #test .gt_font_italic { font-style: italic; }
+   #test .gt_super { font-size: 65%; }
+   #test .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
+   #test .gt_asterisk { font-size: 100%; vertical-align: 0; }
+   
+  </style>
+  <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
+  <thead>
+  
+  <tr class="gt_col_headings">
+    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id=""></th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="num">num</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="char">char</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col" id="fctr">fctr</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="date">date</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="time">time</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="datetime">datetime</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="currency">currency</th>
+  </tr>
+  </thead>
+  <tbody class="gt_table_body">
+    <tr class="gt_group_heading_row">
+      <th class="gt_group_heading" colspan="8">grp_a</th>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_1</th>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td class="gt_row gt_left">one</td>
+      <td class="gt_row gt_right">2015-01-15</td>
+      <td class="gt_row gt_right">13:35</td>
+      <td class="gt_row gt_right">2018-01-01 02:22</td>
+      <td class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub gt_striped">row_2</th>
+      <td class="gt_row gt_right gt_striped">2.222</td>
+      <td class="gt_row gt_left gt_striped">banana</td>
+      <td class="gt_row gt_left gt_striped">two</td>
+      <td class="gt_row gt_right gt_striped">2015-02-15</td>
+      <td class="gt_row gt_right gt_striped">14:40</td>
+      <td class="gt_row gt_right gt_striped">2018-02-02 14:33</td>
+      <td class="gt_row gt_right gt_striped">17.95</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_3</th>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td class="gt_row gt_left">three</td>
+      <td class="gt_row gt_right">2015-03-15</td>
+      <td class="gt_row gt_right">15:45</td>
+      <td class="gt_row gt_right">2018-03-03 03:44</td>
+      <td class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub gt_striped">row_4</th>
+      <td class="gt_row gt_right gt_striped">444.4</td>
+      <td class="gt_row gt_left gt_striped">durian</td>
+      <td class="gt_row gt_left gt_striped">four</td>
+      <td class="gt_row gt_right gt_striped">2015-04-15</td>
+      <td class="gt_row gt_right gt_striped">16:50</td>
+      <td class="gt_row gt_right gt_striped">2018-04-04 15:55</td>
+      <td class="gt_row gt_right gt_striped">65100.0</td>
+    </tr>
+    <tr class="gt_group_heading_row">
+      <th class="gt_group_heading" colspan="8">grp_b</th>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_5</th>
+      <td class="gt_row gt_right">5550.0</td>
+      <td class="gt_row gt_left"><NA></td>
+      <td class="gt_row gt_left">five</td>
+      <td class="gt_row gt_right">2015-05-15</td>
+      <td class="gt_row gt_right">17:55</td>
+      <td class="gt_row gt_right">2018-05-05 04:00</td>
+      <td class="gt_row gt_right">1325.81</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub gt_striped">row_6</th>
+      <td class="gt_row gt_right gt_striped"><NA></td>
+      <td class="gt_row gt_left gt_striped">fig</td>
+      <td class="gt_row gt_left gt_striped">six</td>
+      <td class="gt_row gt_right gt_striped">2015-06-15</td>
+      <td class="gt_row gt_right gt_striped"><NA></td>
+      <td class="gt_row gt_right gt_striped">2018-06-06 16:11</td>
+      <td class="gt_row gt_right gt_striped">13.255</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_7</th>
+      <td class="gt_row gt_right">777000.0</td>
+      <td class="gt_row gt_left">grapefruit</td>
+      <td class="gt_row gt_left">seven</td>
+      <td class="gt_row gt_right"><NA></td>
+      <td class="gt_row gt_right">19:10</td>
+      <td class="gt_row gt_right">2018-07-07 05:22</td>
+      <td class="gt_row gt_right"><NA></td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub gt_striped">row_8</th>
+      <td class="gt_row gt_right gt_striped">8880000.0</td>
+      <td class="gt_row gt_left gt_striped">honeydew</td>
+      <td class="gt_row gt_left gt_striped">eight</td>
+      <td class="gt_row gt_right gt_striped">2015-08-15</td>
+      <td class="gt_row gt_right gt_striped">20:20</td>
+      <td class="gt_row gt_right gt_striped"><NA></td>
+      <td class="gt_row gt_right gt_striped">0.44</td>
+    </tr>
+  </tbody>
+  
+  
+  </table>
+  
+  </div>
+          
+  '''
+# ---

--- a/tests/__snapshots__/test_options.ambr
+++ b/tests/__snapshots__/test_options.ambr
@@ -701,6 +701,31 @@
   
   '''
 # ---
+# name: test_tab_options_striping_body_snap
+  '''
+  <tbody class="gt_table_body">
+    <tr class="gt_group_heading_row">
+      <th class="gt_group_heading" colspan="2">grp_a</th>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_1</th>
+      <td class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_2</th>
+      <td class="gt_row gt_left gt_striped">banana</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_3</th>
+      <td class="gt_row gt_left">coconut</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_4</th>
+      <td class="gt_row gt_left gt_striped">durian</td>
+    </tr>
+  </tbody>
+  '''
+# ---
 # name: test_tab_options_striping_snap
   '''
   <tbody class="gt_table_body">
@@ -722,6 +747,31 @@
     <tr>
       <th class="gt_row gt_left gt_stub gt_striped">row_4</th>
       <td class="gt_row gt_left gt_striped">durian</td>
+    </tr>
+  </tbody>
+  '''
+# ---
+# name: test_tab_options_striping_stub_snap
+  '''
+  <tbody class="gt_table_body">
+    <tr class="gt_group_heading_row">
+      <th class="gt_group_heading" colspan="2">grp_a</th>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_1</th>
+      <td class="gt_row gt_left">apricot</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub gt_striped">row_2</th>
+      <td class="gt_row gt_left">banana</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub">row_3</th>
+      <td class="gt_row gt_left">coconut</td>
+    </tr>
+    <tr>
+      <th class="gt_row gt_left gt_stub gt_striped">row_4</th>
+      <td class="gt_row gt_left">durian</td>
     </tr>
   </tbody>
   '''

--- a/tests/__snapshots__/test_repr.ambr
+++ b/tests/__snapshots__/test_repr.ambr
@@ -34,6 +34,7 @@
    #test .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
    #test .gt_row_group_first td { border-top-width: 2px; }
    #test .gt_row_group_first th { border-top-width: 2px; }
+   #test .gt_striped { background-color: rgba(128,128,128,0.05); }
    #test .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
    #test .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
    #test .gt_sourcenote { font-size: 90%; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
@@ -109,6 +110,7 @@
    #test .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
    #test .gt_row_group_first td { border-top-width: 2px; }
    #test .gt_row_group_first th { border-top-width: 2px; }
+   #test .gt_striped { background-color: rgba(128,128,128,0.05); }
    #test .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
    #test .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
    #test .gt_sourcenote { font-size: 90%; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
@@ -190,6 +192,7 @@
    #test .gt_stub_row_group { color: #333333 !important; background-color: #FFFFFF !important; font-size: 100% !important; font-weight: initial !important; text-transform: inherit !important; border-right-style: solid !important; border-right-width: 2px !important; border-right-color: #D3D3D3 !important; padding-left: 5px !important; padding-right: 5px !important; vertical-align: top !important; }
    #test .gt_row_group_first td { border-top-width: 2px !important; }
    #test .gt_row_group_first th { border-top-width: 2px !important; }
+   #test .gt_striped { background-color: rgba(128,128,128,0.05) !important; }
    #test .gt_table_body { border-top-style: solid !important; border-top-width: 2px !important; border-top-color: #D3D3D3 !important; border-bottom-style: solid !important; border-bottom-width: 2px !important; border-bottom-color: #D3D3D3 !important; }
    #test .gt_sourcenotes { color: #333333 !important; background-color: #FFFFFF !important; border-bottom-style: none !important; border-bottom-width: 2px !important; border-bottom-color: #D3D3D3 !important; border-left-style: none !important; border-left-width: 2px !important; border-left-color: #D3D3D3 !important; border-right-style: none !important; border-right-width: 2px !important; border-right-color: #D3D3D3 !important; }
    #test .gt_sourcenote { font-size: 90% !important; padding-top: 4px !important; padding-bottom: 4px !important; padding-left: 5px !important; padding-right: 5px !important; text-align: left !important; }
@@ -268,6 +271,7 @@
    #test .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
    #test .gt_row_group_first td { border-top-width: 2px; }
    #test .gt_row_group_first th { border-top-width: 2px; }
+   #test .gt_striped { background-color: rgba(128,128,128,0.05); }
    #test .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
    #test .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
    #test .gt_sourcenote { font-size: 90%; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
@@ -343,6 +347,7 @@
    #test .gt_stub_row_group { color: #333333 !important; background-color: #FFFFFF !important; font-size: 100% !important; font-weight: initial !important; text-transform: inherit !important; border-right-style: solid !important; border-right-width: 2px !important; border-right-color: #D3D3D3 !important; padding-left: 5px !important; padding-right: 5px !important; vertical-align: top !important; }
    #test .gt_row_group_first td { border-top-width: 2px !important; }
    #test .gt_row_group_first th { border-top-width: 2px !important; }
+   #test .gt_striped { background-color: rgba(128,128,128,0.05) !important; }
    #test .gt_table_body { border-top-style: solid !important; border-top-width: 2px !important; border-top-color: #D3D3D3 !important; border-bottom-style: solid !important; border-bottom-width: 2px !important; border-bottom-color: #D3D3D3 !important; }
    #test .gt_sourcenotes { color: #333333 !important; background-color: #FFFFFF !important; border-bottom-style: none !important; border-bottom-width: 2px !important; border-bottom-color: #D3D3D3 !important; border-left-style: none !important; border-left-width: 2px !important; border-left-color: #D3D3D3 !important; border-right-style: none !important; border-right-width: 2px !important; border-right-color: #D3D3D3 !important; }
    #test .gt_sourcenote { font-size: 90% !important; padding-top: 4px !important; padding-bottom: 4px !important; padding-left: 5px !important; padding-right: 5px !important; text-align: left !important; }

--- a/tests/__snapshots__/test_scss.ambr
+++ b/tests/__snapshots__/test_scss.ambr
@@ -272,6 +272,10 @@
     border-top-width: 2px;
   }
   
+  #abc .gt_striped {
+    background-color: rgba(128,128,128,0.05);
+  }
+  
   #abc .gt_table_body {
     border-top-style: solid;
     border-top-width: 2px;

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -387,6 +387,36 @@ def test_opt_table_font_raises():
     assert "Either `font=` or `stack=` must be provided." in exc_info.value.args[0]
 
 
+def test_opt_row_striping():
+
+    gt_tbl_0 = GT(exibble)
+    gt_tbl_1 = GT(exibble).opt_row_striping()
+    gt_tbl_2 = GT(exibble).opt_row_striping().opt_row_striping(row_striping=False)
+
+    assert gt_tbl_0._options.row_striping_include_table_body.value == False
+    assert gt_tbl_1._options.row_striping_include_table_body.value == True
+    assert gt_tbl_2._options.row_striping_include_table_body.value == False
+
+
+def test_tab_options_striping():
+
+    gt_tbl_opt = GT(exibble, id="test").opt_row_striping()
+    gt_tbl_tab_options = GT(exibble, id="test").tab_options(row_striping_include_table_body=True)
+
+    assert gt_tbl_opt.as_raw_html() == gt_tbl_tab_options.as_raw_html()
+
+
+def test_tab_options_striping_snap(snapshot):
+
+    gt_tbl = GT(exibble, rowname_col="row", groupname_col="group", id="test").tab_options(
+        row_striping_include_table_body=True,
+        row_striping_include_stub=True,
+        row_striping_background_color="lightblue",
+    )
+
+    assert snapshot == gt_tbl.as_raw_html()
+
+
 @pytest.mark.parametrize("align", ["left", "center", "right"])
 def test_opt_align_table_header(gt_tbl: GT, align: list[str]):
     tbl = gt_tbl.opt_align_table_header(align=align)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -4,6 +4,7 @@ from great_tables import GT, exibble, md, google_font
 from great_tables._scss import compile_scss
 from great_tables._gt_data import default_fonts_list
 from great_tables._helpers import _intify_scaled_px
+from great_tables._utils_render_html import create_body_component_h
 
 
 def test_options_overwrite():
@@ -400,21 +401,30 @@ def test_opt_row_striping():
 
 def test_tab_options_striping():
 
-    gt_tbl_opt = GT(exibble, id="test").opt_row_striping()
-    gt_tbl_tab_options = GT(exibble, id="test").tab_options(row_striping_include_table_body=True)
+    gt_tbl_tab_opts = GT(exibble).tab_options(row_striping_include_table_body=True)
+    gt_tbl_opt_stri = GT(exibble).opt_row_striping()
 
-    assert gt_tbl_opt.as_raw_html() == gt_tbl_tab_options.as_raw_html()
+    assert gt_tbl_tab_opts._options.row_striping_include_table_body.value == True
+    assert gt_tbl_tab_opts._options.row_striping_include_stub.value == False
+
+    assert gt_tbl_opt_stri._options.row_striping_include_table_body.value == True
+    assert gt_tbl_opt_stri._options.row_striping_include_stub.value == False
 
 
 def test_tab_options_striping_snap(snapshot):
 
-    gt_tbl = GT(exibble, rowname_col="row", groupname_col="group", id="test").tab_options(
+    gt_tbl = GT(
+        exibble[["row", "group", "char"]].head(4), rowname_col="row", groupname_col="group"
+    ).tab_options(
         row_striping_include_table_body=True,
         row_striping_include_stub=True,
         row_striping_background_color="lightblue",
     )
 
-    assert snapshot == gt_tbl.as_raw_html()
+    built = gt_tbl._build_data("html")
+    body = create_body_component_h(built)
+
+    assert snapshot == body
 
 
 @pytest.mark.parametrize("align", ["left", "center", "right"])

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -411,12 +411,26 @@ def test_tab_options_striping():
     assert gt_tbl_opt_stri._options.row_striping_include_stub.value == False
 
 
-def test_tab_options_striping_snap(snapshot):
+def test_tab_options_striping_body_snap(snapshot):
 
     gt_tbl = GT(
         exibble[["row", "group", "char"]].head(4), rowname_col="row", groupname_col="group"
     ).tab_options(
         row_striping_include_table_body=True,
+        row_striping_background_color="lightblue",
+    )
+
+    built = gt_tbl._build_data("html")
+    body = create_body_component_h(built)
+
+    assert snapshot == body
+
+
+def test_tab_options_striping_stub_snap(snapshot):
+
+    gt_tbl = GT(
+        exibble[["row", "group", "char"]].head(4), rowname_col="row", groupname_col="group"
+    ).tab_options(
         row_striping_include_stub=True,
         row_striping_background_color="lightblue",
     )


### PR DESCRIPTION
This PR addresses https://github.com/posit-dev/great-tables/issues/435 by making row striping options functional in rendered tables. An example of using row striping involves three new options in `tab_options()`:

```python
from great_tables import GT, exibble

(
    GT(exibble[["num", "char", "row", "group"]], rowname_col="row", groupname_col="group")
    .tab_options(
        row_striping_include_table_body=True,
        row_striping_include_stub=True,
        row_striping_background_color="lightblue"
    )
)
```

<img width="295" alt="image" src="https://github.com/user-attachments/assets/680f5c4b-a299-4417-801f-8b72e24010f4">


Alternatively, the `opt_row_striping()` method allows for a simplified shortcut for `row_striping_include_table_body=True` so the user doesn't have to look through `tab_options()` for this basic functionality:

```python
from great_tables import GT, exibble

(
    GT(exibble[["num", "char", "row", "group"]], rowname_col="row", groupname_col="group")
    .opt_row_striping()
)
```

<img width="297" alt="image" src="https://github.com/user-attachments/assets/ee947753-de5e-4ba5-a9b8-e85c7a9f2ec9">

Note that the default background color for striping is a *very* light gray (by design).
