### PR TITLE
docs: fix deprecation warning in the `superbowl` example

### DIFF
--- a/docs/blog/superbowl-squares/index.qmd
+++ b/docs/blog/superbowl-squares/index.qmd
@@ -47,7 +47,7 @@ df = (
     .with_columns(
         z=pl.when((pl.col("x") == 7) & (pl.col("y") == 4)).then(pl.lit("4/7")).otherwise("z")
     )
-    .pivot(index="x", values="z", columns="y")
+    .pivot(index="x", values="z", on="y")
     .with_row_index()
 )
 


### PR DESCRIPTION
@machow , it seems that the [deprecation warning](https://github.com/posit-dev/great-tables/pull/460#issuecomment-2371277167) is coming from the first code block in the `index.qmd`.