### PR TITLE
feat!: add missing styling (including row striping) in `opt_stylize()`

### DIFF
--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1322,6 +1322,8 @@ def opt_stylize(
     color
         The color scheme of the table. The default value is `"blue"`. The valid values are `"blue"`,
         `"cyan"`, `"pink"`, `"green"`, `"red"`, and `"gray"`.
+    add_row_striping
+        An option to enable row striping in the table body for the style chosen.
 
     Returns
     -------

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1552,7 +1552,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#D5D5D5",
         "grand_summary_row_background_color": "#929292",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "blue-2": {
         "table_hlines_color": "#D5D5D5",
@@ -1568,7 +1567,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#89D3FE",
         "grand_summary_row_background_color": "#00A1FF",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "cyan-2": {
         "table_hlines_color": "#D5D5D5",
@@ -1584,7 +1582,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#A5FEF2",
         "grand_summary_row_background_color": "#7FE9DB",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "pink-2": {
         "table_hlines_color": "#D5D5D5",
@@ -1600,7 +1597,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#FFC6E3",
         "grand_summary_row_background_color": "#EF5FA7",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "green-2": {
         "table_hlines_color": "#D5D5D5",
@@ -1616,7 +1612,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#CAFFAF",
         "grand_summary_row_background_color": "#89FD61",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "red-2": {
         "table_hlines_color": "#D5D5D5",
@@ -1632,7 +1627,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#FFCCC7",
         "grand_summary_row_background_color": "#FF644E",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "gray-3": {
         "table_hlines_color": "#929292",
@@ -1738,7 +1732,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#FFFFFF",
         "grand_summary_row_background_color": "#5F5F5F",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "blue-4": {
         "table_hlines_color": "#D5D5D5",
@@ -1754,7 +1747,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#FFFFFF",
         "grand_summary_row_background_color": "#0076BA",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "cyan-4": {
         "table_hlines_color": "#D5D5D5",
@@ -1770,7 +1762,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#FFFFFF",
         "grand_summary_row_background_color": "#01837B",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "pink-4": {
         "table_hlines_color": "#D5D5D5",
@@ -1786,7 +1777,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#FFFFFF",
         "grand_summary_row_background_color": "#CB2A7B",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "green-4": {
         "table_hlines_color": "#D5D5D5",
@@ -1802,7 +1792,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#FFFFFF",
         "grand_summary_row_background_color": "#038901",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "red-4": {
         "table_hlines_color": "#D5D5D5",
@@ -1818,7 +1807,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#FFFFFF",
         "grand_summary_row_background_color": "#E4220C",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "gray-5": {
         "table_hlines_color": "#D5D5D5",
@@ -1834,7 +1822,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#5F5F5F",
         "grand_summary_row_background_color": "#929292",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "blue-5": {
         "table_hlines_color": "#D5D5D5",
@@ -1850,7 +1837,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#5F5F5F",
         "grand_summary_row_background_color": "#929292",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "cyan-5": {
         "table_hlines_color": "#D5D5D5",
@@ -1866,7 +1852,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#5F5F5F",
         "grand_summary_row_background_color": "#929292",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "pink-5": {
         "table_hlines_color": "#D5D5D5",
@@ -1882,7 +1867,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#5F5F5F",
         "grand_summary_row_background_color": "#929292",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "green-5": {
         "table_hlines_color": "#D5D5D5",
@@ -1898,7 +1882,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#5F5F5F",
         "grand_summary_row_background_color": "#929292",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "red-5": {
         "table_hlines_color": "#D5D5D5",
@@ -1914,7 +1897,6 @@ _dict_styles_colors_params = {
         "summary_row_background_color": "#5F5F5F",
         "grand_summary_row_background_color": "#929292",
         "row_striping_background_color": "#F4F4F4",
-        "table_outline_color": "#D5D5D5",
     },
     "gray-6": {
         "table_hlines_color": "#5F5F5F",

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1413,6 +1413,7 @@ class StyleMapper:
     data_hlines_color: str
     data_vlines_style: str
     data_vlines_color: str
+    row_striping_background_color: str
 
     mappings: ClassVar[dict[str, list[str]]] = {
         "table_hlines_color": ["table_border_top_color", "table_border_bottom_color"],
@@ -1433,6 +1434,7 @@ class StyleMapper:
         "data_hlines_color": ["table_body_hlines_color"],
         "data_vlines_style": ["table_body_vlines_style"],
         "data_vlines_color": ["table_body_vlines_color"],
+        "row_striping_background_color": ["row_striping_background_color"],
     }
 
     def map_entry(self, name: str) -> dict[str, list[str]]:

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1381,14 +1381,11 @@ def opt_stylize(
 
     # Omit keys that are not needed for the `tab_options()` method
     # TODO: the omitted keys are for future use when:
-    #  (1) row striping is implemented
-    #  (2) summary rows are implemented
-    #  (3) grand summary rows are implemented
+    #  (1) summary rows are implemented
+    #  (2) grand summary rows are implemented
     omit_keys = {
         "summary_row_background_color",
         "grand_summary_row_background_color",
-        "row_striping_background_color",
-        "table_outline_color",
     }
 
     def dict_omit_keys(dict: dict[str, str], omit_keys: set[str]) -> dict[str, str]:

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1297,7 +1297,9 @@ def opt_table_font(
     return res
 
 
-def opt_stylize(self: GTSelf, style: int = 1, color: str = "blue") -> GTSelf:
+def opt_stylize(
+    self: GTSelf, style: int = 1, color: str = "blue", add_row_striping: bool = True
+) -> GTSelf:
     """
     Stylize your table with a colorful look.
 

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1395,6 +1395,10 @@ def opt_stylize(
 
     mapped_params = StyleMapper(**params).map_all()
 
+    # Add the `add_row_striping` parameter to the `mapped_params` dictionary
+    if add_row_striping:
+        mapped_params["row_striping_include_table_body"] = ["True"]
+
     # Apply the style parameters to the table using the `tab_options()` method
     res = tab_options(self=self, **mapped_params)
 

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1399,6 +1399,24 @@ def opt_stylize(
     if add_row_striping:
         mapped_params["row_striping_include_table_body"] = ["True"]
 
+    if style in [2, 4, 5]:
+        # For styles 2, 4, and 5 we need to set the border colors and widths
+
+        # Use a dictionary comprehension to generate the border parameters
+        directions = ["top", "bottom", "left", "right"]
+        attributes = ["color", "width", "style"]
+
+        border_params: dict[str, str] = {
+            f"table_border_{d}_{a}": (
+                "#D5D5D5" if a == "color" else "3px" if a == "width" else "solid"
+            )
+            for d in directions
+            for a in attributes
+        }
+
+        # Append the border parameters to the `mapped_params` dictionary
+        mapped_params.update(border_params)
+
     # Apply the style parameters to the table using the `tab_options()` method
     res = tab_options(self=self, **mapped_params)
 

--- a/tests/__snapshots__/test_options.ambr
+++ b/tests/__snapshots__/test_options.ambr
@@ -1403,6 +1403,114 @@
   
   '''
 # ---
+# name: test_opt_stylize_outline_present[1]
+  '''
+  
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #004D80;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #004D80;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+  
+  '''
+# ---
+# name: test_opt_stylize_outline_present[2]
+  '''
+  
+    border-top-style: solid;
+    border-top-width: 3px;
+    border-top-color: #D5D5D5;
+    border-right-style: solid;
+    border-right-width: 3px;
+    border-right-color: #D5D5D5;
+    border-bottom-style: solid;
+    border-bottom-width: 3px;
+    border-bottom-color: #D5D5D5;
+    border-left-style: solid;
+    border-left-width: 3px;
+    border-left-color: #D5D5D5;
+  
+  '''
+# ---
+# name: test_opt_stylize_outline_present[3]
+  '''
+  
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #929292;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #929292;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+  
+  '''
+# ---
+# name: test_opt_stylize_outline_present[4]
+  '''
+  
+    border-top-style: solid;
+    border-top-width: 3px;
+    border-top-color: #D5D5D5;
+    border-right-style: solid;
+    border-right-width: 3px;
+    border-right-color: #D5D5D5;
+    border-bottom-style: solid;
+    border-bottom-width: 3px;
+    border-bottom-color: #D5D5D5;
+    border-left-style: solid;
+    border-left-width: 3px;
+    border-left-color: #D5D5D5;
+  
+  '''
+# ---
+# name: test_opt_stylize_outline_present[5]
+  '''
+  
+    border-top-style: solid;
+    border-top-width: 3px;
+    border-top-color: #D5D5D5;
+    border-right-style: solid;
+    border-right-width: 3px;
+    border-right-color: #D5D5D5;
+    border-bottom-style: solid;
+    border-bottom-width: 3px;
+    border-bottom-color: #D5D5D5;
+    border-left-style: solid;
+    border-left-width: 3px;
+    border-left-color: #D5D5D5;
+  
+  '''
+# ---
+# name: test_opt_stylize_outline_present[6]
+  '''
+  
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #5F5F5F;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #5F5F5F;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+  
+  '''
+# ---
 # name: test_scss_default_generated
   '''
   #abc table {

--- a/tests/__snapshots__/test_options.ambr
+++ b/tests/__snapshots__/test_options.ambr
@@ -1,4 +1,1408 @@
 # serializer version: 1
+# name: test_opt_stylize
+  '''
+  #abc table {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+          }
+  
+  #abc thead,
+  tbody,
+  tfoot,
+  tr,
+  td,
+  th {
+    border-style: none;
+  }
+  
+  tr {
+    background-color: transparent;
+  }
+  
+  #abc p {
+    margin: 0;
+    padding: 0;
+  }
+  
+  #abc .gt_table {
+    display: table;
+    border-collapse: collapse;
+    line-height: normal;
+    margin-left: auto;
+    margin-right: auto;
+    color: #333333;
+    font-size: 16px;
+    font-weight: normal;
+    font-style: normal;
+    background-color: #FFFFFF;
+    width: auto;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #004D80;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #004D80;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+  }
+  
+  #abc .gt_caption {
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+  
+  #abc .gt_title {
+    color: #333333;
+    font-size: 125%;
+    font-weight: initial;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-bottom-color: #FFFFFF;
+    border-bottom-width: 0;
+  }
+  
+  #abc .gt_subtitle {
+    color: #333333;
+    font-size: 85%;
+    font-weight: initial;
+    padding-top: 3px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-top-color: #FFFFFF;
+    border-top-width: 0;
+  }
+  
+  #abc .gt_heading {
+    background-color: #FFFFFF;
+    text-align: center;
+    border-bottom-color: #FFFFFF;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_bottom_border {
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+  }
+  
+  #abc .gt_col_headings {
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_col_heading {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: normal;
+    text-transform: inherit;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+    vertical-align: bottom;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
+    overflow-x: hidden;
+  }
+  
+  #abc .gt_column_spanner_outer {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: normal;
+    text-transform: inherit;
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: 4px;
+    padding-right: 4px;
+  }
+  
+  #abc .gt_column_spanner_outer:first-child {
+    padding-left: 0;
+  }
+  
+  #abc .gt_column_spanner_outer:last-child {
+    padding-right: 0;
+  }
+  
+  #abc .gt_column_spanner {
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    vertical-align: bottom;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    overflow-x: hidden;
+    display: inline-block;
+    width: 100%;
+  }
+  
+  #abc .gt_spanner_row {
+    border-bottom-style: hidden;
+  }
+  
+  #abc .gt_group_heading {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+    vertical-align: middle;
+    text-align: left;
+  }
+  
+  #abc .gt_empty_group_heading {
+    padding: 0.5px;
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    vertical-align: middle;
+  }
+  
+  #abc .gt_from_md> :first-child {
+    margin-top: 0;
+  }
+  
+  #abc .gt_from_md> :last-child {
+    margin-bottom: 0;
+  }
+  
+  #abc .gt_row {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    margin: 10px;
+    border-top-style: none;
+    border-top-width: 1px;
+    border-top-color: #89D3FE;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #89D3FE;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #89D3FE;
+    vertical-align: middle;
+    overflow-x: hidden;
+  }
+  
+  #abc .gt_stub {
+    color: #FFFFFF;
+    background-color: #0076BA;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-right-style: solid;
+    border-right-width: 2px;
+    border-right-color: #0076BA;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+  
+  #abc .gt_stub_row_group {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-right-style: solid;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    padding-left: 5px;
+    padding-right: 5px;
+    vertical-align: top;
+  }
+  
+  #abc .gt_row_group_first td {
+    border-top-width: 2px;
+  }
+  
+  #abc .gt_row_group_first th {
+    border-top-width: 2px;
+  }
+  
+  #abc .gt_striped {
+    background-color: #F4F4F4;
+  }
+  
+  #abc .gt_table_body {
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+  }
+  
+  #abc .gt_sourcenotes {
+    color: #333333;
+    background-color: #FFFFFF;
+    border-bottom-style: none;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_sourcenote {
+    font-size: 90%;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 5px;
+    padding-right: 5px;
+    text-align: left;
+  }
+  
+  #abc .gt_left {
+    text-align: left;
+  }
+  
+  #abc .gt_center {
+    text-align: center;
+  }
+  
+  #abc .gt_right {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  
+  #abc .gt_font_normal {
+    font-weight: normal;
+  }
+  
+  #abc .gt_font_bold {
+    font-weight: bold;
+  }
+  
+  #abc .gt_font_italic {
+    font-style: italic;
+  }
+  
+  #abc .gt_super {
+    font-size: 65%;
+  }
+  
+  #abc .gt_footnote_marks {
+    font-size: 75%;
+    vertical-align: 0.4em;
+    position: initial;
+  }
+  
+  #abc .gt_asterisk {
+    font-size: 100%;
+    vertical-align: 0;
+  }
+  
+  '''
+# ---
+# name: test_opt_stylize.1
+  '''
+  #abc table {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+          }
+  
+  #abc thead,
+  tbody,
+  tfoot,
+  tr,
+  td,
+  th {
+    border-style: none;
+  }
+  
+  tr {
+    background-color: transparent;
+  }
+  
+  #abc p {
+    margin: 0;
+    padding: 0;
+  }
+  
+  #abc .gt_table {
+    display: table;
+    border-collapse: collapse;
+    line-height: normal;
+    margin-left: auto;
+    margin-right: auto;
+    color: #333333;
+    font-size: 16px;
+    font-weight: normal;
+    font-style: normal;
+    background-color: #FFFFFF;
+    width: auto;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #004D80;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #004D80;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+  }
+  
+  #abc .gt_caption {
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+  
+  #abc .gt_title {
+    color: #333333;
+    font-size: 125%;
+    font-weight: initial;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-bottom-color: #FFFFFF;
+    border-bottom-width: 0;
+  }
+  
+  #abc .gt_subtitle {
+    color: #333333;
+    font-size: 85%;
+    font-weight: initial;
+    padding-top: 3px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-top-color: #FFFFFF;
+    border-top-width: 0;
+  }
+  
+  #abc .gt_heading {
+    background-color: #FFFFFF;
+    text-align: center;
+    border-bottom-color: #FFFFFF;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_bottom_border {
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+  }
+  
+  #abc .gt_col_headings {
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_col_heading {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: normal;
+    text-transform: inherit;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+    vertical-align: bottom;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
+    overflow-x: hidden;
+  }
+  
+  #abc .gt_column_spanner_outer {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: normal;
+    text-transform: inherit;
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: 4px;
+    padding-right: 4px;
+  }
+  
+  #abc .gt_column_spanner_outer:first-child {
+    padding-left: 0;
+  }
+  
+  #abc .gt_column_spanner_outer:last-child {
+    padding-right: 0;
+  }
+  
+  #abc .gt_column_spanner {
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    vertical-align: bottom;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    overflow-x: hidden;
+    display: inline-block;
+    width: 100%;
+  }
+  
+  #abc .gt_spanner_row {
+    border-bottom-style: hidden;
+  }
+  
+  #abc .gt_group_heading {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+    vertical-align: middle;
+    text-align: left;
+  }
+  
+  #abc .gt_empty_group_heading {
+    padding: 0.5px;
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    vertical-align: middle;
+  }
+  
+  #abc .gt_from_md> :first-child {
+    margin-top: 0;
+  }
+  
+  #abc .gt_from_md> :last-child {
+    margin-bottom: 0;
+  }
+  
+  #abc .gt_row {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    margin: 10px;
+    border-top-style: none;
+    border-top-width: 1px;
+    border-top-color: #89D3FE;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #89D3FE;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #89D3FE;
+    vertical-align: middle;
+    overflow-x: hidden;
+  }
+  
+  #abc .gt_stub {
+    color: #FFFFFF;
+    background-color: #0076BA;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-right-style: solid;
+    border-right-width: 2px;
+    border-right-color: #0076BA;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+  
+  #abc .gt_stub_row_group {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-right-style: solid;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    padding-left: 5px;
+    padding-right: 5px;
+    vertical-align: top;
+  }
+  
+  #abc .gt_row_group_first td {
+    border-top-width: 2px;
+  }
+  
+  #abc .gt_row_group_first th {
+    border-top-width: 2px;
+  }
+  
+  #abc .gt_striped {
+    background-color: #F4F4F4;
+  }
+  
+  #abc .gt_table_body {
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+  }
+  
+  #abc .gt_sourcenotes {
+    color: #333333;
+    background-color: #FFFFFF;
+    border-bottom-style: none;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_sourcenote {
+    font-size: 90%;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 5px;
+    padding-right: 5px;
+    text-align: left;
+  }
+  
+  #abc .gt_left {
+    text-align: left;
+  }
+  
+  #abc .gt_center {
+    text-align: center;
+  }
+  
+  #abc .gt_right {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  
+  #abc .gt_font_normal {
+    font-weight: normal;
+  }
+  
+  #abc .gt_font_bold {
+    font-weight: bold;
+  }
+  
+  #abc .gt_font_italic {
+    font-style: italic;
+  }
+  
+  #abc .gt_super {
+    font-size: 65%;
+  }
+  
+  #abc .gt_footnote_marks {
+    font-size: 75%;
+    vertical-align: 0.4em;
+    position: initial;
+  }
+  
+  #abc .gt_asterisk {
+    font-size: 100%;
+    vertical-align: 0;
+  }
+  
+  '''
+# ---
+# name: test_opt_stylize_default
+  '''
+  #abc table {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+          }
+  
+  #abc thead,
+  tbody,
+  tfoot,
+  tr,
+  td,
+  th {
+    border-style: none;
+  }
+  
+  tr {
+    background-color: transparent;
+  }
+  
+  #abc p {
+    margin: 0;
+    padding: 0;
+  }
+  
+  #abc .gt_table {
+    display: table;
+    border-collapse: collapse;
+    line-height: normal;
+    margin-left: auto;
+    margin-right: auto;
+    color: #333333;
+    font-size: 16px;
+    font-weight: normal;
+    font-style: normal;
+    background-color: #FFFFFF;
+    width: auto;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #004D80;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #004D80;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+  }
+  
+  #abc .gt_caption {
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+  
+  #abc .gt_title {
+    color: #333333;
+    font-size: 125%;
+    font-weight: initial;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-bottom-color: #FFFFFF;
+    border-bottom-width: 0;
+  }
+  
+  #abc .gt_subtitle {
+    color: #333333;
+    font-size: 85%;
+    font-weight: initial;
+    padding-top: 3px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-top-color: #FFFFFF;
+    border-top-width: 0;
+  }
+  
+  #abc .gt_heading {
+    background-color: #FFFFFF;
+    text-align: center;
+    border-bottom-color: #FFFFFF;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_bottom_border {
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+  }
+  
+  #abc .gt_col_headings {
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_col_heading {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: normal;
+    text-transform: inherit;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+    vertical-align: bottom;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
+    overflow-x: hidden;
+  }
+  
+  #abc .gt_column_spanner_outer {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: normal;
+    text-transform: inherit;
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: 4px;
+    padding-right: 4px;
+  }
+  
+  #abc .gt_column_spanner_outer:first-child {
+    padding-left: 0;
+  }
+  
+  #abc .gt_column_spanner_outer:last-child {
+    padding-right: 0;
+  }
+  
+  #abc .gt_column_spanner {
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    vertical-align: bottom;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    overflow-x: hidden;
+    display: inline-block;
+    width: 100%;
+  }
+  
+  #abc .gt_spanner_row {
+    border-bottom-style: hidden;
+  }
+  
+  #abc .gt_group_heading {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+    vertical-align: middle;
+    text-align: left;
+  }
+  
+  #abc .gt_empty_group_heading {
+    padding: 0.5px;
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    vertical-align: middle;
+  }
+  
+  #abc .gt_from_md> :first-child {
+    margin-top: 0;
+  }
+  
+  #abc .gt_from_md> :last-child {
+    margin-bottom: 0;
+  }
+  
+  #abc .gt_row {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    margin: 10px;
+    border-top-style: none;
+    border-top-width: 1px;
+    border-top-color: #89D3FE;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #89D3FE;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #89D3FE;
+    vertical-align: middle;
+    overflow-x: hidden;
+  }
+  
+  #abc .gt_stub {
+    color: #FFFFFF;
+    background-color: #0076BA;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-right-style: solid;
+    border-right-width: 2px;
+    border-right-color: #0076BA;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+  
+  #abc .gt_stub_row_group {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-right-style: solid;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    padding-left: 5px;
+    padding-right: 5px;
+    vertical-align: top;
+  }
+  
+  #abc .gt_row_group_first td {
+    border-top-width: 2px;
+  }
+  
+  #abc .gt_row_group_first th {
+    border-top-width: 2px;
+  }
+  
+  #abc .gt_striped {
+    background-color: #F4F4F4;
+  }
+  
+  #abc .gt_table_body {
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+  }
+  
+  #abc .gt_sourcenotes {
+    color: #333333;
+    background-color: #FFFFFF;
+    border-bottom-style: none;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_sourcenote {
+    font-size: 90%;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 5px;
+    padding-right: 5px;
+    text-align: left;
+  }
+  
+  #abc .gt_left {
+    text-align: left;
+  }
+  
+  #abc .gt_center {
+    text-align: center;
+  }
+  
+  #abc .gt_right {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  
+  #abc .gt_font_normal {
+    font-weight: normal;
+  }
+  
+  #abc .gt_font_bold {
+    font-weight: bold;
+  }
+  
+  #abc .gt_font_italic {
+    font-style: italic;
+  }
+  
+  #abc .gt_super {
+    font-size: 65%;
+  }
+  
+  #abc .gt_footnote_marks {
+    font-size: 75%;
+    vertical-align: 0.4em;
+    position: initial;
+  }
+  
+  #abc .gt_asterisk {
+    font-size: 100%;
+    vertical-align: 0;
+  }
+  
+  '''
+# ---
+# name: test_opt_stylize_no_striping
+  '''
+  #abc table {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+          }
+  
+  #abc thead,
+  tbody,
+  tfoot,
+  tr,
+  td,
+  th {
+    border-style: none;
+  }
+  
+  tr {
+    background-color: transparent;
+  }
+  
+  #abc p {
+    margin: 0;
+    padding: 0;
+  }
+  
+  #abc .gt_table {
+    display: table;
+    border-collapse: collapse;
+    line-height: normal;
+    margin-left: auto;
+    margin-right: auto;
+    color: #333333;
+    font-size: 16px;
+    font-weight: normal;
+    font-style: normal;
+    background-color: #FFFFFF;
+    width: auto;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #004D80;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #004D80;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+  }
+  
+  #abc .gt_caption {
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+  
+  #abc .gt_title {
+    color: #333333;
+    font-size: 125%;
+    font-weight: initial;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-bottom-color: #FFFFFF;
+    border-bottom-width: 0;
+  }
+  
+  #abc .gt_subtitle {
+    color: #333333;
+    font-size: 85%;
+    font-weight: initial;
+    padding-top: 3px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
+    border-top-color: #FFFFFF;
+    border-top-width: 0;
+  }
+  
+  #abc .gt_heading {
+    background-color: #FFFFFF;
+    text-align: center;
+    border-bottom-color: #FFFFFF;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_bottom_border {
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+  }
+  
+  #abc .gt_col_headings {
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_col_heading {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: normal;
+    text-transform: inherit;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+    vertical-align: bottom;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
+    overflow-x: hidden;
+  }
+  
+  #abc .gt_column_spanner_outer {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: normal;
+    text-transform: inherit;
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: 4px;
+    padding-right: 4px;
+  }
+  
+  #abc .gt_column_spanner_outer:first-child {
+    padding-left: 0;
+  }
+  
+  #abc .gt_column_spanner_outer:last-child {
+    padding-right: 0;
+  }
+  
+  #abc .gt_column_spanner {
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    vertical-align: bottom;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    overflow-x: hidden;
+    display: inline-block;
+    width: 100%;
+  }
+  
+  #abc .gt_spanner_row {
+    border-bottom-style: hidden;
+  }
+  
+  #abc .gt_group_heading {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #D3D3D3;
+    vertical-align: middle;
+    text-align: left;
+  }
+  
+  #abc .gt_empty_group_heading {
+    padding: 0.5px;
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+    vertical-align: middle;
+  }
+  
+  #abc .gt_from_md> :first-child {
+    margin-top: 0;
+  }
+  
+  #abc .gt_from_md> :last-child {
+    margin-bottom: 0;
+  }
+  
+  #abc .gt_row {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
+    margin: 10px;
+    border-top-style: none;
+    border-top-width: 1px;
+    border-top-color: #89D3FE;
+    border-left-style: none;
+    border-left-width: 1px;
+    border-left-color: #89D3FE;
+    border-right-style: none;
+    border-right-width: 1px;
+    border-right-color: #89D3FE;
+    vertical-align: middle;
+    overflow-x: hidden;
+  }
+  
+  #abc .gt_stub {
+    color: #FFFFFF;
+    background-color: #0076BA;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-right-style: solid;
+    border-right-width: 2px;
+    border-right-color: #0076BA;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+  
+  #abc .gt_stub_row_group {
+    color: #333333;
+    background-color: #FFFFFF;
+    font-size: 100%;
+    font-weight: initial;
+    text-transform: inherit;
+    border-right-style: solid;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+    padding-left: 5px;
+    padding-right: 5px;
+    vertical-align: top;
+  }
+  
+  #abc .gt_row_group_first td {
+    border-top-width: 2px;
+  }
+  
+  #abc .gt_row_group_first th {
+    border-top-width: 2px;
+  }
+  
+  #abc .gt_striped {
+    background-color: #F4F4F4;
+  }
+  
+  #abc .gt_table_body {
+    border-top-style: solid;
+    border-top-width: 2px;
+    border-top-color: #0076BA;
+    border-bottom-style: solid;
+    border-bottom-width: 2px;
+    border-bottom-color: #0076BA;
+  }
+  
+  #abc .gt_sourcenotes {
+    color: #333333;
+    background-color: #FFFFFF;
+    border-bottom-style: none;
+    border-bottom-width: 2px;
+    border-bottom-color: #D3D3D3;
+    border-left-style: none;
+    border-left-width: 2px;
+    border-left-color: #D3D3D3;
+    border-right-style: none;
+    border-right-width: 2px;
+    border-right-color: #D3D3D3;
+  }
+  
+  #abc .gt_sourcenote {
+    font-size: 90%;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    padding-left: 5px;
+    padding-right: 5px;
+    text-align: left;
+  }
+  
+  #abc .gt_left {
+    text-align: left;
+  }
+  
+  #abc .gt_center {
+    text-align: center;
+  }
+  
+  #abc .gt_right {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  
+  #abc .gt_font_normal {
+    font-weight: normal;
+  }
+  
+  #abc .gt_font_bold {
+    font-weight: bold;
+  }
+  
+  #abc .gt_font_italic {
+    font-style: italic;
+  }
+  
+  #abc .gt_super {
+    font-size: 65%;
+  }
+  
+  #abc .gt_footnote_marks {
+    font-size: 75%;
+    vertical-align: 0.4em;
+    position: initial;
+  }
+  
+  #abc .gt_asterisk {
+    font-size: 100%;
+    vertical-align: 0;
+  }
+  
+  '''
+# ---
 # name: test_scss_default_generated
   '''
   #abc table {

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,3 +1,5 @@
+import re
+
 import pandas as pd
 import pytest
 from great_tables import GT, exibble, md, google_font
@@ -455,6 +457,20 @@ def test_opt_stylize_no_striping(snapshot):
     )
 
     assert snapshot == compile_scss(gt_tbl, id="abc", compress=False)
+
+
+@pytest.mark.parametrize("style", [1, 2, 3, 4, 5, 6])
+def test_opt_stylize_outline_present(style, snapshot):
+
+    gt_tbl = GT(exibble, rowname_col="row", groupname_col="group").opt_stylize(style=style)
+
+    css = compile_scss(gt_tbl, id="abc", compress=False)
+
+    css_gt_table_cls = re.sub(r"^.*?#abc \.gt_table \{\n(.*?)\}.*$", r"\1", css, flags=re.DOTALL)
+
+    css_gt_table_border = re.sub(r".*?width: auto;(.*)", r"\1", css_gt_table_cls, flags=re.DOTALL)
+
+    assert snapshot == css_gt_table_border
 
 
 @pytest.mark.parametrize("align", ["left", "center", "right"])

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -441,6 +441,22 @@ def test_tab_options_striping_stub_snap(snapshot):
     assert snapshot == body
 
 
+def test_opt_stylize_default(snapshot):
+
+    gt_tbl = GT(exibble, rowname_col="row", groupname_col="group").opt_stylize()
+
+    assert snapshot == compile_scss(gt_tbl, id="abc", compress=False)
+
+
+def test_opt_stylize_no_striping(snapshot):
+
+    gt_tbl = GT(exibble, rowname_col="row", groupname_col="group").opt_stylize(
+        add_row_striping=False
+    )
+
+    assert snapshot == compile_scss(gt_tbl, id="abc", compress=False)
+
+
 @pytest.mark.parametrize("align", ["left", "center", "right"])
 def test_opt_align_table_header(gt_tbl: GT, align: list[str]):
     tbl = gt_tbl.opt_align_table_header(align=align)


### PR DESCRIPTION
This PR makes the following two changes to `opt_stylize()`:

- add the `add_row_striping=` argument to `opt_stylize()`
- include the table outline in some `opt_stylize()` styles

Now that row striping is functional with https://github.com/posit-dev/great-tables/pull/461 we can revisit the missing row striping in the table themes available through `opt_stylize()`. In the gt package (R), `opt_stylize()` has the `add_row_striping` arg and that's added in this PR (with a default of `True`).

Here's what the row striping looks like w/o and w/ this PR using this code:

```python

from great_tables import GT, exibble, md

(
    GT(
        exibble[["num", "char", "currency", "row", "group"]],
        rowname_col="row",
        groupname_col="group",
    )
    .tab_header(
        title=md("Data listing from **exibble**"),
        subtitle=md("`exibble` is a **Great Tables** dataset."),
    )
    .fmt_number(columns="num")
    .fmt_currency(columns="currency")
    .tab_source_note(source_note="This is only a subset of the dataset.")
    .opt_stylize(color="red", style=6)
)
```

before

<img width="646" alt="image" src="https://github.com/user-attachments/assets/c14e5aa1-6b71-4742-8119-214b02850bc7">

after

<img width="646" alt="image" src="https://github.com/user-attachments/assets/a974a2df-c496-42d7-8ead-7693ffe581f7">

Another missing feature that is added here is support for the table outline (in `style` types: `2`, `4`, and `5`). The surrounding border is the same in all three styles (solid, 3px, #D5D5D5). Here's a before and after for `style=2` in blue:

before

<img width="645" alt="image" src="https://github.com/user-attachments/assets/71117a62-f694-46d1-a34d-81539eff2d38">

after

<img width="645" alt="image" src="https://github.com/user-attachments/assets/40e6109e-3eb5-4cb3-a8e5-df7518724e41">

