### PR TITLE
Include `google_font()` helper fn in API reference

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -162,6 +162,7 @@ quartodoc:
         - md
         - html
         - from_column
+        - google_font
         - system_fonts
         - define_units
         - nanoplot_options


### PR DESCRIPTION
Currently the `google_font()` helper function is missing from the package API reference in the site. This PR simply adds it in so it's visible (in time for the next release, `v0.12.0`).