### PR TITLE
Update docs and code to support `GoogleFont` in `opt_table_font()` and add tests

### DIFF
--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, fields, replace
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, ClassVar, cast, Iterable
 
 from great_tables import _utils
 from great_tables._helpers import FontStackName, GoogleFont, _intify_scaled_px, px
@@ -1090,7 +1090,7 @@ def opt_table_outline(
 
 def opt_table_font(
     self: GTSelf,
-    font: str | list[str] | dict[str, str] | None = None,
+    font: str | list[str] | dict[str, str] | GoogleFont | None = None,
     stack: FontStackName | None = None,
     weight: str | int | float | None = None,
     style: str | None = None,
@@ -1110,9 +1110,10 @@ def opt_table_font(
     Parameters
     ----------
     font
-        One or more font names available on the user system. This can be a string or a list of
-        strings. The default value is `None` since you could instead opt to use `stack` to define
-        a list of fonts.
+        One or more font names available on the user's system. This can be provided as a string or
+        a list of strings. Alternatively, you can specify font names using the `google_font()`
+        helper function. The default value is `None` since you could instead opt to use `stack` to
+        define a list of fonts.
     stack
         A name that is representative of a font stack (obtained via internally via the
         `system_fonts()` helper function. If provided, this new stack will replace any defined fonts
@@ -1227,8 +1228,16 @@ def opt_table_font(
     if font is not None:
 
         # If font is a string or GoogleFont object, convert to a list
-        if isinstance(font, str) or isinstance(font, GoogleFont):
-            font = [font]
+        if isinstance(font, (str, GoogleFont)):
+            font: list[str | GoogleFont] = [font]
+
+        if not isinstance(font, Iterable):
+            # We need to raise an exception here. Otherwise, if the provided `font` is not iterable,
+            # the `for item in font` loop will raise a `TypeError` with a message stating that the
+            # object is not iterable.
+            raise TypeError(
+                "`font=` must be a string/GoogleFont object or a list of strings/GoogleFont objects."
+            )
 
         new_font_list: list[str] = []
 
@@ -1251,9 +1260,11 @@ def opt_table_font(
                 res = tab_options(res, table_additional_css=existing_additional_css)
 
             else:
-                raise TypeError("`font=` must be a string or a list of strings.")
+                raise TypeError(
+                    "`font=` must be a string/GoogleFont object or a list of strings/GoogleFont objects."
+                )
 
-        font = new_font_list
+        font: list[str] = new_font_list
 
     else:
         font = []
@@ -1278,7 +1289,7 @@ def opt_table_font(
 
     if weight is not None:
 
-        if isinstance(weight, int) or isinstance(weight, float):
+        if isinstance(weight, (int, float)):
 
             weight = str(round(weight))
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -390,6 +390,27 @@ def test_opt_table_font_raises():
     assert "Either `font=` or `stack=` must be provided." in exc_info.value.args[0]
 
 
+@pytest.mark.parametrize("font", [1, [1]])
+def test_opt_table_font_raises_font(font):
+    with pytest.raises(TypeError) as exc_info:
+        GT(exibble).opt_table_font(font=font)
+
+    assert (
+        "`font=` must be a string/GoogleFont object or a list of strings/GoogleFont objects."
+        in exc_info.value.args[0]
+    )
+
+
+def test_opt_table_font_raises_weight():
+    with pytest.raises(TypeError) as exc_info:
+        GT(exibble).opt_table_font(stack="humanist", weight=(1, 2))
+
+    assert (
+        "`weight=` must be a numeric value between 1 and 1000 or a text-based keyword."
+        in exc_info.value.args[0]
+    )
+
+
 def test_opt_row_striping():
 
     gt_tbl_0 = GT(exibble)


### PR DESCRIPTION
This PR updates the documentation to mention that the `font` parameter of `opt_table_font()` now accepts a `GoogleFont` object. It also consolidates the internal code and introduces additional tests.