### PR TITLE
Update `__repr__()` for `GoogleFont`, `UnitStr` and `UnitDefinitionList`

### DIFF
--- a/great_tables/_helpers.py
+++ b/great_tables/_helpers.py
@@ -286,7 +286,7 @@ class GoogleFont:
     font: str
 
     def __repr__(self) -> str:
-        return f"GoogleFont({self.font})"
+        return f"{type(self).__name__}({self.font})"
 
     def make_import_stmt(self) -> str:
         return f"@import url('https://fonts.googleapis.com/css2?family={self.font.replace(' ', '+')}&display=swap');"
@@ -837,7 +837,7 @@ class UnitStr:
         self.units_str = units_str
 
     def __repr__(self) -> str:
-        return f"UnitStr({self.units_str})"
+        return f"{type(self).__name__}({self.units_str})"
 
     def to_html(self) -> str:
 
@@ -890,7 +890,7 @@ class UnitDefinitionList:
     units_list: list[UnitDefinition]
 
     def __repr__(self) -> str:
-        return f"UnitDefinitionList({self.units_list})"
+        return f"{type(self).__name__}({self.units_list})"
 
     def __len__(self) -> int:
         return len(self.units_list)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -333,6 +333,7 @@ def test_unit_definition_list_class_construction():
 def test_unit_str_class_construction():
     unit_str = UnitStr(["a b"])
     assert unit_str.units_str == ["a b"]
+    assert str(unit_str) == repr(unit_str) == "UnitStr(['a b'])"
     assert len(unit_str) == 1
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -92,6 +92,7 @@ def test_google_font():
         font.make_import_stmt()
         == "@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');"
     )
+    assert str(font) == repr(font) == f"GoogleFont({font_name})"
 
 
 def test_google_font_class():
@@ -320,11 +321,19 @@ def test_unit_definition_class_construction():
 def test_unit_definition_list_class_construction():
     unit_def_list = UnitDefinitionList([UnitDefinition(token="m^2", unit="m", exponent="2")])
     assert unit_def_list.units_list == [UnitDefinition(token="m^2", unit="m", exponent="2")]
+    assert (
+        str(unit_def_list)
+        == repr(unit_def_list)
+        == "UnitDefinitionList([UnitDefinition("
+        + "token='m^2', unit='m', unit_subscript=None, exponent='2', sub_super_overstrike=False, "
+        + "chemical_formula=False, built=None)])"
+    )
 
 
 def test_unit_str_class_construction():
     unit_str = UnitStr(["a b"])
     assert unit_str.units_str == ["a b"]
+    assert len(unit_str) == 1
 
 
 def test_unit_str_from_str_single_unit():


### PR DESCRIPTION
I’d like to propose using `type(self).__name__` to represent the class name, rather than hardcoding the class name directly.