### PR TITLE
docs: fix deprecated warning for `pl.DataFrame.pivot()`

### DIFF
--- a/docs/blog/introduction-0.2.0/index.qmd
+++ b/docs/blog/introduction-0.2.0/index.qmd
@@ -59,7 +59,7 @@ wide_pops = (
         pl.col("country_code_2").is_in(["FM", "GU", "KI", "MH", "MP", "NR", "PW"])
         & pl.col("year").is_in([2000, 2010, 2020])
     )
-    .pivot(index="country_name", columns="year", values="population")
+    .pivot(index="country_name", on="year", values="population")
     .sort("2020", descending=True)
 )
 

--- a/docs/get-started/colorizing-with-data.qmd
+++ b/docs/get-started/colorizing-with-data.qmd
@@ -80,7 +80,7 @@ sza_pivot = (
     .filter((pl.col("latitude") == "20") & (pl.col("tst") <= "1200"))
     .select(pl.col("*").exclude("latitude"))
     .drop_nulls()
-    .pivot(values="sza", index="month", columns="tst", sort_columns=True)
+    .pivot(values="sza", index="month", on="tst", sort_columns=True)
 )
 
 (


### PR DESCRIPTION
This PR addresses uncaught deprecated warnings related to `pl.DataFrame.pivot()` in the documentation examples.