### PR TITLE
fix: resolve global `locale` not being respected in `GT.fmt_*()` functions

### DIFF
--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -279,11 +279,6 @@ def fmt_number(
     Take a look at the functional version of this method:
     [`val_fmt_number()`](`great_tables._formats_vals.val_fmt_number`).
     """
-
-    # Stop if `locale` does not have a valid value; normalize locale and resolve one
-    # that might be set globally
-    _validate_locale(locale=locale)
-    locale = _normalize_locale(locale=locale)
     locale = _resolve_locale(self, locale=locale)
 
     # Use locale-based marks if a locale ID is provided
@@ -458,10 +453,7 @@ def fmt_integer(
     [`val_fmt_integer()`](`great_tables._formats_vals.val_fmt_integer`).
     """
 
-    # Stop if `locale` does not have a valid value; normalize locale and resolve one
-    # that might be set globally
-    _validate_locale(locale=locale)
-    locale = _normalize_locale(locale=locale)
+    locale = _resolve_locale(self, locale=locale)
 
     # Use locale-based marks if a locale ID is provided
     sep_mark = _get_locale_sep_mark(default=sep_mark, use_seps=use_seps, locale=locale)
@@ -665,10 +657,7 @@ def fmt_scientific(
     # large exponent values
     use_seps = True
 
-    # Stop if `locale` does not have a valid value; normalize locale and resolve one
-    # that might be set globally
-    _validate_locale(locale=locale)
-    locale = _normalize_locale(locale=locale)
+    locale = _resolve_locale(self, locale=locale)
 
     # Use locale-based marks if a locale ID is provided
     sep_mark = _get_locale_sep_mark(default=sep_mark, use_seps=use_seps, locale=locale)
@@ -919,10 +908,7 @@ def fmt_percent(
     single numerical value (or a list of them).
     """
 
-    # Stop if `locale` does not have a valid value; normalize locale and resolve one
-    # that might be set globally
-    _validate_locale(locale=locale)
-    locale = _normalize_locale(locale=locale)
+    locale = _resolve_locale(self, locale=locale)
 
     # Use locale-based marks if a locale ID is provided
     sep_mark = _get_locale_sep_mark(default=sep_mark, use_seps=use_seps, locale=locale)
@@ -1143,10 +1129,7 @@ def fmt_currency(
     single numerical value (or a list of them).
     """
 
-    # Stop if `locale` does not have a valid value; normalize locale and resolve one
-    # that might be set globally
-    _validate_locale(locale=locale)
-    locale = _normalize_locale(locale=locale)
+    locale = _resolve_locale(self, locale=locale)
 
     # Use locale-based marks if a locale ID is provided
     sep_mark = _get_locale_sep_mark(default=sep_mark, use_seps=use_seps, locale=locale)
@@ -1483,10 +1466,7 @@ def fmt_bytes(
     numerical value (or a list of them).
     """
 
-    # Stop if `locale` does not have a valid value; normalize locale and resolve one
-    # that might be set globally
-    _validate_locale(locale=locale)
-    locale = _normalize_locale(locale=locale)
+    locale = _resolve_locale(self, locale=locale)
 
     # Use locale-based marks if a locale ID is provided
     sep_mark = _get_locale_sep_mark(default=sep_mark, use_seps=use_seps, locale=locale)
@@ -1692,10 +1672,7 @@ def fmt_date(
     numerical value (or a list of them).
     """
 
-    # Stop if `locale` does not have a valid value; normalize locale and resolve one
-    # that might be set globally
-    _validate_locale(locale=locale)
-    locale = _normalize_locale(locale=locale)
+    locale = _resolve_locale(self, locale=locale)
 
     # Get the date format string based on the `date_style` value
     date_format_str = _get_date_format(date_style=date_style)
@@ -1826,10 +1803,7 @@ def fmt_time(
     numerical value (or a list of them).
     """
 
-    # Stop if `locale` does not have a valid value; normalize locale and resolve one
-    # that might be set globally
-    _validate_locale(locale=locale)
-    locale = _normalize_locale(locale=locale)
+    locale = _resolve_locale(self, locale=locale)
 
     # Get the time format string based on the `time_style` value
     time_format_str = _get_time_format(time_style=time_style)
@@ -1976,10 +1950,7 @@ def fmt_datetime(
     ```
     """
 
-    # Stop if `locale` does not have a valid value; normalize locale and resolve one
-    # that might be set globally
-    _validate_locale(locale=locale)
-    locale = _normalize_locale(locale=locale)
+    locale = _resolve_locale(self, locale=locale)
 
     # Get the date format string based on the `date_style` value
     date_format_str = _get_date_format(date_style=date_style)
@@ -2899,9 +2870,8 @@ def _resolve_locale(x: GTData, locale: str | None = None) -> str | None:
 
     # TODO: why do both the normalize and validate functions convert
     # underscores to hyphens? Should we remove from validate locale?
-    locale = _normalize_locale(locale=locale)
-
     _validate_locale(locale=locale)
+    locale = _normalize_locale(locale=locale)
 
     return locale
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -2103,3 +2103,93 @@ def test_get_currency_str():
 def test_get_currency_str_no_match_raises():
     with pytest.raises(Exception):
         _get_currency_str("NOT_A_CURRENCY")
+
+
+@pytest.mark.parametrize(
+    "src, fn",
+    [
+        (1, "fmt_number"),
+        (2, "fmt_integer"),
+        (3, "fmt_scientific"),
+        (4, "fmt_percent"),
+        (5, "fmt_currency"),
+        (6, "fmt_bytes"),
+        ("2023-12-31", "fmt_date"),
+        ("12:34:56", "fmt_time"),
+        ("2023-12-31 12:34:56", "fmt_datetime"),
+    ],
+)
+def test_fmt_with_locale1(src, fn):
+    df = pd.DataFrame({"x": [src]})
+    global_locale = local_locale = "en"
+
+    # w/o global locale, w/o local locale => use default locale => "en"
+    gt1 = getattr(GT(df), fn)()
+    x1 = _get_column_of_values(gt1, column_name="x", context="html")
+
+    # w global locale, w/o local locale => use global locale => "en"
+    gt2 = getattr(GT(df, locale=global_locale), fn)()
+    x2 = _get_column_of_values(gt2, column_name="x", context="html")
+
+    # w/o global locale, w local locale => use local locale => "en"
+    gt3 = getattr(GT(df), fn)(locale=local_locale)
+    x3 = _get_column_of_values(gt3, column_name="x", context="html")
+
+    assert x1 == x2 == x3
+
+
+@pytest.mark.parametrize(
+    "src, fn",
+    [
+        (1, "fmt_number"),
+        (2, "fmt_integer"),
+        (3, "fmt_scientific"),
+        (4, "fmt_percent"),
+        (5, "fmt_currency"),
+        (6, "fmt_bytes"),
+        ("2023-12-31", "fmt_date"),
+        ("12:34:56", "fmt_time"),
+        ("2023-12-31 12:34:56", "fmt_datetime"),
+    ],
+)
+def test_fmt_with_locale2(src, fn):
+    df = pd.DataFrame({"x": [src]})
+    global_locale = local_locale = "ja"
+
+    # w global locale, w/o local locale => use global locale => "ja"
+    gt1 = getattr(GT(df, locale=global_locale), fn)()
+    x1 = _get_column_of_values(gt1, column_name="x", context="html")
+
+    # w/o global locale, w local locale => use local locale => "ja"
+    gt2 = getattr(GT(df), fn)(locale=local_locale)
+    x2 = _get_column_of_values(gt2, column_name="x", context="html")
+
+    assert x1 == x2
+
+
+@pytest.mark.parametrize(
+    "src, fn",
+    [
+        (1, "fmt_number"),
+        (2, "fmt_integer"),
+        (3, "fmt_scientific"),
+        (4, "fmt_percent"),
+        (5, "fmt_currency"),
+        (6, "fmt_bytes"),
+        ("2023-12-31", "fmt_date"),
+        ("12:34:56", "fmt_time"),
+        ("2023-12-31 12:34:56", "fmt_datetime"),
+    ],
+)
+def test_fmt_with_locale3(src, fn):
+    df = pd.DataFrame({"x": [src]})
+    global_locale, local_locale = "ja", "de"
+
+    # w global locale, w local locale => use local locale => "de"
+    gt = getattr(GT(df, locale=global_locale), fn)(locale=local_locale)
+    x = _get_column_of_values(gt, column_name="x", context="html")
+
+    gt_de = getattr(GT(df, locale="de"), fn)()
+    x_de = _get_column_of_values(gt_de, column_name="x", context="html")
+
+    assert x == x_de


### PR DESCRIPTION
This PR addresses a potential bug where the global `locale` setting is not respected in `GT.fmt_*()` functions that accept `locale` as a parameter.

Consider the following example:
```python
from great_tables import GT, exibble

(
    GT(exibble[["currency"]])
    .with_locale("ja")
    .fmt_currency("currency")
)
```
![image](https://github.com/user-attachments/assets/10028054-6e2c-4e1c-a14b-66080a7cc2d1)


It appears that the global `locale="ja"` setting is applied, but the output doesn't reflect this, and here’s what I expected:

![image](https://github.com/user-attachments/assets/f93a3c47-4ebd-46a8-8feb-3cb98a00c54e)

The issue seems to stem from most of the formatting functions not fetching the global `locale` correctly. The line `locale = x._locale._locale if locale is None else locale` in `_resolve_locale()` is crucial to resolving this.

Therefore, I propose applying `_resolve_locale()` at the start of these formatting functions that accept the `locale` parameter. Additionally, I suggest moving the `_validate_locale()` call before `_normalize_locale()` within `_resolve_locale()` for better logic flow.