### PR TITLE
docs: do not document GT members inline on its reference page

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - main
-      - 'docs-preview-**'
+      - "docs-preview-**"
   pull_request:
     branches:
       - main
@@ -20,6 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install ".[all]"
+          pip install git+https://github.com/machow/quartodoc.git@a98bf47004a76578e6893b4ba6d9447322137a3c
       - uses: quarto-dev/quarto-actions/setup@v2
       - name: Build docs
         run: |

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -82,7 +82,9 @@ quartodoc:
         class, we supply the input data table and some basic options for creating a stub and row
         groups (with the `rowname_col=` and `groupname_col=` arguments).
       contents:
-        - GT
+        - name: GT
+          members: []
+          
     - title: Creating or modifying parts of a table
       desc: >
         A table can contain a few useful components for conveying additional information. These

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -83,7 +83,8 @@ quartodoc:
         groups (with the `rowname_col=` and `groupname_col=` arguments).
       contents:
         - name: GT
-          members: []
+          children: linked
+          
           
     - title: Creating or modifying parts of a table
       desc: >

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -84,8 +84,8 @@ quartodoc:
       contents:
         - name: GT
           children: linked
-          
-          
+
+
     - title: Creating or modifying parts of a table
       desc: >
         A table can contain a few useful components for conveying additional information. These


### PR DESCRIPTION
This PR removes the redundant method documentation on the GT class page.