### PR TITLE
feat: allow passing a webdriver instance to save

### DIFF
--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -197,7 +197,7 @@ class _NoOpDriverCtx:
 
 def save(
     self: GT,
-    file: str,
+    file: Path | str,
     selector: str = "table",
     scale: float = 1.0,
     expand: int = 5,
@@ -279,6 +279,9 @@ def save(
 
     if selector != "table":
         raise NotImplementedError("Currently, only selector='table' is supported.")
+
+    if isinstance(file, Path):
+        file = str(file)
 
     # If there is no file extension, add the .png extension
     if not Path(file).suffix:

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -177,13 +177,31 @@ WebDrivers: TypeAlias = Literal[
 DebugDumpOptions: TypeAlias = Literal["zoom", "width_resize", "final_resize"]
 
 
+class _NoOpDriverCtx:
+    """Context manager that no-ops entering a webdriver(options=...) instance."""
+
+    def __init__(self, driver: webdriver.Remote):
+        self.driver = driver
+
+    def __call__(self, options):
+        # no-op what is otherwise instantiating webdriver with options,
+        # since a webdriver instance was already passed on init
+        return self
+
+    def __enter__(self):
+        return self.driver
+
+    def __exit__(self, *args):
+        pass
+
+
 def save(
     self: GT,
     file: str,
     selector: str = "table",
     scale: float = 1.0,
     expand: int = 5,
-    web_driver: WebDrivers = "chrome",
+    web_driver: WebDrivers | webdriver.Remote = "chrome",
     window_size: tuple[int, int] = (6000, 6000),
     debug_port: None | int = None,
     encoding: str = "utf-8",
@@ -209,9 +227,12 @@ def save(
         (NOT IMPLEMENTED) The number of pixels to expand the screenshot by.  This can be
         increased to capture more of the surrounding area, or decreased to capture less.
     web_driver
-        The webdriver to use when taking the screenshot. By default, uses Google Chrome. Supports
-        `"firefox"` (Mozilla Firefox), `"safari"` (Apple Safari), and `"edge"` (Microsoft Edge).
-        Specified browser must be installed.
+        The webdriver to use when taking the screenshot. Either a driver name, or webdriver
+        instance. By default, uses Google Chrome. Supports `"firefox"` (Mozilla Firefox), `"safari"`
+        (Apple Safari), and `"edge"` (Microsoft Edge).
+
+        Specified browser must be installed. Note that if a webdriver instance is passed, options
+        that require setting up a webdriver, like debug_port, will not be used.
     window_size
         The size of the browser window to use when laying out the table. This shouldn't be necessary
         to capture a table, but may affect the tables appearance.
@@ -267,7 +288,11 @@ def save(
     html_content = as_raw_html(self)
 
     # Set the webdriver and options based on the chosen browser (`web_driver=` argument)
-    if web_driver == "chrome":
+    if isinstance(web_driver, webdriver.Remote):
+        wdriver = _NoOpDriverCtx(web_driver)
+        wd_options = None
+
+    elif web_driver == "chrome":
         wdriver = webdriver.Chrome
         wd_options = webdriver.ChromeOptions()
     elif web_driver == "safari":
@@ -279,6 +304,8 @@ def save(
     elif web_driver == "edge":
         wdriver = webdriver.Edge
         wd_options = webdriver.EdgeOptions()
+    else:
+        raise ValueError(f"Unsupported web driver: {web_driver}")
 
     # specify headless flag ----
     if web_driver in {"firefox", "edge"}:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -44,13 +44,26 @@ def test_save_image_file(gt_tbl: GT, tmp_path):
     f_path = tmp_path / "test_image.png"
     gt_tbl.save(file=str(f_path))
 
-    time.sleep(0.1)
+    time.sleep(0.05)
     assert f_path.exists()
 
 
 def test_save_non_png(gt_tbl: GT, tmp_path):
     f_path = tmp_path / "test_image.pdf"
     gt_tbl.save(file=str(f_path))
+
+
+def test_save_custom_webdriver(gt_tbl: GT, tmp_path):
+    from selenium import webdriver
+
+    f_path = tmp_path / "test_image.png"
+    options = webdriver.ChromeOptions()
+    options.add_argument("--headless=new")
+    with webdriver.Chrome(options) as wd:
+        gt_tbl.save(file=str(f_path), web_driver=wd)
+
+    time.sleep(0.05)
+    assert f_path.exists()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
addresses #416 by allowing a webdriver instance to be passed to `save(web_driver=...)`. This also addresses #479 by coercing file=Path(...) to a string.

Note that:

* Because we do context handling when we create web drivers, I wrapped any passed web drivers in a no-op context handler.
* Some arguments (like debug_port) that require setting options do not apply when a webdriver instance is passed.