### PR TITLE
docs: update `_quarto.yml` to expose `vals.fmt_image()`

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -223,6 +223,7 @@ quartodoc:
         - vals.fmt_date
         - vals.fmt_time
         - vals.fmt_markdown
+        - vals.fmt_image
     - title: Built in datasets
       desc: >
         The **Great Tables** package is equipped with sixteen datasets that come in all shapes and


### PR DESCRIPTION
Related to #451. 

I suggest exposing `vals.fmt_image()` in the documentation.