### PR TITLE
Add `save_pdf` method that directly renders table HTML to PDF

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -208,10 +208,12 @@ quartodoc:
     - title: Export
       desc: >
         There may come a day when you need to export a table to some specific format. A great method
-        for that is `save()`, which allows us to save the table as a standalone image file. You can
-        also get the table code as an HTML fragment with the `as_raw_html()` method.
+        for that is `save()`, which allows us to save the table as a standalone image file. To render
+        to a vector graphics PDF file, use `save_pdf()`. You can also get the table code as an HTML
+        fragment with the `as_raw_html()` method.
       contents:
         - GT.save
+        - GT.save_pdf
         - GT.show
         - GT.as_raw_html
     - title: Value formatting functions

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -485,7 +485,7 @@ def save_pdf(
     -------
     We create the output file based on the HTML version of the table.
 
-    This process is facilitated by two libraries:
+    This process is facilitated by three libraries:
 
     - `weasyprint`, which renders the HTML to PDF
     - `pdfplumber`, which allows to find the area on the page occupied by the table
@@ -501,13 +501,12 @@ def save_pdf(
     ```
 
     """
-    for pkg in "weasyprint", "pdfplumber", "pypdf":
-        _try_import(name=pkg, pip_install_line=f"pip install {pkg}")
     from io import BytesIO, StringIO
     import math
-    import pdfplumber
-    import pypdf
-    import weasyprint
+
+    weasyprint = _try_import(name="weasyprint", pip_install_line="pip install weasyprint")
+    pdfplumber = _try_import(name="pdfplumber", pip_install_line="pip install pdfplumber")
+    pypdf = _try_import(name="pypdf", pip_install_line="pip install pypdf")
 
     if not isinstance(page_size, str):
         page_size = " ".join(map(str, page_size))

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -10,7 +10,7 @@ from great_tables._gt_data import GTData
 from great_tables._body import body_reassemble
 from great_tables._boxhead import cols_align, cols_label
 from great_tables._data_color import data_color
-from great_tables._export import as_raw_html, save, show
+from great_tables._export import as_raw_html, save, save_pdf, show
 from great_tables._formats import (
     fmt,
     fmt_bytes,
@@ -268,6 +268,7 @@ class GT(
     with_locale = with_locale
 
     save = save
+    save_pdf = save_pdf
     show = show
     as_raw_html = as_raw_html
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ all = [
 extra = [
     "selenium>=4.18.1",
     "Pillow>=10.2.0",
+    "weasyprint",
+    "pdfplumber",
+    "pypdf"
 ]
 
 dev = [


### PR DESCRIPTION
# Summary

Generate a real vector graphics PDF without depending on a web browser.

The `weasyprint` package is used to generate the PDF, followed by `pdfplumber` to determine the bounding box of table elements, and finally `pypdf` writes the cropped PDF.

This could also be used to replace the `save` method, e.g. using `PyMuPDF` to render the resulting PDF into a raster image. Should this be desired, `PyMuPDF` could (probably) also be used for cropping, removing the need for `pypdf`.


# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.
