### PR TITLE
Improve `GT.save()` usability

### DIFF
--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -369,6 +369,7 @@ def _save_screenshot(
 
     from PIL import Image
 
+    # convert to other formats (e.g. pdf, bmp) using PIL
     Image.open(fp=BytesIO(el.screenshot_as_png)).save(fp=path)
 
 

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -188,7 +188,6 @@ def save(
     debug_port: None | int = None,
     encoding: str = "utf-8",
     _debug_dump: DebugDumpOptions | None = None,
-    **params,
 ) -> GTSelf:
     """
     Produce a high-resolution image file or PDF of the table.
@@ -227,14 +226,6 @@ def save(
         Whether the saved image should be a big browser window, with key elements outlined. This is
         helpful for debugging this function's resizing, cropping heuristics. This is an internal
         parameter and subject to change.
-    **params
-        Additional parameters supported by
-        [Image.save()](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save)
-        in Pillow. For instance, when saving the table as a
-        [PNG](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#png), you can
-        adjust the `compress_level` to balance between speed and compression. The `compress_level`
-        ranges from 0 to 9, where 1 offers the best speed, 9 offers maximum compression, and 0
-        applies no compression. The default value is 6.
 
     Returns
     -------
@@ -286,7 +277,7 @@ def save(
         encoded = base64.b64encode(html_content.encode(encoding=encoding)).decode(encoding=encoding)
         headless_browser.get(f"data:text/html;base64,{encoded}")
 
-        _save_screenshot(headless_browser, scale, file, debug=_debug_dump, **params)
+        _save_screenshot(headless_browser, scale, file, debug=_debug_dump)
 
     if debug_port and web_driver not in {"chrome", "firefox"}:
         warnings.warn("debug_port argument only supported on chrome and firefox")
@@ -304,7 +295,7 @@ def save(
 
 
 def _save_screenshot(
-    driver: webdriver.Chrome, scale: float, path: str, debug: DebugDumpOptions | None, **params
+    driver: webdriver.Chrome, scale: float, path: str, debug: DebugDumpOptions | None
 ) -> None:
     from io import BytesIO
     from selenium.webdriver.common.by import By
@@ -378,7 +369,7 @@ def _save_screenshot(
 
     from PIL import Image
 
-    Image.open(fp=BytesIO(el.screenshot_as_png)).save(fp=path, **params)
+    Image.open(fp=BytesIO(el.screenshot_as_png)).save(fp=path)
 
 
 def _dump_debug_screenshot(driver, path):

--- a/great_tables/_utils_selenium.py
+++ b/great_tables/_utils_selenium.py
@@ -34,6 +34,8 @@ class _NoOpDriverCtx:
     ) -> bool | None:
         pass
 
+    def quit(self): ...
+
 
 class _BaseWebDriver:
 

--- a/great_tables/_utils_selenium.py
+++ b/great_tables/_utils_selenium.py
@@ -47,7 +47,7 @@ class _ChromeWebDriver(_BaseWebDriver):
 
 
 class _SafariWebDriver(_BaseWebDriver):
-    cls_driver = webdriver.Chrome
+    cls_driver = webdriver.Safari
     cls_wd_options = webdriver.SafariOptions
 
 

--- a/great_tables/_utils_selenium.py
+++ b/great_tables/_utils_selenium.py
@@ -16,8 +16,11 @@ WebDrivers: TypeAlias = Literal[
 
 class _BaseWebDriver:
 
-    def __init__(self):
+    def __init__(self, debug_port: bool):
+        self.debug_port = debug_port
+        self.wd_options = self.cls_wd_options()
         self.add_arguments()
+        self.driver = self.cls_driver(self.wd_options)
 
     def add_arguments(self): ...
 
@@ -34,11 +37,8 @@ class _BaseWebDriver:
 
 
 class _ChromeWebDriver(_BaseWebDriver):
-    def __init__(self, debug_port: int | None = None):
-        self.debug_port = debug_port
-        self.wd_options = webdriver.ChromeOptions()
-        super().__init__()
-        self.driver = webdriver.Chrome(self.wd_options)
+    cls_driver = webdriver.Chrome
+    cls_wd_options = webdriver.ChromeOptions
 
     def add_arguments(self):
         self.wd_options.add_argument("--headless=new")
@@ -47,19 +47,13 @@ class _ChromeWebDriver(_BaseWebDriver):
 
 
 class _SafariWebDriver(_BaseWebDriver):
-    def __init__(self, debug_port: int | None = None):
-        self.debug_port = debug_port
-        self.wd_options = webdriver.SafariOptions()
-        super().__init__()
-        self.driver = webdriver.Safari(self.wd_options)
+    cls_driver = webdriver.Chrome
+    cls_wd_options = webdriver.SafariOptions
 
 
 class _FirefoxWebDriver(_BaseWebDriver):
-    def __init__(self, debug_port: int | None = None):
-        self.debug_port = debug_port
-        self.wd_options = webdriver.FirefoxOptions()
-        super().__init__()
-        self.driver = webdriver.Firefox(self.wd_options)
+    cls_driver = webdriver.Firefox
+    cls_wd_options = webdriver.FirefoxOptions
 
     def add_arguments(self):
         self.wd_options.add_argument("--headless")
@@ -68,11 +62,8 @@ class _FirefoxWebDriver(_BaseWebDriver):
 
 
 class _EdgeWebDriver(_BaseWebDriver):
-    def __init__(self, debug_port: int | None = None):
-        self.debug_port = debug_port
-        self.wd_options = webdriver.EdgeOptions()
-        super().__init__()
-        self.driver = webdriver.Edge(self.wd_options)
+    cls_driver = webdriver.Edge
+    cls_wd_options = webdriver.EdgeOptions
 
     def add_arguments(self):
         self.wd_options.add_argument("--headless")

--- a/great_tables/_utils_selenium.py
+++ b/great_tables/_utils_selenium.py
@@ -1,0 +1,122 @@
+from types import TracebackType
+from typing import Literal
+from typing_extensions import TypeAlias, Self
+from selenium import webdriver
+
+# Create a list of all selenium webdrivers
+WebDrivers: TypeAlias = Literal[
+    "chrome",
+    "firefox",
+    "safari",
+    "edge",
+]
+
+
+class _NoOpDriverCtx:
+    """Context manager that no-ops entering a webdriver(options=...) instance."""
+
+    def __init__(self, driver: webdriver.Remote):
+        self.driver = driver
+
+    def __call__(self, options) -> Self:
+        # no-op what is otherwise instantiating webdriver with options,
+        # since a webdriver instance was already passed on init
+        return self
+
+    def __enter__(self) -> webdriver.Remote:
+        return self.driver
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        pass
+
+
+class _BaseWebDriver:
+
+    def __init__(self):
+        self.add_arguments()
+
+    def add_arguments(self): ...
+
+    def __enter__(self) -> WebDrivers | webdriver.Remote:
+        return self.driver
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        self.driver.quit()
+
+
+class _ChromeWebDriver(_BaseWebDriver):
+    def __init__(self, debug_port: int | None = None):
+        self.debug_port = debug_port
+        self.wd_options = webdriver.ChromeOptions()
+        super().__init__()
+        self.driver = webdriver.Chrome(self.wd_options)
+
+    def add_arguments(self):
+        self.wd_options.add_argument("--headless=new")
+        if self.debug_port is not None:
+            self.wd_options.add_argument(f"--remote-debugging-port={self.debug_port}")
+
+
+class _SafariWebDriver(_BaseWebDriver):
+    def __init__(self, debug_port: int | None = None):
+        self.debug_port = debug_port
+        self.wd_options = webdriver.SafariOptions()
+        super().__init__()
+        self.driver = webdriver.Safari(self.wd_options)
+
+
+class _FirefoxWebDriver(_BaseWebDriver):
+    def __init__(self, debug_port: int | None = None):
+        self.debug_port = debug_port
+        self.wd_options = webdriver.FirefoxOptions()
+        super().__init__()
+        self.driver = webdriver.Firefox(self.wd_options)
+
+    def add_arguments(self):
+        self.wd_options.add_argument("--headless")
+        if self.debug_port is not None:
+            self.wd_options.add_argument(f"--start-debugger-server {self.debug_port}")
+
+
+class _EdgeWebDriver(_BaseWebDriver):
+    def __init__(self, debug_port: int | None = None):
+        self.debug_port = debug_port
+        self.wd_options = webdriver.EdgeOptions()
+        super().__init__()
+        self.driver = webdriver.Edge(self.wd_options)
+
+    def add_arguments(self):
+        self.wd_options.add_argument("--headless")
+
+
+class _NoOpWebDriver(_BaseWebDriver):
+    def __init__(self, debug_port: int | None = None):
+        self.debug_port = debug_port
+        self.wd_options = None
+        super().__init__()
+        self.driver = _NoOpDriverCtx(self.wd_options)
+
+
+def _get_web_driver(web_driver: WebDrivers | webdriver.Remote):
+    if isinstance(web_driver, webdriver.Remote):
+        return _NoOpWebDriver
+    elif web_driver == "chrome":
+        return _ChromeWebDriver
+    elif web_driver == "safari":
+        return _SafariWebDriver
+    elif web_driver == "firefox":
+        return _FirefoxWebDriver
+    elif web_driver == "edge":
+        return _EdgeWebDriver
+    else:
+        raise ValueError(f"Unsupported web driver: {web_driver}")

--- a/great_tables/_utils_selenium.py
+++ b/great_tables/_utils_selenium.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from types import TracebackType
 from typing import Literal
-from typing_extensions import TypeAlias, Self
+from typing_extensions import TypeAlias
 from selenium import webdriver
 
 # Create a list of all selenium webdrivers

--- a/great_tables/_utils_selenium.py
+++ b/great_tables/_utils_selenium.py
@@ -16,7 +16,7 @@ WebDrivers: TypeAlias = Literal[
 
 class _BaseWebDriver:
 
-    def __init__(self, debug_port: bool):
+    def __init__(self, debug_port: int | None = None):
         self.debug_port = debug_port
         self.wd_options = self.cls_wd_options()
         self.add_arguments()

--- a/tests/test__utils_selenium.py
+++ b/tests/test__utils_selenium.py
@@ -1,0 +1,39 @@
+import pytest
+
+from great_tables._utils_selenium import (
+    _get_web_driver,
+    no_op_callable,
+    _ChromeWebDriver,
+    _SafariWebDriver,
+    _FirefoxWebDriver,
+    _EdgeWebDriver,
+)
+
+
+def test_no_op_callable():
+    """
+    The test should cover the scenario of obtaining a remote driver in `_get_web_driver`.
+    """
+    fake_input = object()
+    f = no_op_callable(fake_input)
+    assert f(1, x="x") is fake_input
+
+
+@pytest.mark.parametrize(
+    "web_driver,Driver",
+    [
+        ("chrome", _ChromeWebDriver),
+        ("safari", _SafariWebDriver),
+        ("firefox", _FirefoxWebDriver),
+        ("edge", _EdgeWebDriver),
+    ],
+)
+def test_get_web_driver(web_driver, Driver):
+    assert _get_web_driver(web_driver) is Driver
+
+
+def test_get_web_driver_raise():
+    fake_web_driver = "fake_web_driver"
+    with pytest.raises(ValueError) as exc_info:
+        _get_web_driver(fake_web_driver)
+        assert exc_info.value.args[0] == f"Unsupported web driver: {fake_web_driver}"


### PR DESCRIPTION
Related PR: #496.

This PR introduces several improvements to enhance the usability of `GT.save()`:

* Propose exposing `**params` to allow advanced users to customize save parameters directly via [Pillow](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save).
* Streamline the `.png` extension check to a single line.
* Construct the URL directly, similar to `FmtImage._get_image_uri()`, without using `tempfile.TemporaryDirectory()`.
* Replace the final `time.sleep(0.05)` with `WebDriverWait(driver, 1).until()` (we may need to determine the optimal timeout for most use cases).
* Remove the `.png` saving branch that relied on `selenium`; all files are now saved using `Pillow`.
* Suggest modifying `GT.save()` to return itself, allowing users to save intermediate tables. For example:
  ```python
  GT(exibble).save("initial.png").tab_header("title").save("with_title.png")
  ```

Additionally, I noticed a potential speed boost (approximately 40-50% faster on my machine) when calling `headless_browser=wdriver(options=wd_options)` directly, bypassing the context manager. However, I'm unsure about the safety implications of this approach.