### PR TITLE
Fix: `cols_width()` should exclude hidden columns

### DIFF
--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -432,6 +432,16 @@ class Boxhead(_Sequence[ColInfo]):
     def _get_column_widths(self) -> list[str | None]:
         return [x.column_width for x in self._d if x.type == ColInfoTypeEnum.default]
 
+    # Get a column width for a specific var value
+    def _get_column_width_by_var(self, var: str) -> str | None:
+
+        column_width = [x.column_width for x in self._d if x.var == var]
+
+        # Convert the single column width value in the list to a string
+        column_width = str(column_width[0])
+
+        return column_width
+
     # Get a list of visible columns
     def _get_default_columns(self) -> list[ColInfo]:
         default_columns = [x for x in self._d if x.type == ColInfoTypeEnum.default]

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -428,9 +428,9 @@ class Boxhead(_Sequence[ColInfo]):
 
         return self.__class__(out_cols)
 
-    # Get a list of column widths
+    # Get a list of visible column widths
     def _get_column_widths(self) -> list[str | None]:
-        return [x.column_width for x in self._d]
+        return [x.column_width for x in self._d if x.type == ColInfoTypeEnum.default]
 
     # Get a list of visible columns
     def _get_default_columns(self) -> list[ColInfo]:

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -719,7 +719,7 @@ def _get_table_defs(data: GTData) -> dict[str, Any]:
 
     # Get all the widths for the columns as a list where None values mean that the width is
     # not set for that column
-    # TODO: ensure that the stub column is set first in the list
+    # TODO: ensure that the stub column (if present) is included and set first in the list
     widths = data._boxhead._get_column_widths()
 
     # If all of the widths are defined as px values for all columns, then ensure that the width

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -719,8 +719,16 @@ def _get_table_defs(data: GTData) -> dict[str, Any]:
 
     # Get all the widths for the columns as a list where None values mean that the width is
     # not set for that column
-    # TODO: ensure that the stub column (if present) is included and set first in the list
     widths = data._boxhead._get_column_widths()
+
+    # Get the stub column variable
+    stub_var = data._boxhead._get_stub_column()
+
+    # If there is a stub column, then get the width for that column and insert it at the beginning
+    if stub_var is not None:
+
+        stub_width = data._boxhead._get_column_width_by_var(var=stub_var.var)
+        widths.insert(0, stub_width)
 
     # If all of the widths are defined as px values for all columns, then ensure that the width
     # values are strictly respected as absolute width values (even if table width already set)


### PR DESCRIPTION
This fixes https://github.com/posit-dev/great-tables/issues/491, and the problem is that hidden columns are included in the `<colgroup>` tag when only visible columns should be included.

With the fix, the following table renders correctly (adapted from the issue's table):

```python
from great_tables import GT, exibble

exibble_mini = exibble[["num", "char", "date", "datetime", "row"]].head(1)

exibble_mini["long_text"] = (
    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
)


tbl = (
    GT(exibble_mini)
    .cols_hide(columns="datetime")
    .cols_width(
        cases={
            "num": "50px",
            "char": "50px",
            "date": "400px",
            "row": "50px",
            "long_text": "400px",
            "datetime": "20px"}
    )
    .tab_options(
        table_body_vlines_style="solid",
        table_body_vlines_width="3px",
        table_body_vlines_color="red"
    )
)

tbl
```

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/986dc03c-dede-4271-bb0b-9a99c63d8ae2">


The colgroup here is now:

```
<colgroup>
  <col style="width:50px;"/>
  <col style="width:50px;"/>
  <col style="width:400px;"/>
  <col style="width:50px;"/>
  <col style="width:400px;"/>
</colgroup>
```

which matches the number of columns and has the correct widths for each of the columns. Including or excluding a column width definition for a hidden column in the GT code makes no difference to the final result.

There was also another bug addressed with column widths and it involves not writing a column width in `<colgroup>` for a stub column. This PR fixes that by retrieving the column width (if any) for a stub column and placing it at the beginning of the series in `<colgroup>`. Here's a revised version of the above code that uses the `"date"` column as the row label column in the stub:

```python
...

tbl = (
    GT(exibble_mini, rowname_col="date")
...
```

<img width="1052" alt="image" src="https://github.com/user-attachments/assets/4af057ad-cd6f-4398-9881-4c685dc9b27b">

Here's the resulting `<colgroup>`:

```
<colgroup>
  <col style="width:400px;"/>
  <col style="width:50px;"/>
  <col style="width:50px;"/>
  <col style="width:50px;"/>
  <col style="width:400px;"/>
</colgroup>
```

Fixes: https://github.com/posit-dev/great-tables/issues/491