### PR TITLE
Fix missing exception raise in `_val_is_numeric()` and `_val_is_str()`

### DIFF
--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -26,7 +26,7 @@ def _val_is_numeric(x: Any) -> bool:
 
     # If a list then signal a failure
     if isinstance(x, list):
-        ValueError("The input cannot be a list. It must be a single value.")
+        raise ValueError("The input cannot be a list. It must be a single value.")
 
     return isinstance(x, (int, float))
 
@@ -38,7 +38,7 @@ def _val_is_str(x: Any) -> bool:
 
     # If a list then signal a failure
     if isinstance(x, list):
-        ValueError("The input cannot be a list. It must be a single value.")
+        raise ValueError("The input cannot be a list. It must be a single value.")
 
     return isinstance(x, (str))
 

--- a/tests/test__utils_nanoplots.py
+++ b/tests/test__utils_nanoplots.py
@@ -74,7 +74,6 @@ def test_val_is_numeric():
     assert not _val_is_numeric("a")
 
 
-@pytest.mark.xfail
 def test_val_is_numeric_fails_list_input():
     with pytest.raises(ValueError):
         _val_is_numeric([1, 2, 3])
@@ -88,7 +87,6 @@ def test_val_is_str():
     assert not _val_is_str(1)
 
 
-@pytest.mark.xfail
 def test_val_is_str_fails_list_input():
     with pytest.raises(ValueError):
         _val_is_str(["a", "b", "c"])


### PR DESCRIPTION
Hello Team,  

While reviewing these two functions, I noticed that a `ValueError` exception is created but not raised.  
I suspect this might be a bug, but please feel free to correct me if this behavior is intentional.