### PR TITLE
dev: fix some `mypy` errors and switch to ruff

### DIFF
--- a/.github/scripts/no_pandas.py
+++ b/.github/scripts/no_pandas.py
@@ -1,5 +1,5 @@
 # %%
-from ast import NodeVisitor, Import, ImportFrom, alias, parse
+from ast import NodeVisitor, Import, ImportFrom, parse
 from pathlib import Path
 from os import walk
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: "(.*\\.svg)|(.*\\.qmd)|(.*\\.ambr)|(.*\\.csv)|(.*\\.txt)|(.*\\.json)"
+exclude: "(.*\\.svg)|(.*\\.qmd)|(.*\\.ambr)|(.*\\.csv)|(.*\\.txt)|(.*\\.json)|(.*\\.ipynb)"
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 exclude: "(.*\\.svg)|(.*\\.qmd)|(.*\\.ambr)|(.*\\.csv)|(.*\\.txt)|(.*\\.json)"
 repos:
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.8.0
     hooks:
-      - id: flake8
-        types:
-          - python
-        additional_dependencies:
-          - flake8-pyproject
+      # Run the linter.
+      - id: ruff
+      # Run the formatter.
+      - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
@@ -16,7 +16,3 @@ repos:
       - id: check-yaml
         args: ["--unsafe"]
       - id: check-added-large-files
-  - repo: https://github.com/psf/black
-    rev: 24.2.0
-    hooks:
-      - id: black

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,12 @@
   },
   "editor.rulers": [100],
   "[python]": {
-    "editor.defaultFormatter": "ms-python.black-formatter"
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit",
+      "source.organizeImports": "explicit"
+    },
   },
   "python.testing.pytestArgs": ["tests"],
   "python.testing.unittestEnabled": false,

--- a/great_tables/_body.py
+++ b/great_tables/_body.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING
 from ._tbl_data import copy_data
 
 if TYPE_CHECKING:
-    from ._gt_data import Body, Boxhead, RowGroups, Stub
+    from ._gt_data import Body
 
 
-def body_reassemble(body: Body, stub_df: Stub, boxhead: Boxhead) -> Body:
+def body_reassemble(body: Body) -> Body:
     # Note that this used to order the body based on groupings, but now that occurs in the
     # renderer itself.
     return body.__class__(copy_data(body.body))

--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -135,9 +135,7 @@ def cols_label(
     new_kwargs: dict[str, UnitStr | str | BaseText] = {}
 
     for k, v in new_cases.items():
-
         if isinstance(v, str):
-
             unitstr_v = UnitStr.from_str(v)
 
             if len(unitstr_v.units_str) == 1 and isinstance(unitstr_v.units_str[0], str):

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -419,7 +419,6 @@ def _html_color(colors: list[str], alpha: int | float | None = None) -> list[str
     all_hex_colors = all(_is_hex_col(colors=colors))
 
     if not all_hex_colors:
-
         # Translate named colors to hexadecimal values
         colors = _color_name_to_hex(colors=colors)
 
@@ -509,7 +508,6 @@ def _color_name_to_hex(colors: list[str]) -> list[str]:
     hex_colors: list[str] = []
 
     for color in colors:
-
         if _is_hex_col([color])[0]:
             hex_colors.append(color)
         else:

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -434,7 +434,6 @@ def save(
         tempfile.TemporaryDirectory() as tmp_dir,
         wdriver(options=wd_options) as headless_browser,
     ):
-
         # Write the HTML content to the temp file
         with open(f"{tmp_dir}/table.html", "w", encoding=encoding) as temp_file:
             temp_file.write(html_content)

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -3033,7 +3033,7 @@ def _get_locales_list() -> list[str]:
     # Get the 'locales' dataset and obtain from that a list of locales
     # TODO: remove pandas
     locales = _get_locales_data()
-    locale_list = [entry["locale"] for entry in locales]
+    locale_list: list[str] = [entry["locale"] for entry in locales]
 
     # Ensure that `locale_list` is of the type 'str'
     # TODO: we control this data and should enforce this in the data schema
@@ -4106,7 +4106,7 @@ def fmt_nanoplot(
     # For autoscale, we need to get the minimum and maximum from all values for the y-axis
     if autoscale:
 
-        from great_tables._utils_nanoplots import _flatten_list
+        from great_tables._utils import _flatten_list
 
         # TODO: if a column of delimiter separated strings is passed. E.g. "1 2 3 4". Does this mean
         # that autoscale does not work? In this case, is col_i_y_vals_raw a string that gets processed?

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -362,7 +362,6 @@ def fmt_number_context(
 
     # Use a supplied pattern specification to decorate the formatted value
     if pattern != "{x}":
-
         # Escape LaTeX special characters from literals in the pattern
         if context == "latex":
             pattern = escape_pattern_str_latex(pattern_str=pattern)
@@ -550,7 +549,6 @@ def fmt_integer_context(
 
     # Use a supplied pattern specification to decorate the formatted value
     if pattern != "{x}":
-
         # Escape LaTeX special characters from literals in the pattern
         if context == "latex":
             pattern = escape_pattern_str_latex(pattern_str=pattern)
@@ -832,7 +830,6 @@ def fmt_scientific_context(
 
     # Use a supplied pattern specification to decorate the formatted value
     if pattern != "{x}":
-
         # Escape LaTeX special characters from literals in the pattern
         if context == "latex":
             pattern = escape_pattern_str_latex(pattern_str=pattern)
@@ -1076,7 +1073,6 @@ def fmt_percent_context(
 
     # Use a supplied pattern specification to decorate the formatted value
     if pattern != "{x}":
-
         # Escape LaTeX special characters from literals in the pattern
         if context == "latex":
             pattern = escape_pattern_str_latex(pattern_str=pattern)
@@ -1341,7 +1337,6 @@ def fmt_currency_context(
 
     # Use a supplied pattern specification to decorate the formatted value
     if pattern != "{x}":
-
         # Escape LaTeX special characters from literals in the pattern
         if context == "latex":
             pattern = escape_pattern_str_latex(pattern_str=pattern)
@@ -1465,7 +1460,6 @@ def fmt_roman_context(
 
     # Use a supplied pattern specification to decorate the formatted value
     if pattern != "{x}":
-
         # Escape LaTeX special characters from literals in the pattern
         if context == "latex":
             pattern = escape_pattern_str_latex(pattern_str=pattern)
@@ -1723,7 +1717,6 @@ def fmt_bytes_context(
 
     # Use a supplied pattern specification to decorate the formatted value
     if pattern != "{x}":
-
         # Escape LaTeX special characters from literals in the pattern
         if context == "latex":
             pattern = escape_pattern_str_latex(pattern_str=pattern)
@@ -1864,7 +1857,6 @@ def fmt_date_context(
 
     # If `x` is a string, we assume it is an ISO date string and convert it to a date object
     if isinstance(x, str):
-
         # Convert the ISO date string to a date object
         x = _iso_str_to_date(x)
 
@@ -1883,7 +1875,6 @@ def fmt_date_context(
 
     # Use a supplied pattern specification to decorate the formatted value
     if pattern != "{x}":
-
         # Escape LaTeX special characters from literals in the pattern
         if context == "latex":
             pattern = escape_pattern_str_latex(pattern_str=pattern)
@@ -2012,7 +2003,6 @@ def fmt_time_context(
 
     # If `x` is a string, assume it is an ISO time string and convert it to a time object
     if isinstance(x, str):
-
         # Convert the ISO time string to a time object
         x = _iso_str_to_time(x)
 
@@ -2031,7 +2021,6 @@ def fmt_time_context(
 
     # Use a supplied pattern specification to decorate the formatted value
     if pattern != "{x}":
-
         # Escape LaTeX special characters from literals in the pattern
         if context == "latex":
             pattern = escape_pattern_str_latex(pattern_str=pattern)
@@ -2186,7 +2175,6 @@ def fmt_datetime_context(
 
     # If `x` is a string, assume it is an ISO datetime string and convert it to a datetime object
     if isinstance(x, str):
-
         # Convert the ISO datetime string to a datetime object
         x = _iso_str_to_datetime(x)
 
@@ -2205,7 +2193,6 @@ def fmt_datetime_context(
 
     # Use a supplied pattern specification to decorate the formatted value
     if pattern != "{x}":
-
         # Escape LaTeX special characters from literals in the pattern
         if context == "latex":
             pattern = escape_pattern_str_latex(pattern_str=pattern)
@@ -2293,7 +2280,6 @@ def fmt_markdown_context(
     data: GTData,
     context: str,
 ) -> str:
-
     if context == "latex":
         raise NotImplementedError("fmt_markdown() is not supported in LaTeX.")
 
@@ -2888,13 +2874,12 @@ def _has_sci_order_zero(value: int | float) -> bool:
 
 
 def _context_exp_marks(context: str) -> list[str]:
-
     if context == "html":
-        marks = [" \u00D7 10<sup style='font-size: 65%;'>", "</sup>"]
+        marks = [" \u00d7 10<sup style='font-size: 65%;'>", "</sup>"]
     elif context == "latex":
         marks = [" $\\times$ 10\\textsuperscript{", "}"]
     else:
-        marks = [" \u00D7 10^", ""]
+        marks = [" \u00d7 10^", ""]
 
     return marks
 
@@ -2917,7 +2902,6 @@ def _context_exp_str(exp_style: str) -> str:
 
 
 def _context_minus_mark(context: str) -> str:
-
     if context == "html":
         mark = "\u2212"
     else:
@@ -2927,7 +2911,6 @@ def _context_minus_mark(context: str) -> str:
 
 
 def _context_percent_mark(context: str) -> str:
-
     if context == "latex":
         mark = "\\%"
     else:
@@ -2937,7 +2920,6 @@ def _context_percent_mark(context: str) -> str:
 
 
 def _context_dollar_mark(context: str) -> str:
-
     if context == "latex":
         mark = "\\$"
     else:
@@ -3782,7 +3764,6 @@ class FmtImage:
         return span
 
     def to_latex(self, val: Any):
-
         from ._gt_data import FormatterSkipElement
         from warnings import warn
 
@@ -4086,7 +4067,6 @@ def fmt_nanoplot(
     # If a bar plot is requested and the data consists of single y values, then we need to
     # obtain a list of all single y values in the targeted column (from `columns`)
     if plot_type in ["line", "bar"] and scalar_vals:
-
         # Check each cell in the column and get each of them that contains a scalar value
         # Why are we grabbing the first element of a tuple? (Note this also happens again below.)
         all_single_y_vals = to_list(data_tbl[columns])
@@ -4105,7 +4085,6 @@ def fmt_nanoplot(
 
     # For autoscale, we need to get the minimum and maximum from all values for the y-axis
     if autoscale:
-
         from great_tables._utils import _flatten_list
 
         # TODO: if a column of delimiter separated strings is passed. E.g. "1 2 3 4". Does this mean
@@ -4119,7 +4098,6 @@ def fmt_nanoplot(
             # TODO: this dictionary handling seems redundant with _generate_data_vals dict handling?
             # Can this if-clause be removed?
             if isinstance(data_vals_i, dict):
-
                 if len(data_vals_i) == 1:
                     # If there is only one key in the dictionary, then we can assume that the
                     # dictionary deals with y-values only
@@ -4134,7 +4112,6 @@ def fmt_nanoplot(
 
             # If not a list, then convert to a list
             if not isinstance(data_vals_i, list):
-
                 data_vals_i = [data_vals_i]
 
             all_y_vals.extend(data_vals_i)
@@ -4157,7 +4134,6 @@ def fmt_nanoplot(
         all_single_y_vals: list[int | float] | None = all_single_y_vals,
         options_plots: dict[str, Any] = options_plots,
     ) -> str:
-
         if context == "latex":
             raise NotImplementedError("fmt_nanoplot() is not supported in LaTeX.")
 
@@ -4173,7 +4149,6 @@ def fmt_nanoplot(
         # TODO: where are tuples coming from? Need example / tests that induce tuples
         # If `x` is a tuple, then we have x and y values; otherwise, we only have y values
         if isinstance(x, tuple):
-
             x_vals, y_vals = x
 
             # Ensure that both objects are lists
@@ -4228,7 +4203,6 @@ def _generate_data_vals(
         data_vals = to_list(data_vals)
 
     if isinstance(data_vals, list):
-
         # If the list contains string values, determine whether they are date values
         if all(isinstance(val, str) for val in data_vals):
             if not is_x_axis:
@@ -4252,7 +4226,6 @@ def _generate_data_vals(
         return data_vals
 
     elif isinstance(data_vals, str):
-
         # If the cell value is a string, assume it is a value stream and convert to a list
 
         # Detect whether there are time values or numeric values in the string
@@ -4262,7 +4235,6 @@ def _generate_data_vals(
             data_vals = _process_number_stream(data_vals)
 
     elif isinstance(data_vals, dict):
-
         # If the cell value is a dictionary, assume it contains data values
         # This is possibly for x and for y
 
@@ -4271,17 +4243,14 @@ def _generate_data_vals(
 
         # If the dictionary contains only one key, then assume that the values are for y
         if num_keys == 1:
-
             data_vals = list(data_vals.values())[0]
 
             # The data values can be anything, so recursively call this function to process them
             data_vals = _generate_data_vals(data_vals=data_vals)
 
         if num_keys >= 2:
-
             # For two or more keys, we need to see if the 'x' and 'y' keys are present
             if "x" in data_vals and "y" in data_vals:
-
                 x_vals: Any = data_vals["x"]
                 y_vals: Any = data_vals["y"]
 

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -915,7 +915,6 @@ class FormatFns:
 
 
 class CellSubset:
-
     def resolve(self) -> list[tuple[str, int]]:
         raise NotImplementedError("Not implemented")
 

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -5,13 +5,11 @@ import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
 from enum import Enum, auto
-from typing import Any, Callable, Literal, Tuple, TypeVar, Union, overload, TYPE_CHECKING
+from typing import Any, Callable, TypeVar, overload, TYPE_CHECKING, Literal
 
-from typing_extensions import Self, TypeAlias
-from functools import partial
+from typing_extensions import Self, TypeAlias, Union
 
 # TODO: move this class somewhere else (even gt_data could work)
-from ._options import tab_options
 from ._styles import CellStyle
 from ._tbl_data import (
     DataFrameLike,
@@ -29,7 +27,7 @@ from ._text import BaseText
 from ._utils import _str_detect, OrderedSet
 
 if TYPE_CHECKING:
-    from ._helpers import Md, Html, UnitStr
+    from ._helpers import UnitStr
     from ._locations import Loc
 
 T = TypeVar("T")
@@ -38,7 +36,9 @@ T = TypeVar("T")
 # GT Data ----
 
 
-def _prep_gt(data, rowname_col, groupname_col, auto_align) -> Tuple[Stub, Boxhead, GroupRows]:
+def _prep_gt(
+    data, rowname_col: str | None, groupname_col: str | None, auto_align: bool
+) -> tuple[Stub, Boxhead]:
     # this function is similar to Stub._set_cols, except it differs in two ways.
     #   * it supports auto-alignment (an expensive operation)
     #   * it assumes its run on data initialization, whereas _set_cols may be run after
@@ -126,12 +126,12 @@ class _Sequence(Sequence[T]):
     def __getitem__(self, ii: int) -> T: ...
 
     @overload
-    def __getitem__(self, ii: slice) -> Self[T]: ...
+    def __getitem__(self, ii: slice) -> Self: ...
 
     @overload
-    def __getitem__(self, ii: list[int]) -> Self[T]: ...
+    def __getitem__(self, ii: list[int]) -> Self: ...
 
-    def __getitem__(self, ii: int | slice | list[int]) -> T | Self[T]:
+    def __getitem__(self, ii: int | slice | list[int]) -> T | Self:
         if isinstance(ii, slice):
             return self.__class__(self._d[ii])
         elif isinstance(ii, list):
@@ -139,10 +139,10 @@ class _Sequence(Sequence[T]):
 
         return self._d[ii]
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._d)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{type(self).__name__}({self._d.__repr__()})"
 
     def __eq__(self, other: Any) -> bool:
@@ -179,7 +179,7 @@ class Body:
 
         return self
 
-    def copy(self):
+    def copy(self) -> Self:
         return self.__class__(copy_data(self.body))
 
     @classmethod
@@ -190,13 +190,7 @@ class Body:
 
 
 # Boxhead ----
-
-
-class ColumnAlignment(Enum):
-    left = auto()
-    center = auto()
-    right = auto()
-    justify = auto()
+ColumnAlignment: TypeAlias = Literal["left", "center", "right", "justify"]
 
 
 class ColInfoTypeEnum(Enum):
@@ -211,7 +205,7 @@ class ColInfo:
     # TODO: Make var readonly
     var: str
     type: ColInfoTypeEnum = ColInfoTypeEnum.default
-    column_label: str | Md | Html | UnitStr | None = None
+    column_label: str | BaseText | None = None
     column_align: ColumnAlignment | None = None
     column_width: str | None = None
 
@@ -250,7 +244,7 @@ class Boxhead(_Sequence[ColInfo]):
         auto_align: bool = True,
         rowname_col: str | None = None,
         groupname_col: str | None = None,
-    ):
+    ) -> Self:
         obj = super().__new__(cls)
 
         if isinstance(data, list):
@@ -267,10 +261,16 @@ class Boxhead(_Sequence[ColInfo]):
 
         return obj
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        data: TblData | list[ColInfo],
+        auto_align: bool = True,
+        rowname_col: str | None = None,
+        groupname_col: str | None = None,
+    ):
         pass
 
-    def set_stub_cols(self, rowname_col: str | None, groupname_col: str | None):
+    def set_stub_cols(self, rowname_col: str | None, groupname_col: str | None) -> Self:
         # Note that None unsets a column
         # TODO: validate that rowname_col is in the boxhead
         if rowname_col is not None and rowname_col == groupname_col:
@@ -296,7 +296,7 @@ class Boxhead(_Sequence[ColInfo]):
 
         return self.__class__(new_cols)
 
-    def set_cols_hidden(self, colnames: list[str]):
+    def set_cols_hidden(self, colnames: list[str]) -> Self:
         # TODO: validate that colname is in the boxhead
         res: list[ColInfo] = []
         for col in self._d:
@@ -308,7 +308,7 @@ class Boxhead(_Sequence[ColInfo]):
 
         return self.__class__(res)
 
-    def align_from_data(self, data: TblData):
+    def align_from_data(self, data: TblData) -> Self:
         """Updates align attribute in entries based on data types."""
 
         # TODO: validate that data columns and ColInfo list correspond
@@ -379,8 +379,8 @@ class Boxhead(_Sequence[ColInfo]):
 
         # Set the alignment for each column in the boxhead
         new_cols: list[ColInfo] = []
-        for col, alignment in zip(self._d, align):
-            new_cols.append(replace(col, column_align=alignment))
+        for col_info, alignment in zip(self._d, align):
+            new_cols.append(replace(col_info, column_align=alignment))
 
         return self.__class__(new_cols)
 
@@ -401,11 +401,11 @@ class Boxhead(_Sequence[ColInfo]):
         return [x.var for x in self._d]
 
     # Get a list of column labels
-    def _get_column_labels(self) -> list[str | None]:
+    def _get_column_labels(self) -> list[str | BaseText | None]:
         return [x.column_label for x in self._d]
 
     # Set column label
-    def _set_column_labels(self, col_labels: dict[str, str | UnitStr | BaseText]) -> Self:
+    def _set_column_labels(self, col_labels: dict[str, str | BaseText]) -> Self:
         out_cols: list[ColInfo] = []
         for x in self._d:
             new_label = col_labels.get(x.var, None)
@@ -450,7 +450,7 @@ class Boxhead(_Sequence[ColInfo]):
         return column[0]
 
     # Get a list of visible column labels
-    def _get_default_column_labels(self) -> list[str | None]:
+    def _get_default_column_labels(self) -> list[Union[str, BaseText, None]]:
         default_column_labels = [
             x.column_label for x in self._d if x.type == ColInfoTypeEnum.default
         ]
@@ -477,9 +477,7 @@ class Boxhead(_Sequence[ColInfo]):
             raise ValueError(f"The `var` used ({var}) doesn't exist in the boxhead.")
 
         # Convert the single alignment value in the list to a string
-        alignment = str(alignment[0])
-
-        return alignment
+        return str(alignment[0])
 
     # Get the number of columns for the visible (not hidden) data; this
     # excludes the number of columns required for the table stub
@@ -560,7 +558,9 @@ class Stub:
         self.group_rows = group_rows
 
     @classmethod
-    def from_data(cls, data, rowname_col: str | None = None, groupname_col: str | None = None):
+    def from_data(
+        cls, data, rowname_col: str | None = None, groupname_col: str | None = None
+    ) -> Self:
         # Obtain a list of row indices from the data and initialize
         # the `_stub` from that
         row_indices = list(range(n_rows(data)))
@@ -589,7 +589,7 @@ class Stub:
 
     def _set_cols(
         self, data: TblData, boxhead: Boxhead, rowname_col: str | None, groupname_col: str | None
-    ) -> Tuple[Stub, Boxhead]:
+    ) -> tuple[Stub, Boxhead]:
         """Return a new Stub and Boxhead, with updated rowname and groupname columns.
 
         Note that None unsets a column.
@@ -609,7 +609,7 @@ class Stub:
 
         return self.__class__(new_rows, self.group_rows)
 
-    def order_groups(self, group_order: RowGroups):
+    def order_groups(self, group_order: RowGroups) -> Self:
         # TODO: validate
         return self.__class__(self.rows, self.group_rows.reorder(group_order))
 
@@ -743,7 +743,7 @@ class GroupRows(_Sequence[GroupRowInfo]):
 
         return self.__class__(reordered)
 
-    def indices_map(self, n: int) -> list[tuple[int, GroupRowInfo]]:
+    def indices_map(self, n: int) -> list[tuple[int, GroupRowInfo | None]]:
         """Return pairs of row index, group label for all rows in data.
 
         Note that when no groupings exist, n is used to return from range(n).
@@ -770,7 +770,7 @@ class SpannerInfo:
     vars: list[str] = field(default_factory=list)
     built: str | None = None
 
-    def built_label(self) -> str:
+    def built_label(self) -> str | BaseText | UnitStr:
         """Return a list of spanner labels that have been built."""
         label = self.built if self.built is not None else self.spanner_label
         if label is None:
@@ -832,8 +832,8 @@ class Spanners(_Sequence[SpannerInfo]):
 
 @dataclass(frozen=True)
 class Heading:
-    title: str | None = None
-    subtitle: str | None = None
+    title: str | BaseText | None = None
+    subtitle: str | BaseText | None = None
     preheader: str | list[str] | None = None
 
 

--- a/great_tables/_helpers.py
+++ b/great_tables/_helpers.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-
 import random
+import re
 import string
+from dataclasses import dataclass
 from typing import Any, Callable, Literal
 
-from typing_extensions import TypeAlias, Self
-
-from ._text import Md, Html, BaseText
-
-import re
-from dataclasses import dataclass
+from typing_extensions import Self, TypeAlias
 
 from great_tables._text import _md_html
+
+from ._text import BaseText, Html, Md
 
 FontStackName: TypeAlias = Literal[
     "system-ui",
@@ -594,7 +592,6 @@ def _get_font_stack(name: FontStackName = "system-ui", add_emoji: bool = True) -
 
 
 def _generate_tokens_list(units_notation: str) -> list[str]:
-
     # Remove any surrounding double braces before splitting the string into a list of tokens
     tokens_list = re.split(r"\s+", re.sub(r"^\{\{\s*|\s*\}\}$", "", units_notation))
 
@@ -626,7 +623,6 @@ class UnitDefinition:
 
     @classmethod
     def from_token(cls, token: str) -> UnitDefinition:
-
         unit_subscript = None
         sub_super_overstrike = False
         chemical_formula = False
@@ -635,7 +631,6 @@ class UnitDefinition:
         # Case: Chemical formula
         #   * e.g. "%C6H12O6%", where the '%' characters are used to denote a chemical formula
         if re.match(r"^%.*%$", token) and len(token) > 2:
-
             chemical_formula = True
 
             # Extract the formula w/o the surrounding `%` signs
@@ -644,7 +639,6 @@ class UnitDefinition:
         # Case: Subscript and exponent present inside square brackets, so overstriking required
         #   * e.g., 'm_[0^3]'
         elif re.search(r".+?\[_.+?\^.+?\]", token):
-
             sub_super_overstrike = True
 
             # Extract the unit w/o subscript from the string
@@ -662,7 +656,6 @@ class UnitDefinition:
         # Case: Subscript and exponent present (overstriking is *not* required here)
         #   * e.g., 'm_2^3'
         elif re.search(r".+?_.+?\^.+?", token):
-
             # Extract the unit w/o subscript from the string
             unit = re.sub(r"^(.+?)_.+?\^.+?$", r"\1", token)
 
@@ -681,7 +674,6 @@ class UnitDefinition:
         #     in the string)
         #   * e.g., 'm^2'
         elif re.search(r"\^", token):
-
             # Extract the unit w/o exponent from the string
             unit = re.sub(r"^(.+?)\^.+?$", r"\1", token)
 
@@ -693,7 +685,6 @@ class UnitDefinition:
         #     anywhere in the string)
         #   * e.g., 'm_2'
         elif re.search(r"_", token):
-
             # Extract the unit w/o subscript from the string
             unit = re.sub(r"^(.+?)_.+?$", r"\1", token)
 
@@ -792,7 +783,6 @@ class UnitDefinition:
             and units_object.unit_subscript is not None
             and units_object.exponent is not None
         ):
-
             units_str += _units_html_sub_super(
                 content_sub=_md_html(
                     _escape_html_tags(
@@ -814,7 +804,6 @@ class UnitDefinition:
         # and place all numbers (which are recognized now to be part of the chemical formula)
         # into spans that are styled to be subscripts:
         elif units_object.chemical_formula:
-
             units_str = re.sub(
                 "(\\d+)",
                 '<span style="white-space:nowrap;"><sub style="line-height:0;">\\1</sub></span>',
@@ -822,7 +811,6 @@ class UnitDefinition:
             )
 
         else:
-
             if unit_subscript is not None:
                 units_str += unit_subscript
 
@@ -840,7 +828,6 @@ class UnitStr(BaseText):
         return f"{type(self).__name__}({self.units_str})"
 
     def to_html(self) -> str:
-
         built_units = "".join(
             [
                 unit_def.to_html() if isinstance(unit_def, UnitDefinitionList) else unit_def
@@ -851,7 +838,6 @@ class UnitStr(BaseText):
         return built_units
 
     def to_latex(self) -> str:
-
         raise NotImplementedError("LaTeX conversion of units is not yet supported.")
 
     def _repr_html_(self):
@@ -862,7 +848,6 @@ class UnitStr(BaseText):
 
     @classmethod
     def from_str(cls, string: str) -> Self:
-
         # "energy ({{J m^-1}})"
         # UnitStr(["energy (", define_units("J m^-1"), ")"])
 
@@ -878,7 +863,6 @@ class UnitStr(BaseText):
         token_parts: list[str | UnitDefinitionList] = []
 
         for part in re.split(r"(\{\{.*?\}\})", string):
-
             m = re.match(r"\{\{(.*?)\}\}", part)
 
             if m:
@@ -908,7 +892,6 @@ class UnitDefinitionList:
         units_str = ""
 
         for unit_add in built_units:
-
             if re.search("\\($|\\[$", units_str) or re.search("^\\)|^\\]", unit_add):
                 spacer = ""
             else:
@@ -950,7 +933,6 @@ def _units_html_sub_super(content_sub: str, content_sup: str) -> str:
 
 
 def _replace_units_symbol(text: str, detect: str, pattern: str, replace: str) -> str:
-
     if re.search(detect, text):
         text = re.sub(pattern, replace, text)
 
@@ -958,7 +940,6 @@ def _replace_units_symbol(text: str, detect: str, pattern: str, replace: str) ->
 
 
 def _units_symbol_replacements(text: str) -> str:
-
     # Replace certain units symbols with HTML entities; these are cases where the parsed
     # text should be at the beginning of a string (or should be the entire string)
     text = _replace_units_symbol(text, "^-", "^-", "&minus;")
@@ -976,7 +957,6 @@ def _units_symbol_replacements(text: str) -> str:
 
 
 def _escape_html_tags(text: str) -> str:
-
     # Replace the '<' and '>' characters with their HTML entity equivalents
     text = text.replace("<", "&lt;")
     text = text.replace(">", "&gt;")
@@ -1003,7 +983,6 @@ UNITS_SYMBOLS_HTML = {
     ":micro:": "&micro;",
     ":ohm:": "&#8486;",
     ":angstrom:": "&#8491;",
-    ":times:": "&times;",
     ":plusminus:": "&plusmn;",
     ":permil:": "&permil;",
     ":permille:": "&permil;",
@@ -1155,7 +1134,6 @@ def define_units(units_notation: str) -> UnitDefinitionList:
 # dataclass and then pair on a post_init hook).
 # Check that certain values are either a list or a single value
 def _normalize_listable_nanoplot_options(nano_opt: Any, option_type: Any) -> list[Any] | None:
-
     if nano_opt is None:
         return None
 

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import itertools
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import singledispatch
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, Union
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from typing_extensions import TypeAlias
 
@@ -851,7 +851,7 @@ def _(loc: LocColumnLabels, data: GTData) -> list[tuple[str, int]]:
 
 
 @resolve.register
-def _(loc: LocRowGroups, data: GTData) -> set[int]:
+def _(loc: LocRowGroups, data: GTData) -> set[str]:
     # TODO: what are the rules for matching row groups?
     # TODO: resolve_rows_i will match a list expr to row names (not group names)
     group_pos = set(name for name, _ in resolve_rows_i(data, loc.rows, row_name_attr="group_id"))

--- a/great_tables/_modify_rows.py
+++ b/great_tables/_modify_rows.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, TypedDict, TypeVar, cast
+from typing import TYPE_CHECKING
 
-from ._gt_data import GTData, Locale, Options, RowGroups, Spanners, Stub, Boxhead, Styles
+from ._gt_data import Locale, RowGroups, Styles
 
 if TYPE_CHECKING:
     from ._types import GTSelf

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -1227,7 +1227,6 @@ def opt_table_font(
     res = self
 
     if font is not None:
-
         # If font is a string or GoogleFont object, convert to a list
         if isinstance(font, (str, GoogleFont)):
             font: list[str | GoogleFont] = [font]
@@ -1243,7 +1242,6 @@ def opt_table_font(
         new_font_list: list[str] = []
 
         for item in font:
-
             if isinstance(item, str):
                 # Case where list item is a string; here, it's converted to a list
                 new_font_list.append(item)
@@ -1271,7 +1269,6 @@ def opt_table_font(
         font = []
 
     if stack is not None:
-
         # Case where value is given to `stack=` and this is a keyword that returns a
         # list of fonts (i.e., the font stack); in this case we combine with `font=` values
         # (if provided) and we *always* replace the existing fonts (`add=` is ignored)
@@ -1289,9 +1286,7 @@ def opt_table_font(
     res = tab_options(res, table_font_names=combined_fonts)
 
     if weight is not None:
-
         if isinstance(weight, (int, float)):
-
             weight = str(round(weight))
 
         elif not isinstance(weight, str):
@@ -1303,7 +1298,6 @@ def opt_table_font(
         res = tab_options(res, column_labels_font_weight=weight)
 
     if style is not None:
-
         res = tab_options(res, table_font_style=style)
 
     return res

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -6,15 +6,16 @@ from typing import TYPE_CHECKING
 from ._gt_data import SpannerInfo, Spanners
 from ._locations import resolve_cols_c
 from ._tbl_data import SelectExpr
-from ._text import BaseText
+from ._text import BaseText, Text
 from ._utils import OrderedSet, _assert_list_is_subset
+from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
     from ._gt_data import Boxhead
     from ._types import GTSelf
 
 
-SpannerMatrix = "list[dict[str, str | None]]"
+SpannerMatrix: TypeAlias = list[dict[str, "str | None"]]
 
 
 def tab_spanner(
@@ -132,7 +133,7 @@ def tab_spanner(
     if id is None:
         # The label may contain HTML or Markdown, so we need to extract
         # it from the Text object
-        if isinstance(label, BaseText):
+        if isinstance(label, Text):
             id = label.text
         else:
             id = label

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -190,7 +190,6 @@ def tab_spanner(
 
     # Handle units syntax in the label (e.g., "Density ({{ppl / mi^2}})")
     if isinstance(label, str):
-
         unitstr = UnitStr.from_str(label)
 
         if len(unitstr.units_str) == 1 and isinstance(unitstr.units_str[0], str):

--- a/great_tables/_stub.py
+++ b/great_tables/_stub.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from ._gt_data import RowGroups, Stub
-from .utils_render_common import get_row_reorder_df
+from ._gt_data import Stub
 
 
 def reorder_stub_df(stub_df: Stub) -> Stub:

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -336,7 +336,6 @@ class CellStyleBorders(CellStyle):
     sides: (
         Literal["all", "top", "bottom", "left", "right"]
         | list[Literal["all", "top", "bottom", "left", "right"]]
-        | ColumnExpr
     ) = "all"
     color: str | ColumnExpr = "#000000"
     style: str | ColumnExpr = "solid"

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -228,7 +228,6 @@ class CellStyleText(CellStyle):
     ) = None
 
     def _to_html_style(self) -> str:
-
         rendered = ""
 
         if self.color:

--- a/great_tables/_tab_create_modify.py
+++ b/great_tables/_tab_create_modify.py
@@ -124,7 +124,6 @@ def tab_style(
     # 1. transform dictionary to string (with Google Font name)
     # 2. add Google Font import statement via tab_options(table_additional_css)
     if any(isinstance(s, CellStyle) for s in style):
-
         for s in style:
             if (
                 isinstance(s, CellStyle)

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -4,7 +4,7 @@ import warnings
 import re
 
 from functools import singledispatch
-from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from typing_extensions import TypeAlias
 
@@ -101,7 +101,7 @@ def _raise_pandas_required(msg: Any):
     raise ImportError(msg)
 
 
-def _re_version(raw_version: str) -> Tuple[int, int, int]:
+def _re_version(raw_version: str) -> tuple[int, int, int]:
     """Return a semver-like version string as a 3-tuple of integers.
 
     Note two important caveats: (1) separators like dev are dropped (e.g. "3.2.1dev3" -> (3, 2, 1)),
@@ -280,11 +280,13 @@ def _(data: PlDataFrame, group_key: str) -> dict[Any, list[int]]:
 # eval_select ----
 
 SelectExpr: TypeAlias = Union[
+    str,
+    list[str],
+    int,
+    list[int],
     list["str | int"],
     PlSelectExpr,
     list[PlSelectExpr],
-    str,
-    int,
     Callable[[str], bool],
     None,
 ]
@@ -515,7 +517,7 @@ def _(ser: PlSeries) -> list[Any]:
 
 @singledispatch
 def is_series(ser: Any) -> bool:
-    False
+    return False
 
 
 @is_series.register

--- a/great_tables/_text.py
+++ b/great_tables/_text.py
@@ -48,7 +48,6 @@ class Html(Text):
         return self.text
 
     def to_latex(self) -> str:
-
         from ._utils_render_latex import _not_implemented
 
         _not_implemented(
@@ -64,25 +63,21 @@ def _md_html(x: str) -> str:
 
 
 def _md_latex(x: str) -> str:
-
     # TODO: Implement commonmark to LaTeX conversion (through a different library as
     # commonmark-py does not support it)
     raise NotImplementedError("Markdown to LaTeX conversion is not supported yet")
 
 
 def _process_text(x: str | BaseText | None, context: str = "html") -> str:
-
     if x is None:
         return ""
 
     escape_fn = _html_escape if context == "html" else _latex_escape
 
     if isinstance(x, str):
-
         return escape_fn(x)
 
     elif isinstance(x, BaseText):
-
         return x.to_html() if context == "html" else x.to_latex()
 
     raise TypeError(f"Invalid type: {type(x)}")
@@ -97,7 +92,6 @@ def _html_escape(x: str) -> str:
 
 
 def _latex_escape(text: str) -> str:
-
     latex_escape_regex = "[\\\\&%$#_{}~^]"
     text = re.sub(latex_escape_regex, lambda match: "\\" + match.group(), text)
 
@@ -105,7 +99,6 @@ def _latex_escape(text: str) -> str:
 
 
 def escape_pattern_str_latex(pattern_str: str) -> str:
-
     pattern = r"(\{[x0-9]+\})"
 
     return process_string(pattern_str, pattern, _latex_escape)

--- a/great_tables/_utils.py
+++ b/great_tables/_utils.py
@@ -1,23 +1,19 @@
 from __future__ import annotations
 
-from collections.abc import Set
 import importlib
 import itertools
 import json
 import re
-from collections.abc import Generator
+from collections.abc import Generator, Set
 from types import ModuleType
-from typing import Any, Iterator, Iterable
+from typing import TYPE_CHECKING, Any, Iterable, Iterator
 
-
-from ._tbl_data import PdDataFrame, _set_cell, _get_cell, get_column_names, n_rows
-from ._text import _process_text, BaseText
-
-from typing import TYPE_CHECKING
+from ._tbl_data import PdDataFrame, _get_cell, _set_cell, get_column_names, n_rows
+from ._text import BaseText, _process_text
 
 if TYPE_CHECKING:
-    from great_tables._tbl_data import TblData
     from great_tables._gt_data import FormatInfo, GTData
+    from great_tables._tbl_data import TblData
 
 
 def _try_import(name: str, pip_install_line: str | None = None) -> ModuleType:
@@ -131,34 +127,6 @@ def _as_css_font_family_attr(fonts: list[str], value_only: bool = False) -> str:
         return fonts_str
 
     return f"font-family: {fonts_str};"
-
-
-def _object_as_dict(v: Any) -> Any:
-    try:
-        return v.object_as_dict()
-    except Exception:
-        pass
-    if isinstance(v, PdDataFrame):
-        return v.to_dict()
-    if isinstance(v, (tuple, list)):
-        return list(_object_as_dict(i) for i in v)
-    if isinstance(v, dict):
-        return dict((k, _object_as_dict(val)) for (k, val) in v.items())
-    if type(v) == type(_object_as_dict):  # FIXME figure out how to get "function"
-        return f"<function {v.__name__}>"
-    try:
-        d = vars(v)
-    except TypeError:
-        try:
-            json.dumps(v)
-        except TypeError:
-            return "JSON_UNSERIALIZABLE"
-        return v
-    return dict((k, _object_as_dict(v)) for (k, v) in d.items())
-
-
-def prettify_gt_object(v: Any) -> str:
-    return json.dumps(_object_as_dict(v), indent=2)
 
 
 def _collapse_list_elements(lst: list[Any], separator: str = "") -> str:
@@ -299,7 +267,6 @@ def _migrate_unformatted_to_output(
     # in the future)
 
     for col, row in all_unformatted_cells:
-
         # Get the cell value and cast as string
         cell_value = _get_cell(data_tbl, row, col)
         cell_value_str = str(cell_value)

--- a/great_tables/_utils.py
+++ b/great_tables/_utils.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import importlib
 import itertools
-import json
 import re
 from collections.abc import Generator, Set
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Iterable, Iterator
 
-from ._tbl_data import PdDataFrame, _get_cell, _set_cell, get_column_names, n_rows
+from ._tbl_data import _get_cell, _set_cell, get_column_names, n_rows
 from ._text import BaseText, _process_text
 
 if TYPE_CHECKING:

--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -124,7 +124,6 @@ def _format_number_compactly(
     from great_tables.vals import fmt_currency, fmt_scientific, fmt_integer, fmt_number
 
     if fn is not None and isinstance(fn, Callable):
-
         res = fn(val)
 
         # Check whether the result is a single string value; if not, raise an error
@@ -140,7 +139,6 @@ def _format_number_compactly(
         return "0"
 
     if abs(val) < 0.01:
-
         use_subunits = True
         decimals = None
 
@@ -148,7 +146,6 @@ def _format_number_compactly(
         compact = False
 
     elif abs(val) < 1:
-
         use_subunits = True
         decimals = None
 
@@ -156,7 +153,6 @@ def _format_number_compactly(
         compact = False
 
     elif abs(val) < 100:
-
         use_subunits = True
         decimals = None
 
@@ -164,7 +160,6 @@ def _format_number_compactly(
         compact = False
 
     elif abs(val) < 1000:
-
         use_subunits = True
         decimals = None
 
@@ -172,7 +167,6 @@ def _format_number_compactly(
         compact = False
 
     elif abs(val) < 10000:
-
         use_subunits = False
         decimals = 2
 
@@ -180,7 +174,6 @@ def _format_number_compactly(
         compact = True
 
     elif abs(val) < 100000:
-
         use_subunits = False
         decimals = 1
 
@@ -188,7 +181,6 @@ def _format_number_compactly(
         compact = True
 
     elif abs(val) < 1000000:
-
         use_subunits = False
         decimals = 0
 
@@ -196,7 +188,6 @@ def _format_number_compactly(
         compact = True
 
     elif abs(val) < 1e15:
-
         use_subunits = False
         decimals = 1
 
@@ -204,7 +195,6 @@ def _format_number_compactly(
         compact = True
 
     else:
-
         use_subunits = False
         decimals = None
         n_sigfig = 2
@@ -213,9 +203,7 @@ def _format_number_compactly(
     # Format value accordingly
 
     if currency is not None:
-
         if abs(val) >= 1e15:
-
             val_formatted = fmt_currency(
                 1e15,
                 currency=currency,
@@ -227,7 +215,6 @@ def _format_number_compactly(
             val_formatted = f">{val_formatted}"
 
         else:
-
             val_formatted = fmt_currency(
                 val,
                 currency=currency,
@@ -237,9 +224,7 @@ def _format_number_compactly(
             )
 
     else:
-
         if abs(val) < 0.01 or abs(val) >= 1e15:
-
             val_formatted = fmt_scientific(
                 val,
                 exp_style="E",
@@ -248,13 +233,10 @@ def _format_number_compactly(
             )
 
         else:
-
             if as_integer and val > -100 and val < 100:
-
                 val_formatted = fmt_integer(val)
 
             else:
-
                 val_formatted = fmt_number(
                     val,
                     n_sigfig=n_sigfig,
@@ -627,7 +609,6 @@ def _generate_nanoplot(
 
     # Handle case where `x_vals` exists (i.e., is not `NULL`)
     if x_vals is not None:
-
         # If the number of `x` values is zero or an empty string,
         # return an empty string
         if len(x_vals) == 0:
@@ -695,7 +676,6 @@ def _generate_nanoplot(
     # If `y_vals` is a scalar value we requested a 'line' or 'bar' plot, then
     # reset several parameters
     if isinstance(y_vals, (int, float)) and plot_type in ["line", "bar"]:
-
         single_horizontal_plot = True
         show_data_points = True
         show_data_line = True
@@ -709,7 +689,6 @@ def _generate_nanoplot(
 
     # If this is a box plot, set several parameters
     if plot_type == "boxplot":
-
         show_data_points = False
         show_data_line = False
         show_data_area = False
@@ -727,7 +706,6 @@ def _generate_nanoplot(
 
     # Handle cases where collection of `y_vals` is invariant
     if y_scale_min == y_scale_max and expand_y is None:
-
         if y_scale_min == 0:
             expand_y_dist = 5
         else:
@@ -793,7 +771,6 @@ def _generate_nanoplot(
     #
 
     if show_reference_line and show_reference_area:
-
         # Case where there is both a reference line and a reference area
 
         #
@@ -846,7 +823,6 @@ def _generate_nanoplot(
         data_y_ref_area_u = safe_y_d + ((1 - y_proportions_ref_area_u) * data_y_height)
 
     elif show_reference_line:
-
         # Case where there is a reference line
 
         if (
@@ -876,7 +852,6 @@ def _generate_nanoplot(
         data_y_ref_line = safe_y_d + ((1 - y_proportion_ref_line) * data_y_height)
 
     elif show_reference_area:
-
         # Case where there is a reference area
 
         # Note if y_ref_area were None, we would not be in this clause
@@ -913,7 +888,6 @@ def _generate_nanoplot(
         data_y_ref_area_u = safe_y_d + ((1 - y_proportions_ref_area_u) * data_y_height)
 
     else:
-
         # Case where there is no reference line or reference area
 
         # Recompute the `y` scale min and max values
@@ -938,9 +912,7 @@ def _generate_nanoplot(
     # there are no x values, generate equally-spaced x values according
     # to the number of y values
     if plot_type == "line" and x_vals is not None:
-
         if expand_x is not None and _val_is_str(expand_x):
-
             # TODO: the line below lacked tests, and called non-existent methods.
             # replace with something that doesn't use pandas and returns the correct thing.
 
@@ -1018,18 +990,15 @@ def _generate_nanoplot(
     #
 
     if plot_type == "line" and show_data_line and data_line_type == "curved":
-
         data_path_tags = []
 
         for i in range(n_segments):
-
             curve_x = data_x_points[start_data_y_points[i] : end_data_y_points[i]]
             curve_y = data_y_points[start_data_y_points[i] : end_data_y_points[i]]
 
             curved_path_string = [f"M {curve_x[0]},{curve_y[0]}"]
 
             for j in range(1, len(curve_x)):
-
                 point_b1 = f"{curve_x[j - 1] + x_d / 2},{curve_y[j - 1]}"
                 point_b2 = f"{curve_x[j] - x_d / 2},{curve_y[j]}"
                 point_i = f"{curve_x[j]},{curve_y[j]}"
@@ -1047,11 +1016,9 @@ def _generate_nanoplot(
         data_path_tags = "\n".join(data_path_tags)
 
     if plot_type == "line" and show_data_line and data_line_type == "straight":
-
         data_path_tags = []
 
         for i in range(n_segments):
-
             line_x = data_x_points[start_data_y_points[i] : end_data_y_points[i]]
             line_y = data_y_points[start_data_y_points[i] : end_data_y_points[i]]
 
@@ -1068,20 +1035,16 @@ def _generate_nanoplot(
     #
 
     if plot_type == "line" and show_data_points:
-
         circle_strings = []
 
         for i, _ in enumerate(data_x_points):
-
             data_point_radius_i = data_point_radius[i]
             data_point_stroke_color_i = data_point_stroke_color[i]
             data_point_stroke_width_i = data_point_stroke_width[i]
             data_point_fill_color_i = data_point_fill_color[i]
 
             if data_y_points[i] is None:
-
                 if missing_vals == "marker":
-
                     # Create a symbol that should denote that a missing value is present
                     circle_strings_i = f'<circle cx="{data_x_points[i]}" cy="{safe_y_d + (data_y_height / 2)}" r="{data_point_radius_i + (data_point_radius_i / 2)}" stroke="red" stroke-width="{data_point_stroke_width_i}" fill="white"></circle>'
 
@@ -1100,20 +1063,16 @@ def _generate_nanoplot(
     #
 
     if plot_type == "bar" and single_horizontal_plot is False:
-
         bar_strings = []
 
         for i, _ in enumerate(data_x_points):
-
             data_point_radius_i = data_point_radius[i]
             data_bar_stroke_color_i = data_bar_stroke_color[i]
             data_bar_stroke_width_i = data_bar_stroke_width[i]
             data_bar_fill_color_i = data_bar_fill_color[i]
 
             if data_y_points[i] is None:
-
                 if missing_vals == "marker":
-
                     # Create a symbol that should denote that a missing value is present
                     bar_strings_i = f'<circle cx="{data_x_points[i]}" cy="{safe_y_d + (data_y_height / 2)}" r="{data_point_radius_i + (data_point_radius_i / 2)}" stroke="red" stroke-width="{data_bar_stroke_width_i}" fill="transparent"></circle>'
 
@@ -1121,9 +1080,7 @@ def _generate_nanoplot(
                     continue
 
             else:
-
                 if y_vals[i] < 0:
-
                     y_value_i = data_y0_point
                     y_height = data_y_points[i] - data_y0_point
                     data_bar_stroke_color_i = data_bar_negative_stroke_color
@@ -1131,12 +1088,10 @@ def _generate_nanoplot(
                     data_bar_fill_color_i = data_bar_negative_fill_color
 
                 elif y_vals[i] > 0:
-
                     y_value_i = data_y_points[i]
                     y_height = data_y0_point - data_y_points[i]
 
                 elif y_vals[i] == 0:
-
                     y_value_i = data_y0_point - 1
                     y_height = 2
                     data_bar_stroke_color_i = "#808080"
@@ -1154,7 +1109,6 @@ def _generate_nanoplot(
     #
 
     if plot_type == "bar" and single_horizontal_plot:
-
         # This type of display assumes there is only a single `y` value and there
         # are possibly several such horizontal bars across different rows that
         # need to be on a common scale
@@ -1162,14 +1116,12 @@ def _generate_nanoplot(
         bar_thickness = data_point_radius[0] * 4
 
         if all(val == 0 for val in all_single_y_vals):
-
             # Handle case where all values across rows are `0`
 
             y_proportion = 0.5
             y_proportion_zero = 0.5
 
         else:
-
             # Scale to proportional values
             y_proportions_list = _normalize_to_dict(val=y_vals, all_vals=all_single_y_vals, zero=0)
 
@@ -1180,7 +1132,6 @@ def _generate_nanoplot(
         y_width = y_proportion * data_x_width
 
         if y_vals[0] < 0:
-
             data_bar_stroke_color = data_bar_negative_stroke_color
             data_bar_stroke_width = data_bar_negative_stroke_width
             data_bar_fill_color = data_bar_negative_fill_color
@@ -1189,7 +1140,6 @@ def _generate_nanoplot(
             rect_width = y0_width - y_width
 
         elif y_vals[0] > 0:
-
             data_bar_stroke_color = data_bar_stroke_color[0]
             data_bar_stroke_width = data_bar_stroke_width[0]
             data_bar_fill_color = data_bar_fill_color[0]
@@ -1198,7 +1148,6 @@ def _generate_nanoplot(
             rect_width = y_width - y0_width
 
         elif y_vals[0] == 0:
-
             data_bar_stroke_color = "#808080"
             data_bar_stroke_width = 4
             data_bar_fill_color = "#808080"
@@ -1214,22 +1163,17 @@ def _generate_nanoplot(
         rect_strings = f'<rect x="0" y="{bottom_y / 2 - bar_thickness / 2}" width="600" height="{bar_thickness}" stroke="transparent" stroke-width="{vertical_guide_stroke_width}" fill="transparent"></rect>'
 
         if y_vals[0] > 0:
-
             text_strings = f'<text x="{y0_width + 10}" y="{safe_y_d + 10}" fill="transparent" stroke="transparent" font-size="30px">{y_value}</text>'
 
         elif y_vals[0] < 0:
-
             text_strings = f'<text x="{y0_width - 10}" y="{safe_y_d + 10}" fill="transparent" stroke="transparent" font-size="30px" text-anchor="end">{y_value}</text>'
 
         elif y_vals[0] == 0:
-
             if all(val == 0 for val in all_single_y_vals):
-
                 text_anchor = "start"
                 x_position_text = y0_width + 10
 
             elif all(val < 0 for val in all_single_y_vals):
-
                 text_anchor = "end"
                 x_position_text = y0_width - 10
 
@@ -1255,7 +1199,6 @@ def _generate_nanoplot(
 
     # TODO: Make this a line with a single point
     if plot_type == "line" and single_horizontal_plot:
-
         # This type of display assumes there is only a single `y` value and there
         # are possibly several such horizontal bars across different rows that
         # need to be on a common scale
@@ -1268,14 +1211,12 @@ def _generate_nanoplot(
         bar_thickness = data_point_radius[0] * 4
 
         if all(val == 0 for val in all_single_y_vals):
-
             # Handle case where all values across rows are `0`
 
             y_proportion = 0.5
             y_proportion_zero = 0.5
 
         else:
-
             # Scale to proportional values
             y_proportions_list = _normalize_to_dict(val=y_vals, all_vals=all_single_y_vals, zero=0)
 
@@ -1286,21 +1227,18 @@ def _generate_nanoplot(
         y_width = y_proportion * data_x_width
 
         if y_vals[0] < 0:
-
             x1_val = y_width
             x2_val = y0_width
 
             circle_x_val = x1_val
 
         elif y_vals[0] > 0:
-
             x1_val = y0_width
             x2_val = y_width
 
             circle_x_val = x2_val
 
         elif y_vals[0] == 0:
-
             x1_val = y_width
             x2_val = y0_width
 
@@ -1314,22 +1252,17 @@ def _generate_nanoplot(
         rect_strings = f'<rect x="0" y="{bottom_y / 2 - bar_thickness / 2}" width="600" height="{bar_thickness}" stroke="transparent" stroke-width="{vertical_guide_stroke_width}" fill="transparent"></rect>'
 
         if y_vals[0] > 0:
-
             text_strings = f'<text x="{y0_width + 10}" y="{safe_y_d + 10}" fill="transparent" stroke="transparent" font-size="30px">{y_value}</text>'
 
         elif y_vals[0] < 0:
-
             text_strings = f'<text x="{y0_width - 10}" y="{safe_y_d + 10}" fill="transparent" stroke="transparent" font-size="30px" text-anchor="end">{y_value}</text>'
 
         elif y_vals[0] == 0:
-
             if all(val == 0 for val in all_single_y_vals):
-
                 text_anchor = "start"
                 x_position_text = y0_width + 10
 
             elif all(val < 0 for val in all_single_y_vals):
-
                 text_anchor = "end"
                 x_position_text = y0_width - 10
 
@@ -1363,7 +1296,6 @@ def _generate_nanoplot(
     #
 
     if plot_type == "bar" and single_horizontal_plot is False:
-
         zero_line_tags = f'<line x1="{data_x_points[0] - 27.5}" y1="{data_y0_point}" x2="{data_x_points[-1] + 27.5}" y2="{data_y0_point}" stroke="{zero_line_stroke_color}" stroke-width="{zero_line_stroke_width}"></line>'
 
     #
@@ -1371,7 +1303,6 @@ def _generate_nanoplot(
     #
 
     if show_reference_line:
-
         stroke = reference_line_color
         stroke_width = 1
         stroke_dasharray = "4 3"
@@ -1391,7 +1322,6 @@ def _generate_nanoplot(
     #
 
     if show_reference_area:
-
         fill = reference_area_fill_color
 
         p_ul = f"{data_x_points[0]},{data_y_ref_area_u}"
@@ -1452,7 +1382,6 @@ def _generate_nanoplot(
         g_guide_strings = []
 
         for i, _ in enumerate(data_x_points):
-
             rect_strings_i = f'<rect x="{data_x_points[i] - 10}" y="{top_y}" width="20" height="{bottom_y}" stroke="transparent" stroke-width="{vertical_guide_stroke_width}" fill="transparent"></rect>'
 
             # Format value in a compact manner
@@ -1492,18 +1421,15 @@ def _generate_nanoplot(
     )
 
     if plot_type == "line" and show_data_area:
-
         area_path_tags = []
 
         for i in range(n_segments):
-
             area_x = data_x_points[start_data_y_points[i] : end_data_y_points[i]]
             area_y = data_y_points[start_data_y_points[i] : end_data_y_points[i]]
 
             area_path_string = []
 
             for j in range(0, len(area_x)):
-
                 area_path_j = f"{area_x[j]},{area_y[j]}"
                 area_path_string.append(area_path_j)
 

--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -4,7 +4,7 @@ from typing import Any, Callable
 
 import numpy as np
 from great_tables._tbl_data import Agnostic, is_na
-from great_tables._utils import _match_arg
+from great_tables._utils import _match_arg, _flatten_list
 
 REFERENCE_LINE_KEYWORDS = ["mean", "median", "min", "max", "q1", "q3"]
 
@@ -102,7 +102,7 @@ def _normalize_option_list(option_list: Any | list[Any], num_y_vals: int) -> lis
     return option_list
 
 
-def calc_ref_value(val_or_calc: "int | float | str", data) -> int | float:
+def calc_ref_value(val_or_calc: int | float | str, data) -> int | float | str:
     if _val_is_numeric(val_or_calc):
         return val_or_calc
     elif _val_is_str(val_or_calc) and val_or_calc in REFERENCE_LINE_KEYWORDS:
@@ -341,20 +341,6 @@ def _gt_q3(x: list[int | float]) -> float:
     Calculate the third quartile of a list of values.
     """
     return _gt_quantile(x, 0.75)
-
-
-def _flatten_list(x: list[Any]) -> list[int] | list[float] | list[int | float]:
-    """
-    Flatten a list of values.
-    """
-
-    flat_list = []
-    for element in x:
-        if isinstance(element, list):
-            flat_list.extend(_flatten_list(element))
-        else:
-            flat_list.append(element)
-    return flat_list
 
 
 def _get_extreme_value(

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from itertools import chain, groupby
-from math import isnan
+from itertools import chain
 from typing import Any, cast
 
 from great_tables._spanners import spanners_print_matrix
 from htmltools import HTML, TagList, css, tags
 
 from ._gt_data import GTData, Styles, GroupRowInfo
-from ._tbl_data import _get_cell, cast_frame_to_string, n_rows, replace_null_frame
+from ._tbl_data import _get_cell, cast_frame_to_string, replace_null_frame
 from ._text import _process_text, _process_text_id
 from ._utils import heading_has_subtitle, heading_has_title, seq_groups
 from . import _locations as loc
@@ -21,7 +20,7 @@ def _is_loc(loc: str | loc.Loc, cls: type[loc.Loc]):
     return isinstance(loc, cls)
 
 
-def _flatten_styles(styles: Styles, wrap: bool = False) -> str:
+def _flatten_styles(styles: Styles, wrap: bool = False) -> str | None:
     # flatten all StyleInfo.styles lists
     style_entries = list(chain(*[x.styles for x in styles]))
     rendered_styles = [el._to_html_style() for el in style_entries]

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from itertools import chain
 from typing import Any, cast
 
-from great_tables._spanners import spanners_print_matrix
 from htmltools import HTML, TagList, css, tags
 
-from ._gt_data import GTData, Styles, GroupRowInfo
+from . import _locations as loc
+from ._gt_data import GroupRowInfo, GTData, Styles
+from ._spanners import spanners_print_matrix
 from ._tbl_data import _get_cell, cast_frame_to_string, replace_null_frame
 from ._text import _process_text, _process_text_id
 from ._utils import heading_has_subtitle, heading_has_title, seq_groups
-from . import _locations as loc
 
 
 def _is_loc(loc: str | loc.Loc, cls: type[loc.Loc]):
@@ -457,7 +457,6 @@ def create_body_component_h(data: GTData) -> str:
     ordered_index: list[tuple[int, GroupRowInfo]] = data._stub.group_indices_map()
 
     for i, group_info in ordered_index:
-
         # For table striping we want to add a striping CSS class to the even-numbered
         # rows in the rendered table; to target these rows, determine if `i` in the current
         # row render is an odd number
@@ -510,7 +509,6 @@ def create_body_component_h(data: GTData) -> str:
             _body_styles = [x for x in styles_cells if x.rownum == i and x.colname == colinfo.var]
 
             if is_stub_cell:
-
                 el_name = "th"
 
                 classes = ["gt_row", "gt_left", "gt_stub"]
@@ -521,7 +519,6 @@ def create_body_component_h(data: GTData) -> str:
                     classes.append("gt_striped")
 
             else:
-
                 el_name = "td"
 
                 classes = ["gt_row", f"gt_{cell_alignment}"]

--- a/great_tables/_utils_render_latex.py
+++ b/great_tables/_utils_render_latex.py
@@ -27,24 +27,20 @@ LENGTH_TRANSLATIONS_TO_PX = {
 
 
 def _not_implemented(msg: str) -> None:
-
     warnings.warn(msg)
 
 
 def is_css_length_string(x: str) -> bool:
-
     # This checks if there is a number followed by an optional string (only of letters)
     return re.match(r"^[0-9.]+[a-zA-Z]*$", x) is not None
 
 
 def is_number_without_units(x: str) -> bool:
-
     # This check if the string is a number without any text
     return re.match(r"^[0-9.]+$", x) is not None
 
 
 def css_length_has_supported_units(x: str, no_units_valid: bool = True) -> bool:
-
     # Check if the the string is a valid CSS length string with a text string
 
     if not is_css_length_string(x):
@@ -60,7 +56,6 @@ def css_length_has_supported_units(x: str, no_units_valid: bool = True) -> bool:
 
 
 def get_units_from_length_string(length: str) -> str:
-
     # Extract the units from a string that is likely in the form of '123px' or '3.23in' in
     # order to return 'px' or 'in' respectively; we'll also need to trim any whitespace and
     # convert the string to lowercase
@@ -73,7 +68,6 @@ def get_units_from_length_string(length: str) -> str:
 
 
 def get_px_conversion(length: str) -> float:
-
     input_units = get_units_from_length_string(length)
 
     if input_units == "px":
@@ -88,7 +82,6 @@ def get_px_conversion(length: str) -> float:
 
 
 def convert_to_px(length: str) -> float:
-
     # Extract the units from a string that is likely in the form of '123px' or '3.23in'
     units = get_units_from_length_string(length=length)
 
@@ -108,14 +101,12 @@ def convert_to_px(length: str) -> float:
 
 
 def convert_to_pt(x: str) -> float:
-
     px_value = convert_to_px(x)
 
     return px_value * 3 / 4
 
 
 def latex_heading_row(content: list[str]) -> str:
-
     return "".join([" & ".join(content) + " \\\\ \n", "\\midrule\\addlinespace[2.5pt]"])
 
 
@@ -144,11 +135,9 @@ def create_table_start_l(data: GTData, use_longtable: bool) -> str:
     source_notes = data._source_notes
 
     if len(source_notes) > 0:
-
         longtable_post_length = "\\setlength{\\LTpost}{0mm}\n"
 
     else:
-
         longtable_post_length = ""
 
     # Get the column alignments for the visible columns as a list of `col_defs`
@@ -168,12 +157,10 @@ def create_table_start_l(data: GTData, use_longtable: bool) -> str:
     hdr_tabular = ""
 
     if not use_longtable:
-
         # we need to use the extracolsep here for tabular* regardless of width
         extra_sep = "@{\\extracolsep{\\fill}}"
 
         if table_width.endswith("%"):
-
             tw = float(table_width.replace("%", ""))
 
             tw_frac = tw / 100
@@ -181,12 +168,10 @@ def create_table_start_l(data: GTData, use_longtable: bool) -> str:
             hdr_tabular = f"\\begin{{tabular*}}{{{tw_frac}\\linewidth}}{{"
 
         elif table_width.endswith("px"):
-
             width_in_pt = convert_to_pt(table_width)
             hdr_tabular = f"\\begin{{tabular*}}{{{width_in_pt}pt}}{{"
 
         else:
-
             hdr_tabular = "\\begin{tabular*}{\\linewidth}{"
 
     # Generate setup statements for table including default left
@@ -241,7 +226,6 @@ def create_heading_component_l(data: GTData, use_longtable: bool) -> str:
     has_subtitle = heading_has_subtitle(subtitle)
 
     if has_subtitle:
-
         subtitle_str = _process_text(subtitle, context="latex")
 
         subtitle_row = f"{{\\small {subtitle_str}}}"
@@ -252,7 +236,6 @@ def create_heading_component_l(data: GTData, use_longtable: bool) -> str:
 }} {line_continuation if use_longtable else ""}"""
 
     else:
-
         header_component = f"""\\caption*{{
 {title_row}
 }} {line_continuation if use_longtable else ""}"""
@@ -290,7 +273,6 @@ def create_columns_component_l(data: GTData) -> str:
     table_col_headings = "".join(latex_heading_row(content=headings_labels))
 
     if spanner_row_count > 0:
-
         boxhead = data._boxhead
 
         table_col_spanners = []
@@ -315,7 +297,6 @@ def create_columns_component_l(data: GTData) -> str:
         # )
 
         for i in range(len(spanners)):
-
             spanners_row = spanners[i]
 
             for k, v in spanners_row.items():
@@ -331,7 +312,6 @@ def create_columns_component_l(data: GTData) -> str:
 
             for colspan, span_label in zip(colspans, spanners_row.values()):
                 if colspan > 0:
-
                     if span_label:
                         span = _process_text(span_label, context="latex")
 
@@ -345,15 +325,12 @@ def create_columns_component_l(data: GTData) -> str:
             span_accumlator = 0
 
             for j, _ in enumerate(level_i_spanners):
-
                 if level_i_spanners[j] is None:
-
                     # Get the number of columns to span nothing
                     span = group_spans[j][0]
                     spanner_labs.append("" * span)
 
                 elif level_i_spanners[j] is not None:
-
                     # Get the number of columns to span the spanner
                     span = group_spans[j][0]
 
@@ -388,7 +365,6 @@ def create_columns_component_l(data: GTData) -> str:
         table_col_spanners = "".join(table_col_spanners)
 
     else:
-
         table_col_spanners = ""
 
     columns_component = "\\toprule\n" + table_col_spanners + table_col_headings
@@ -425,7 +401,6 @@ def create_body_component_l(data: GTData) -> str:
     ordered_index: list[tuple[int, GroupRowInfo | None]] = data._stub.group_indices_map()
 
     for i, _ in ordered_index:
-
         body_cells: list[str] = []
 
         # Create a body row
@@ -511,7 +486,6 @@ def create_table_end_l(use_longtable: bool) -> str:
 
 
 def derive_table_width_statement_l(data: GTData, use_longtable: bool) -> str:
-
     # Get the table width value
     tbl_width = data._options.table_width.value
 
@@ -520,11 +494,9 @@ def derive_table_width_statement_l(data: GTData, use_longtable: bool) -> str:
 
     # Bookends are not required if a table width is not specified or if using floating table
     if tbl_width == "auto" or not use_longtable:
-
         statement = ""
 
     elif tbl_width.endswith("%"):
-
         tw = float(tbl_width.strip("%"))
 
         side_width = (100 - tw) / 200
@@ -533,7 +505,6 @@ def derive_table_width_statement_l(data: GTData, use_longtable: bool) -> str:
         statement = "\n".join([f"\\setlength\\{side}{{{side_width}\\linewidth}}" for side in sides])
 
     else:
-
         width_in_pt = convert_to_pt(tbl_width)
 
         halfwidth_in_pt = f"{width_in_pt / 2:.6f}".rstrip("0").rstrip(".")
@@ -547,23 +518,19 @@ def derive_table_width_statement_l(data: GTData, use_longtable: bool) -> str:
 
 
 def create_fontsize_statement_l(data: GTData) -> str:
-
     table_font_size = data._options.table_font_size.value
 
     fs_fmt = "\\fontsize{%3.1fpt}{%3.1fpt}\\selectfont\n"
 
     if table_font_size.endswith("%"):
-
         multiple = float(table_font_size.strip("%")) / 100
         fs_statement = fs_fmt % (multiple * 12, multiple * 12 * 1.2)
 
     elif table_font_size.endswith("pt"):
-
         size_in_pt = float(table_font_size[:-2])
         fs_statement = fs_fmt % (size_in_pt, size_in_pt * 1.2)
 
     elif css_length_has_supported_units(table_font_size):
-
         size_in_pt = convert_to_px(table_font_size) * 0.75
         fs_statement = fs_fmt % (size_in_pt, size_in_pt * 1.2)
 
@@ -574,7 +541,6 @@ def create_fontsize_statement_l(data: GTData) -> str:
 
 
 def create_wrap_start_l(use_longtable: bool, tbl_pos: str | None) -> str:
-
     if is_quarto_render():
         tbl_pos = ""
 
@@ -591,14 +557,12 @@ def create_wrap_start_l(use_longtable: bool, tbl_pos: str | None) -> str:
 
 
 def create_wrap_end_l(use_longtable: bool) -> str:
-
     wrap_end = "\\endgroup" if use_longtable else "\\end{table}"
 
     return wrap_end
 
 
 def _render_as_latex(data: GTData, use_longtable: bool = False, tbl_pos: str | None = None) -> str:
-
     # Check for styles (not yet supported so warn user)
     if data._styles:
         _not_implemented("Styles are not yet supported in LaTeX output.")
@@ -608,7 +572,6 @@ def _render_as_latex(data: GTData, use_longtable: bool = False, tbl_pos: str | N
 
     # Throw exception if a stub is present in the table
     if "rowname" in stub_layout or "group_label" in stub_layout:
-
         raise NotImplementedError(
             "The table stub (row names and/or row groups) are not yet supported in LaTeX output."
         )
@@ -619,7 +582,6 @@ def _render_as_latex(data: GTData, use_longtable: bool = False, tbl_pos: str | N
     # Throw exception if row groups are used in LaTeX output (extra case where row
     # groups are used but not in the stub)
     if has_groups:
-
         raise NotImplementedError("Row groups are not yet supported in LaTeX output.")
 
     # Create a LaTeX fragment for the start of the table
@@ -652,7 +614,6 @@ def _render_as_latex(data: GTData, use_longtable: bool = False, tbl_pos: str | N
 
     # Compose the LaTeX table
     if use_longtable:
-
         finalized_table = f"""{wrap_start_statement}
 {table_width_statement}
 {fontsize_statement}
@@ -666,7 +627,6 @@ def _render_as_latex(data: GTData, use_longtable: bool = False, tbl_pos: str | N
 """
 
     else:
-
         finalized_table = f"""{wrap_start_statement}
 {heading_component}
 {table_width_statement}

--- a/great_tables/_utils_render_latex.py
+++ b/great_tables/_utils_render_latex.py
@@ -282,7 +282,6 @@ def create_columns_component_l(data: GTData) -> str:
     spanner_row_count = _get_spanners_matrix_height(data=data, omit_columns_row=True)
 
     # Get the column headings
-    headings_vars = data._boxhead._get_default_columns()
     headings_labels = data._boxhead._get_default_column_labels()
 
     # Ensure that the heading labels are processed for LaTeX
@@ -307,13 +306,13 @@ def create_columns_component_l(data: GTData) -> str:
         # TODO: ensure that spanner IDs are not included in the output (spanner
         # labels should be used instead)
 
-        spanner_ids, spanner_col_names = spanners_print_matrix(
-            spanners=data._spanners,
-            boxhead=boxhead,
-            include_hidden=False,
-            ids=True,
-            omit_columns_row=True,
-        )
+        # spanner_ids, spanner_col_names = spanners_print_matrix(
+        #     spanners=data._spanners,
+        #     boxhead=boxhead,
+        #     include_hidden=False,
+        #     ids=True,
+        #     omit_columns_row=True,
+        # )
 
         for i in range(len(spanners)):
 
@@ -423,7 +422,7 @@ def create_body_component_l(data: GTData) -> str:
 
     body_rows = []
 
-    ordered_index: list[tuple[int, GroupRowInfo]] = data._stub.group_indices_map()
+    ordered_index: list[tuple[int, GroupRowInfo | None]] = data._stub.group_indices_map()
 
     for i, _ in ordered_index:
 

--- a/great_tables/_utils_selenium.py
+++ b/great_tables/_utils_selenium.py
@@ -15,7 +15,6 @@ WebDrivers: TypeAlias = Literal[
 
 
 class _BaseWebDriver:
-
     def __init__(self, debug_port: int | None = None):
         self.debug_port = debug_port
         self.wd_options = self.cls_wd_options()

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -348,7 +348,6 @@ class GT(
         make_page: bool = False,
         all_important: bool = False,
     ) -> str:
-
         heading_component = create_heading_component_h(data=self)
         column_labels_component = create_columns_component_h(data=self)
         body_component = create_body_component_h(data=self)
@@ -416,7 +415,6 @@ class GT(
         """
 
         if make_page:
-
             # Create an HTML page and place the table within it
             finalized_table = f"""<!DOCTYPE html>
 <html lang="en">

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
-
+from typing import Any, TYPE_CHECKING
 from typing_extensions import Self
 
 from great_tables._gt_data import GTData
@@ -73,6 +72,9 @@ from great_tables._utils_render_html import (
     create_source_notes_component_h,
 )
 
+
+if TYPE_CHECKING:
+    from ._helpers import BaseText
 
 __all__ = ["GT"]
 
@@ -312,7 +314,7 @@ class GT(
             )
 
         # built._perform_col_merge()
-        final_body = body_reassemble(built._body, built._stub, built._boxhead)
+        final_body = body_reassemble(built._body)
 
         # Reordering of the metadata elements of the table
 
@@ -439,7 +441,7 @@ class GT(
 # =============================================================================
 
 
-def _get_column_labels(gt: GT, context: str) -> list[str]:
+def _get_column_labels(gt: GT, context: str) -> list[str | BaseText | None]:
     gt_built = gt._build_data(context=context)
     column_labels = [x.column_label for x in gt_built._boxhead]
     return column_labels

--- a/great_tables/vals.py
+++ b/great_tables/vals.py
@@ -1,3 +1,5 @@
+# ruff: noqa: F401
+
 from __future__ import annotations
 
 from ._formats_vals import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,13 +105,9 @@ exclude = ["docs", ".venv", "tests/*"]
 ignore = [
     "E402",    # module level import not at top of file
     "E501",    # line too long (maximum 100 characters)
-    "W503",    # line break before binary operator
     "F811",    # redefinition of unused name
     "E203",    # whitespace before ':'
     "F401",    # 'module' imported but unused
     "F841",    # local variable 'name' is assigned to but never used
     "E702",    # multiple statements on one line (semicolon)
-    "E704",    # multiple statements on one line (def)
 ]
-
-max-line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ ignore = [
     "E501",    # line too long (maximum 100 characters)
     "F811",    # redefinition of unused name
     "E203",    # whitespace before ':'
-    "F401",    # 'module' imported but unused
     "F841",    # local variable 'name' is assigned to but never used
     "E702",    # multiple statements on one line (semicolon)
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dev = [
 ]
 
 dev-no-pandas = [
-    "black",
+    "ruff==0.8.0",
     "jupyter",
     "quartodoc>=0.8.1; python_version >= '3.9'",
     "griffe==0.38.1",
@@ -82,7 +82,24 @@ dev-no-pandas = [
 homepage = "https://github.com/posit-dev/great-tables"
 documentation = "https://posit-dev.github.io/great-tables/"
 
-[tool.flake8]
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q --cov=great_tables -m 'not no_pandas'"
+asyncio_mode = "strict"
+testpaths = [
+    "tests"
+]
+
+markers = [
+    "extra: marks tests that require extra dependencies to run",
+    "no_pandas: test meant to run without pandas installed",
+]
+
+[tool.ruff]
+line-length = 100
+
+
+[tool.ruff.lint]
 exclude = ["docs", ".venv", "tests/*"]
 
 ignore = [
@@ -98,19 +115,3 @@ ignore = [
 ]
 
 max-line-length = 100
-
-[tool.pytest.ini_options]
-minversion = "6.0"
-addopts = "-ra -q --cov=great_tables -m 'not no_pandas'"
-asyncio_mode = "strict"
-testpaths = [
-    "tests"
-]
-
-markers = [
-    "extra: marks tests that require extra dependencies to run",
-    "no_pandas: test meant to run without pandas installed",
-]
-
-[tool.black]
-line-length = 100

--- a/tests/test__utils_nanoplots.py
+++ b/tests/test__utils_nanoplots.py
@@ -124,7 +124,6 @@ def test_is_integerlike():
 
 
 def test_normalize_option_list():
-
     # Test case 1: Normalization with five values
     x = [1, 2, 3, 4, 5]
     expected_output = [1, 2, 3, 4, 5]
@@ -632,7 +631,6 @@ def _nanoplot_has_tag_attrs(nanoplot_str: str, tag: str, attrs: list[tuple[str, 
 
 # Test case 1: Simple line-based nanoplot with no missing values and no additional options
 def test_nanoplot_out_data_lines():
-
     out_data_lines = _generate_nanoplot(**CASES[0])
 
     assert _is_nanoplot_output(out_data_lines)
@@ -716,7 +714,6 @@ def test_nanoplot_out_data_lines():
 
 # Test case 2: Line-based nanoplot w/ reference line (using static numeric value)
 def test_nanoplot_out_with_num_ref_line():
-
     out_with_num_ref_line = _generate_nanoplot(**CASES[1])
 
     assert _is_nanoplot_output(out_with_num_ref_line)
@@ -815,7 +812,6 @@ def test_nanoplot_out_with_num_ref_line():
 
 # Test case 3: Line-based nanoplot w/ reference line (using keyword to generate value)
 def test_nanoplot_out_with_kword_ref_line():
-
     out_with_kword_ref_line = _generate_nanoplot(**CASES[2])
 
     assert _is_nanoplot_output(out_with_kword_ref_line)
@@ -914,7 +910,6 @@ def test_nanoplot_out_with_kword_ref_line():
 
 # Test case 4: Line nanoplot w/ ref area (using numbers to define limits)
 def test_nanoplot_out_with_num_ref_area():
-
     out_with_num_ref_area = _generate_nanoplot(**CASES[3])
 
     assert _is_nanoplot_output(out_with_num_ref_area)
@@ -1009,7 +1004,6 @@ def test_nanoplot_out_with_num_ref_area():
 
 # Test case 5: Line nanoplot w/ ref area (using numbers, descending order, to define limits)
 def test_nanoplot_out_with_num_ref_area_rev():
-
     out_with_num_ref_area_rev = _generate_nanoplot(**CASES[4])
 
     assert _is_nanoplot_output(out_with_num_ref_area_rev)
@@ -1019,7 +1013,6 @@ def test_nanoplot_out_with_num_ref_area_rev():
 
 # Test case 6: Line nanoplot w/ ref area (using two keywords to define limits)
 def test_nanoplot_out_with_kword_ref_area():
-
     out_with_kword_ref_area = _generate_nanoplot(**CASES[5])
 
     assert _is_nanoplot_output(out_with_kword_ref_area)
@@ -1114,7 +1107,6 @@ def test_nanoplot_out_with_kword_ref_area():
 
 # Test case 7: Line nanoplot w/ ref area (using two keywords to define limits; reversed order)
 def test_nanoplot_out_with_kword_ref_area_rev():
-
     out_with_kword_ref_area_rev = _generate_nanoplot(**CASES[6])
 
     assert _is_nanoplot_output(out_with_kword_ref_area_rev)
@@ -1124,7 +1116,6 @@ def test_nanoplot_out_with_kword_ref_area_rev():
 
 # Test case 8: Line nanoplot w/ ref area (using keywords + literal int value to define limits)
 def test_nanoplot_out_with_mixed_ref_area_1():
-
     out_with_mixed_ref_area_1 = _generate_nanoplot(**CASES[7])
 
     assert _is_nanoplot_output(out_with_mixed_ref_area_1)
@@ -1219,7 +1210,6 @@ def test_nanoplot_out_with_mixed_ref_area_1():
 
 # Test case 9: Line nanoplot w/ ref area (using keywords + literal int value to define limits)
 def test_nanoplot_out_with_mixed_ref_area_2():
-
     out_with_mixed_ref_area_2 = _generate_nanoplot(**CASES[8])
 
     assert _is_nanoplot_output(out_with_mixed_ref_area_2)
@@ -1314,7 +1304,6 @@ def test_nanoplot_out_with_mixed_ref_area_2():
 
 # Test case 10: Line nanoplot w/ ref area and ref line
 def test_nanoplot_out_with_ref_line_and_area():
-
     out_with_ref_line_and_area = _generate_nanoplot(**CASES[9])
 
     assert _is_nanoplot_output(out_with_ref_line_and_area)
@@ -1424,7 +1413,6 @@ def test_nanoplot_out_with_ref_line_and_area():
 
 # Test case 11: Simple bar-based nanoplot
 def test_nanoplot_out_data_bars():
-
     out_data_bars = _generate_nanoplot(**CASES[10])
 
     assert _is_nanoplot_output(out_data_bars)
@@ -1471,7 +1459,6 @@ def test_nanoplot_out_data_bars():
 
 # Test case 12: Bar nanoplot with a reference line (static numeric value)
 def test_nanoplot_out_bars_with_num_ref_line():
-
     out_bars_with_num_ref_line = _generate_nanoplot(**CASES[11])
 
     assert _is_nanoplot_output(out_bars_with_num_ref_line)
@@ -1533,7 +1520,6 @@ def test_nanoplot_out_bars_with_num_ref_line():
 
 # Test case 13: Bar nanoplot with a reference line (keyword to generate value)
 def test_nanoplot_out_bars_with_kword_ref_line():
-
     out_bars_with_kword_ref_line = _generate_nanoplot(**CASES[12])
 
     assert _is_nanoplot_output(out_bars_with_kword_ref_line)
@@ -1595,7 +1581,6 @@ def test_nanoplot_out_bars_with_kword_ref_line():
 
 # Test case 14: Bar nanoplot with a reference area (using numbers to define limits)
 def test_nanoplot_out_bars_with_num_ref_area():
-
     out_bars_with_num_ref_area = _generate_nanoplot(**CASES[13])
 
     assert _is_nanoplot_output(out_bars_with_num_ref_area)
@@ -1653,7 +1638,6 @@ def test_nanoplot_out_bars_with_num_ref_area():
 
 # Test case 15: Bar nanoplot with a reference area (using keywords)
 def test_nanoplot_out_bars_with_kword_ref_area():
-
     out_bars_with_kword_ref_area = _generate_nanoplot(**CASES[14])
 
     assert _is_nanoplot_output(out_bars_with_kword_ref_area)
@@ -1711,7 +1695,6 @@ def test_nanoplot_out_bars_with_kword_ref_area():
 
 # Test case 16: Bar nanoplot with a reference area (using keyword + literal int value)
 def test_nanoplot_out_bars_with_mixed_ref_area_1():
-
     out_bars_with_mixed_ref_area_1 = _generate_nanoplot(**CASES[15])
 
     assert _is_nanoplot_output(out_bars_with_mixed_ref_area_1)
@@ -1769,7 +1752,6 @@ def test_nanoplot_out_bars_with_mixed_ref_area_1():
 
 # Test case 17: Bar nanoplot with a reference area (using keyword + literal float value)
 def test_nanoplot_out_bars_with_mixed_ref_area_2():
-
     out_bars_with_mixed_ref_area_2 = _generate_nanoplot(**CASES[16])
 
     assert _is_nanoplot_output(out_bars_with_mixed_ref_area_2)
@@ -1827,7 +1809,6 @@ def test_nanoplot_out_bars_with_mixed_ref_area_2():
 
 # Test case 18: Bar nanoplot with a reference line and area
 def test_nanoplot_out_bars_with_ref_line_and_area():
-
     out_bars_with_ref_line_and_area = _generate_nanoplot(**CASES[17])
 
     assert _is_nanoplot_output(out_bars_with_ref_line_and_area)
@@ -1900,7 +1881,6 @@ def test_nanoplot_out_bars_with_ref_line_and_area():
 
 # Test case 19: Horizontal line-based nanoplot
 def test_nanoplot_out_horizontal_line():
-
     out_horizontal_line = _generate_nanoplot(**CASES[18])
 
     assert _is_nanoplot_output(out_horizontal_line)
@@ -1927,7 +1907,6 @@ def test_nanoplot_out_horizontal_line():
 
 # Test case 20: Horizontal line-based nanoplot with value not in `vals` list
 def test_nanoplot_out_horizontal_line_non_incl():
-
     out_horizontal_line_non_incl = _generate_nanoplot(**CASES[19])
 
     assert _is_nanoplot_output(out_horizontal_line_non_incl)
@@ -1952,7 +1931,6 @@ def test_nanoplot_out_horizontal_line_non_incl():
 
 # Test case 21: Horizontal bar-based nanoplot
 def test_nanoplot_out_horizontal_bar():
-
     out_horizontal_bar = _generate_nanoplot(**CASES[20])
 
     assert _is_nanoplot_output(out_horizontal_bar)
@@ -1969,7 +1947,6 @@ def test_nanoplot_out_horizontal_bar():
 
 # Test case 22: Horizontal bar-based nanoplot with value not in `vals` list
 def test_nanoplot_out_horizontal_bar_non_incl():
-
     out_horizontal_bar_non_incl = _generate_nanoplot(**CASES[21])
 
     assert _is_nanoplot_output(out_horizontal_bar_non_incl)
@@ -1986,14 +1963,12 @@ def test_nanoplot_out_horizontal_bar_non_incl():
 
 # Test case 23: Line-based nanoplot with x-values
 def test_nanoplot_out_data_lines_x_vals():
-
     out_data_lines_x_vals = _generate_nanoplot(**CASES[22])
     assert _is_nanoplot_output(out_data_lines_x_vals)
 
 
 # Test case 24: Line-based nanoplot with no x-values (generates an empty string)
 def test_nanoplot_out_data_lines_x_vals_empty():
-
     out_data_lines_x_vals_empty = _generate_nanoplot(**CASES[23])
     assert out_data_lines_x_vals_empty == ""
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -41,7 +41,6 @@ def test_html_string_generated(gt_tbl: GT, snapshot: str):
 @pytest.mark.skipif(sys.platform == "win32", reason="chrome might not be installed.")
 @pytest.mark.extra
 def test_save_image_file(gt_tbl: GT, tmp_path):
-
     f_path = tmp_path / "test_image.png"
     gt_tbl.save(file=str(f_path))
 
@@ -100,7 +99,6 @@ def test_create_temp_file_server():
 
 
 def test_snap_as_latex(snapshot):
-
     gt_tbl = (
         GT(
             gtcars[["mfr", "model", "hp", "trq", "msrp"]].head(5),

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1116,7 +1116,6 @@ def test_fmt_currency_case(fmt_currency_kwargs: dict[str, Any], x_out: list[str]
 
 
 def test_fmt_currency_force_sign():
-
     df = pd.DataFrame({"x": [-234.654, -0.0001, 0, 2352.23, 12354.3, 9939293923.23]})
 
     gt = GT(df).fmt_currency(columns="x", force_sign=True)
@@ -1139,35 +1138,30 @@ df_fmt_time = pd.DataFrame({"x": ["10:59:59", "13:23:59", "23:15"]})
 
 
 def test_fmt_time_iso():
-
     gt = GT(df_fmt_time).fmt_time(columns="x", time_style="iso")
     x = _get_column_of_values(gt, column_name="x", context="html")
     assert x == ["10:59:59", "13:23:59", "23:15:00"]
 
 
 def test_fmt_time_iso_short():
-
     gt = GT(df_fmt_time).fmt_time(columns="x", time_style="iso-short")
     x = _get_column_of_values(gt, column_name="x", context="html")
     assert x == ["10:59", "13:23", "23:15"]
 
 
 def test_fmt_time_h_m_s_p():
-
     gt = GT(df_fmt_time).fmt_time(columns="x", time_style="h_m_s_p")
     x = _get_column_of_values(gt, column_name="x", context="html")
     assert x == ["10:59:59 AM", "1:23:59 PM", "11:15:00 PM"]
 
 
 def test_fmt_time_h_m_p():
-
     gt = GT(df_fmt_time).fmt_time(columns="x", time_style="h_m_p")
     x = _get_column_of_values(gt, column_name="x", context="html")
     assert x == ["10:59 AM", "1:23 PM", "11:15 PM"]
 
 
 def test_fmt_time_h_p():
-
     gt = GT(df_fmt_time).fmt_time(columns="x", time_style="h_p")
     x = _get_column_of_values(gt, column_name="x", context="html")
     assert x == ["10 AM", "1 PM", "11 PM"]
@@ -1179,7 +1173,6 @@ def test_fmt_time_h_p():
 
 
 def test_fmt_date():
-
     df = pd.DataFrame(
         {
             "x": [
@@ -1209,7 +1202,6 @@ def test_fmt_date():
 
 
 def test_fmt_datetime():
-
     df = pd.DataFrame(
         {
             "x": [
@@ -1240,7 +1232,6 @@ def test_fmt_datetime():
 
 
 def test_fmt_datetime_bad_date_style_raises():
-
     df = pd.DataFrame(
         {
             "x": [
@@ -1310,14 +1301,12 @@ df_fmt_roman = pd.DataFrame({"x": [-1234, 0, 0.4, 0.8, 1, 99, 4500]})
 
 
 def test_fmt_roman_upper():
-
     gt = GT(df_fmt_roman).fmt_roman(columns="x")
     x = _get_column_of_values(gt, column_name="x", context="html")
     assert x == ["MCCXXXIV", "N", "N", "I", "I", "XCIX", "ex terminis"]
 
 
 def test_fmt_roman_lower():
-
     gt = GT(df_fmt_roman).fmt_roman(columns="x", case="lower")
     x = _get_column_of_values(gt, column_name="x", context="html")
     assert x == ["mccxxxiv", "n", "n", "i", "i", "xcix", "ex terminis"]
@@ -1587,7 +1576,6 @@ def test_fmt_image_path_http(url: str):
     ],
 )
 def test_fmt_units(src: str, dst: str):
-
     units_tbl = pl.DataFrame({"units": [src]})
     gt_tbl = GT(units_tbl).fmt_units(columns="units")
 
@@ -1651,7 +1639,6 @@ FMT_NANOPLOT_CASES: list[dict[str, Any]] = [
 
 # Test category 1: Horizontal line-based nanoplot single values
 def test_fmt_nanoplot_single_vals_only_line():
-
     gt = GT(df_fmt_nanoplot_single).fmt_nanoplot(
         columns="vals",
         plot_type="line",
@@ -1682,7 +1669,6 @@ def test_fmt_nanoplot_single_vals_only_line():
     # as this previous one (none will error as the non-relevant options are no ops)
 
     for _, params in enumerate(FMT_NANOPLOT_CASES[1:], start=1):
-
         gt = GT(df_fmt_nanoplot_single).fmt_nanoplot(
             columns="vals",
             plot_type="line",
@@ -1695,7 +1681,6 @@ def test_fmt_nanoplot_single_vals_only_line():
 
 # Test category 2: Horizontal bar-based nanoplot single values
 def test_fmt_nanoplot_single_vals_only_bar():
-
     gt = GT(df_fmt_nanoplot_single).fmt_nanoplot(
         columns="vals",
         plot_type="bar",
@@ -1735,7 +1720,6 @@ def test_fmt_nanoplot_single_vals_only_bar():
     # All other test cases for the horizontal bar nanoplot will produce the same output
     # as this previous one (none will error as the non-relevant options are no ops)
     for _, params in enumerate(FMT_NANOPLOT_CASES[1:], start=1):
-
         gt = GT(df_fmt_nanoplot_single).fmt_nanoplot(
             columns="vals",
             plot_type="bar",
@@ -1748,7 +1732,6 @@ def test_fmt_nanoplot_single_vals_only_bar():
 
 # Test category 3: Line-based nanoplot, multiple values per row
 def test_fmt_nanoplot_multi_vals_line():
-
     # Subcase with default options
     gt = GT(df_fmt_nanoplot_multi).fmt_nanoplot(
         columns="vals",
@@ -1836,7 +1819,6 @@ def test_fmt_nanoplot_multi_vals_line():
 
 # Test category 3: Line-based nanoplot, multiple values per row, use of reference line
 def test_fmt_nanoplot_multi_vals_line_ref_line():
-
     # Subcase with reference line
     gt = GT(df_fmt_nanoplot_multi).fmt_nanoplot(
         columns="vals",
@@ -1862,7 +1844,6 @@ def test_fmt_nanoplot_multi_vals_line_ref_line():
 # Test category 4: Line-based nanoplot, multiple values per row, use of reference
 # line and reference area
 def test_fmt_nanoplot_multi_vals_line_ref_line_ref_area():
-
     gt = GT(df_fmt_nanoplot_multi).fmt_nanoplot(
         columns="vals",
         plot_type="line",
@@ -1897,7 +1878,6 @@ def test_fmt_nanoplot_multi_vals_line_ref_line_ref_area():
 
 # Test category 5: Bar-based nanoplot, multiple values per row
 def test_fmt_nanoplot_multi_vals_bar():
-
     # Subcase with default options
     gt = GT(df_fmt_nanoplot_multi).fmt_nanoplot(
         columns="vals",
@@ -1945,7 +1925,6 @@ def test_fmt_nanoplot_multi_vals_bar():
 
 # Test category 6: Bar-based nanoplot, multiple values per row, use of reference line
 def test_fmt_nanoplot_multi_vals_bar_ref_line():
-
     gt = GT(df_fmt_nanoplot_multi).fmt_nanoplot(
         columns="vals",
         plot_type="bar",
@@ -1969,7 +1948,6 @@ def test_fmt_nanoplot_multi_vals_bar_ref_line():
 
 # Test category 7: Bar-based nanoplot, multiple values per row, reference line and reference area
 def test_fmt_nanoplot_multi_vals_bar_ref_line_ref_area():
-
     gt = GT(df_fmt_nanoplot_multi).fmt_nanoplot(
         columns="vals",
         plot_type="bar",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -134,7 +134,6 @@ def test_get_font_stack_add_emoji_true(font_stack_names):
     ],
 )
 def assert_generate_tokens_list(units: str, x_out: str):
-
     x = _generate_tokens_list(units_notation=units)
     assert x == x_out
 
@@ -338,7 +337,6 @@ def test_unit_str_class_construction():
 
 
 def test_unit_str_from_str_single_unit():
-
     res = UnitStr.from_str("speed {{m s^-1}}").units_str
 
     assert len(res) == 3
@@ -349,7 +347,6 @@ def test_unit_str_from_str_single_unit():
 
 
 def test_unit_str_from_str_two_units():
-
     res = UnitStr.from_str("speed {{m s^-1}} and acceleration {{m s^-2}}").units_str
 
     assert len(res) == 5
@@ -363,7 +360,6 @@ def test_unit_str_from_str_two_units():
 
 
 def test_unit_str_from_without_units():
-
     res = UnitStr.from_str("a b").units_str
 
     assert len(res) == 1
@@ -371,7 +367,6 @@ def test_unit_str_from_without_units():
 
 
 def test_unit_str_unmatched_brackets():
-
     res = UnitStr.from_str("speed {{m s^-1 and acceleration {{m s^-2}}").units_str
 
     assert len(res) == 3
@@ -382,7 +377,6 @@ def test_unit_str_unmatched_brackets():
 
 
 def test_define_units_latex_raises():
-
     with pytest.raises(NotImplementedError) as exc_info:
         UnitStr.from_str("a b").to_latex()
 

--- a/tests/test_modify_rows.py
+++ b/tests/test_modify_rows.py
@@ -53,7 +53,6 @@ def test_with_groupname_col_undo_spanner_style():
 
 
 def test_with_groupname_col_unset():
-
     gt = GT(
         pd.DataFrame({"g": ["b"], "row": ["one"], "x": [1], "y": [3]}),
         rowname_col="row",
@@ -108,7 +107,6 @@ def test_with_rowname_col_undo_spanner_style():
 
 
 def test_with_rowname_col_unset():
-
     gt = GT(
         pd.DataFrame({"g": ["b"], "row": ["one"], "x": [1], "y": [3]}),
         rowname_col="row",

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -332,7 +332,6 @@ def test_scss_from_opt_table_outline(gt_tbl: GT, snapshot):
 
 
 def test_opt_table_font_add_font():
-
     gt_tbl = GT(exibble).opt_table_font(font="Arial", weight="bold", style="italic")
 
     assert gt_tbl._options.table_font_names.value == ["Arial"] + default_fonts_list
@@ -341,7 +340,6 @@ def test_opt_table_font_add_font():
 
 
 def test_opt_table_font_replace_font():
-
     gt_tbl = GT(exibble).opt_table_font(font="Arial", weight="bold", style="bold", add=False)
 
     assert gt_tbl._options.table_font_names.value == ["Arial"]
@@ -350,7 +348,6 @@ def test_opt_table_font_replace_font():
 
 
 def test_opt_table_font_use_stack():
-
     gt_tbl = GT(exibble).opt_table_font(stack="humanist")
 
     assert gt_tbl._options.table_font_names.value[0] == "Seravek"
@@ -358,7 +355,6 @@ def test_opt_table_font_use_stack():
 
 
 def test_opt_table_font_use_stack_and_system_font():
-
     gt_tbl = GT(exibble).opt_table_font(font="Comic Sans MS", stack="humanist")
 
     assert gt_tbl._options.table_font_names.value[0] == "Comic Sans MS"
@@ -367,7 +363,6 @@ def test_opt_table_font_use_stack_and_system_font():
 
 
 def test_opt_table_font_google_font():
-
     gt_tbl = GT(exibble).opt_table_font(font=google_font(name="IBM Plex Mono"))
 
     rendered_html = gt_tbl.as_raw_html()
@@ -382,7 +377,6 @@ def test_opt_table_font_google_font():
 
 
 def test_opt_table_font_raises():
-
     # Both `font` and `stack` cannot be `None`
     with pytest.raises(ValueError) as exc_info:
         GT(exibble).opt_table_font(font=None, stack=None)
@@ -412,7 +406,6 @@ def test_opt_table_font_raises_weight():
 
 
 def test_opt_row_striping():
-
     gt_tbl_0 = GT(exibble)
     gt_tbl_1 = GT(exibble).opt_row_striping()
     gt_tbl_2 = GT(exibble).opt_row_striping().opt_row_striping(row_striping=False)
@@ -423,7 +416,6 @@ def test_opt_row_striping():
 
 
 def test_tab_options_striping():
-
     gt_tbl_tab_opts = GT(exibble).tab_options(row_striping_include_table_body=True)
     gt_tbl_opt_stri = GT(exibble).opt_row_striping()
 
@@ -435,7 +427,6 @@ def test_tab_options_striping():
 
 
 def test_tab_options_striping_body_snap(snapshot):
-
     gt_tbl = GT(
         exibble[["row", "group", "char"]].head(4), rowname_col="row", groupname_col="group"
     ).tab_options(
@@ -450,7 +441,6 @@ def test_tab_options_striping_body_snap(snapshot):
 
 
 def test_tab_options_striping_stub_snap(snapshot):
-
     gt_tbl = GT(
         exibble[["row", "group", "char"]].head(4), rowname_col="row", groupname_col="group"
     ).tab_options(
@@ -465,14 +455,12 @@ def test_tab_options_striping_stub_snap(snapshot):
 
 
 def test_opt_stylize_default(snapshot):
-
     gt_tbl = GT(exibble, rowname_col="row", groupname_col="group").opt_stylize()
 
     assert snapshot == compile_scss(gt_tbl, id="abc", compress=False)
 
 
 def test_opt_stylize_no_striping(snapshot):
-
     gt_tbl = GT(exibble, rowname_col="row", groupname_col="group").opt_stylize(
         add_row_striping=False
     )
@@ -482,7 +470,6 @@ def test_opt_stylize_no_striping(snapshot):
 
 @pytest.mark.parametrize("style", [1, 2, 3, 4, 5, 6])
 def test_opt_stylize_outline_present(style, snapshot):
-
     gt_tbl = GT(exibble, rowname_col="row", groupname_col="group").opt_stylize(style=style)
 
     css = compile_scss(gt_tbl, id="abc", compress=False)

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -13,14 +13,12 @@ def gt():
 
 
 def assert_rendered_html_repr(snapshot, gt):
-
     html_repr_output = gt._repr_html_()
     assert snapshot == html_repr_output
 
 
 @mock.patch.dict(os.environ, {"QUARTO_BIN_PATH": "1"}, clear=True)
 def test_repr_html_quarto(gt, snapshot):
-
     assert infer_render_env() == "quarto"
 
     assert_rendered_html_repr(snapshot, gt)
@@ -28,7 +26,6 @@ def test_repr_html_quarto(gt, snapshot):
 
 @mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "1"}, clear=True)
 def test_repr_html_databricks(gt, snapshot):
-
     assert infer_render_env() == "databricks"
 
     assert_rendered_html_repr(snapshot, gt)
@@ -36,7 +33,6 @@ def test_repr_html_databricks(gt, snapshot):
 
 @mock.patch.dict(os.environ, {"VSCODE_PID": "1"}, clear=True)
 def test_repr_html_vscode(gt, snapshot):
-
     assert infer_render_env() == "vscode"
 
     assert_rendered_html_repr(snapshot, gt)
@@ -44,14 +40,12 @@ def test_repr_html_vscode(gt, snapshot):
 
 @mock.patch.dict(os.environ, {"POSITRON_VERSION": "1"}, clear=True)
 def test_repr_html_positron(gt, snapshot):
-
     assert infer_render_env() == "positron"
 
     assert_rendered_html_repr(snapshot, gt)
 
 
 def test_repr_html_default(gt, snapshot):
-
     assert infer_render_env() == "default"
 
     assert_rendered_html_repr(snapshot, gt)

--- a/tests/test_tab_create_modify.py
+++ b/tests/test_tab_create_modify.py
@@ -34,7 +34,6 @@ def test_tab_style_multiple_columns(gt: GT):
 
 
 def test_tab_style_google_font(gt: GT):
-
     new_gt = tab_style(
         gt,
         style=style.text(font=google_font(name="IBM Plex Mono")),
@@ -50,7 +49,6 @@ def test_tab_style_google_font(gt: GT):
 
 
 def test_tab_style_font_local(gt: GT):
-
     new_gt = tab_style(
         gt,
         style=style.text(font="Courier"),
@@ -63,7 +61,6 @@ def test_tab_style_font_local(gt: GT):
 
 
 def test_tab_style_font_from_column():
-
     tbl = pl.DataFrame({"x": [1, 2], "font": ["Helvetica", "Courier"]})
 
     gt_tbl = GT(tbl).tab_style(

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -12,7 +12,6 @@ from great_tables._text import (
 
 
 def test_base_text_class():
-
     with pytest.raises(NotImplementedError):
         BaseText().to_html()
 
@@ -21,38 +20,32 @@ def test_base_text_class():
 
 
 def test_text_class():
-
     assert Text("<p>Some Text</p>").to_html() == "<p>Some Text</p>"
     assert Text("__Some Text__").to_latex() == "__Some Text__"
 
 
 def test_md_class():
-
     assert Md("**text**").to_html() == "<strong>text</strong>"
 
 
 def test_html_class():
-
     assert Html("<strong>text</strong>").to_html() == "<strong>text</strong>"
     assert Html("<strong>text</strong>").to_latex() == "<strong>text</strong>"
 
 
 def test_latex_escape():
-
     assert _latex_escape("a & b") == "a \\& b"
     assert _latex_escape("a & b & c") == "a \\& b \\& c"
     assert _latex_escape("\\a_\\d") == "\\\\a\\_\\\\d"
 
 
 def test_escape_pattern_str_latex():
-
     assert escape_pattern_str_latex("{x}") == "{x}"
     assert escape_pattern_str_latex("a $_{1} %ab {2}") == "a \\$\\_{1} \\%ab {2}"
     assert escape_pattern_str_latex("a{b}c") == "a\\{b\\}c"
 
 
 def test_process_text_html():
-
     assert _process_text("a & <b>", context="html") == "a &amp; &lt;b&gt;"
     assert _process_text(Text("a & <b>"), context="html") == "a & <b>"
     assert _process_text(Md("**a** & <b>"), context="html") == "<strong>a</strong> &amp; <b>"
@@ -61,7 +54,6 @@ def test_process_text_html():
 
 
 def test_process_text_latex():
-
     assert _process_text("a & _b_", context="latex") == "a \\& \\_b\\_"
     assert _process_text(Text("\\_\\$"), context="latex") == "\\_\\$"
     assert _process_text(Html("**a** & <b>"), context="latex") == "**a** \\& <b>"
@@ -74,7 +66,6 @@ def test_process_text_latex():
 
 
 def test_process_text_raises():
-
     with pytest.raises(TypeError) as exc_info:
         _process_text(1, context="html")  # type: ignore
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -182,7 +182,6 @@ def test_seq_groups_raises():
 
 
 def test_migrate_unformatted_to_output_latex():
-
     gt_tbl = GT(exibble.head(2)).fmt_number(columns="num", decimals=3)
 
     # After rendering the data cells all the unformatted cells will be NA values in the
@@ -201,7 +200,6 @@ def test_migrate_unformatted_to_output_latex():
 
 
 def test_migrate_unformatted_to_output_html():
-
     gt_tbl = GT(exibble.head(2)).fmt_number(columns="num", decimals=3)
 
     # After rendering the data cells all the unformatted cells will be NA values in the

--- a/tests/test_utils_render_latex.py
+++ b/tests/test_utils_render_latex.py
@@ -62,7 +62,6 @@ def gt_tbl_dttm():
 
 
 def test_is_css_length_string():
-
     assert is_css_length_string("12.5pt")
     assert is_css_length_string("12.5px")
     assert is_css_length_string("12.5")
@@ -70,13 +69,11 @@ def test_is_css_length_string():
 
 
 def test_is_number_without_units():
-
     assert is_number_without_units("12.5")
     assert not is_number_without_units("12.5pt")
 
 
 def test_css_length_has_supported_units():
-
     assert css_length_has_supported_units("12.5pt")
     assert css_length_has_supported_units("12.5px")
     assert css_length_has_supported_units("12.5")
@@ -88,19 +85,16 @@ def test_css_length_has_supported_units():
 
 
 def test_get_units_from_length_string():
-
     assert get_units_from_length_string("12.5pt") == "pt"
     assert get_units_from_length_string("") == "px"
 
 
 def test_get_px_conversion_val():
-
     assert get_px_conversion(length="2343.23pt") == 4 / 3
     assert get_px_conversion(length="43.2px") == 1.0
 
 
 def test_get_px_conversion_val_raises():
-
     with pytest.raises(ValueError) as exc_info:
         get_px_conversion(length="12.8bolts")
 
@@ -108,58 +102,49 @@ def test_get_px_conversion_val_raises():
 
 
 def test_convert_to_px():
-
     assert convert_to_px("12.5pt") == 17.0
     assert convert_to_px("12.5px") == 12.5
 
 
 def test_convert_to_pt():
-
     assert convert_to_pt("16px") == 12.0
 
 
 def test_create_fontsize_statement_l(gt_tbl: GT):
-
     assert create_fontsize_statement_l(gt_tbl) == "\\fontsize{12.0pt}{14.4pt}\\selectfont\n"
 
 
 def test_create_fontsize_statement_l_pt(gt_tbl: GT):
-
     gt_tbl_new = gt_tbl.tab_options(table_font_size="18.2pt")
 
     assert create_fontsize_statement_l(gt_tbl_new) == "\\fontsize{18.2pt}{21.8pt}\\selectfont\n"
 
 
 def test_create_fontsize_statement_l_px(gt_tbl: GT):
-
     gt_tbl_new = gt_tbl.tab_options(table_font_size="11px")
 
     assert create_fontsize_statement_l(gt_tbl_new) == "\\fontsize{8.2pt}{9.9pt}\\selectfont\n"
 
 
 def test_create_fontsize_statement_l_pct(gt_tbl: GT):
-
     gt_tbl_new = gt_tbl.tab_options(table_font_size="50%")
 
     assert create_fontsize_statement_l(gt_tbl_new) == "\\fontsize{6.0pt}{7.2pt}\\selectfont\n"
 
 
 def test_create_fontsize_statement_l_cm(gt_tbl: GT):
-
     gt_tbl_new = gt_tbl.tab_options(table_font_size="0.6cm")
 
     assert create_fontsize_statement_l(gt_tbl_new) == "\\fontsize{17.2pt}{20.7pt}\\selectfont\n"
 
 
 def test_create_fontsize_statement_l_unknown_unit(gt_tbl: GT):
-
     gt_tbl_new = gt_tbl.tab_options(table_font_size="1span")
 
     assert create_fontsize_statement_l(gt_tbl_new) == ""
 
 
 def test_derive_table_width_statement_l_px_lt(gt_tbl: GT):
-
     gt_tbl_new = gt_tbl.tab_options(table_width="500px")
 
     assert (
@@ -169,7 +154,6 @@ def test_derive_table_width_statement_l_px_lt(gt_tbl: GT):
 
 
 def test_derive_table_width_statement_l_pct_lt(gt_tbl: GT):
-
     gt_tbl_new = gt_tbl.tab_options(table_width="45%")
 
     assert (
@@ -179,21 +163,18 @@ def test_derive_table_width_statement_l_pct_lt(gt_tbl: GT):
 
 
 def test_derive_table_width_statement_l_px_no_lt(gt_tbl: GT):
-
     gt_tbl_new = gt_tbl.tab_options(table_width="500px")
 
     assert derive_table_width_statement_l(gt_tbl_new, use_longtable=False) == ""
 
 
 def test_create_fontsize_statement_l_settings():
-
     gt_tbl = GT(exibble).tab_options(table_font_size="18.5px")
 
     assert create_fontsize_statement_l(gt_tbl) == "\\fontsize{13.9pt}{16.6pt}\\selectfont\n"
 
 
 def test_create_heading_component_l():
-
     gt_tbl_no_heading = GT(exibble)
     gt_tbl_title = GT(exibble).tab_header(title="Title")
     gt_tbl_title_subtitle = GT(exibble).tab_header(title="Title", subtitle="Subtitle")
@@ -210,7 +191,6 @@ def test_create_heading_component_l():
 
 
 def test_create_columns_component_l_simple():
-
     gt_tbl = GT(exibble)
 
     assert (
@@ -220,7 +200,6 @@ def test_create_columns_component_l_simple():
 
 
 def test_create_columns_component_l_simple_hidden_cols():
-
     gt_tbl = GT(exibble).cols_hide(columns=["char", "date"])
 
     assert (
@@ -230,7 +209,6 @@ def test_create_columns_component_l_simple_hidden_cols():
 
 
 def test_create_columns_component_l_one_spanner():
-
     gt_tbl = GT(exibble).tab_spanner(label="Spanner", columns=["num", "char"])
 
     assert (
@@ -240,7 +218,6 @@ def test_create_columns_component_l_one_spanner():
 
 
 def test_create_columns_component_l_adjacent_spanners_hiding():
-
     gt_tbl = (
         GT(exibble)
         .tab_spanner(label="Spanner 1", columns=["num", "char"])
@@ -256,7 +233,6 @@ def test_create_columns_component_l_adjacent_spanners_hiding():
 
 
 def test_create_columns_component_l_many_spanners():
-
     gt_tbl = (
         GT(exibble)
         .tab_spanner(label="Spanner 1", columns=["num", "char"])
@@ -273,12 +249,10 @@ def test_create_columns_component_l_many_spanners():
 
 
 def test_create_body_component_l_simple(gt_tbl: GT):
-
     assert create_body_component_l(data=gt_tbl) == "1 & 4 \\\\\n2 & 5 \\\\"
 
 
 def test_create_footer_component_one_note(gt_tbl: GT):
-
     gt_tbl_new = gt_tbl.tab_source_note(source_note="Source Note.")
 
     assert (
@@ -288,7 +262,6 @@ def test_create_footer_component_one_note(gt_tbl: GT):
 
 
 def test_create_footer_component_two_notes(gt_tbl: GT):
-
     gt_tbl_new = gt_tbl.tab_source_note(source_note="Source Note 1.").tab_source_note(
         source_note="Source Note 2."
     )
@@ -300,12 +273,10 @@ def test_create_footer_component_two_notes(gt_tbl: GT):
 
 
 def test_create_footer_component_no_notes(gt_tbl: GT):
-
     assert create_footer_component_l(gt_tbl) == ""
 
 
 def test_create_body_component_l_fmt_number(gt_tbl_dec: GT):
-
     gt_tbl_built = gt_tbl_dec.fmt_number(
         columns="x", rows=0, scale_by=-1, decimals=3, pattern="{x} _"
     )._build_data(context="latex")
@@ -314,7 +285,6 @@ def test_create_body_component_l_fmt_number(gt_tbl_dec: GT):
 
 
 def test_create_body_component_l_fmt_integer(gt_tbl_dec: GT):
-
     gt_tbl_built = gt_tbl_dec.fmt_integer(
         columns="x", rows=0, scale_by=-1, pattern="{x} _"
     )._build_data(context="latex")
@@ -323,7 +293,6 @@ def test_create_body_component_l_fmt_integer(gt_tbl_dec: GT):
 
 
 def test_create_body_component_l_fmt_scientific(gt_tbl_sci: GT):
-
     gt_tbl_built = gt_tbl_sci.fmt_scientific(columns="x", pattern="{x} _")._build_data(
         context="latex"
     )
@@ -335,7 +304,6 @@ def test_create_body_component_l_fmt_scientific(gt_tbl_sci: GT):
 
 
 def test_create_body_component_l_fmt_percent(gt_tbl_pct: GT):
-
     gt_tbl_built = gt_tbl_pct.fmt_percent(columns="x", pattern="{x} _")._build_data(context="latex")
 
     assert (
@@ -345,7 +313,6 @@ def test_create_body_component_l_fmt_percent(gt_tbl_pct: GT):
 
 
 def test_create_body_component_l_fmt_currency(gt_tbl_dec: GT):
-
     gt_tbl_built = gt_tbl_dec.fmt_currency(columns="x", pattern="{x} _")._build_data(
         context="latex"
     )
@@ -357,7 +324,6 @@ def test_create_body_component_l_fmt_currency(gt_tbl_dec: GT):
 
 
 def test_create_body_component_l_fmt_bytes(gt_tbl_sci: GT):
-
     gt_tbl_built = gt_tbl_sci.fmt_bytes(columns="x", pattern="{x} _")._build_data(context="latex")
 
     assert (
@@ -367,7 +333,6 @@ def test_create_body_component_l_fmt_bytes(gt_tbl_sci: GT):
 
 
 def test_create_body_component_l_fmt_date(gt_tbl_dttm: GT):
-
     gt_tbl_built = gt_tbl_dttm.fmt_date(
         columns="date", date_style="wday_month_day_year", pattern="{x} _"
     )._build_data(context="latex")
@@ -379,7 +344,6 @@ def test_create_body_component_l_fmt_date(gt_tbl_dttm: GT):
 
 
 def test_create_body_component_l_fmt_time(gt_tbl_dttm: GT):
-
     gt_tbl_built = gt_tbl_dttm.fmt_time(
         columns="time", time_style="h_m_s_p", pattern="{x} _"
     )._build_data(context="latex")
@@ -391,7 +355,6 @@ def test_create_body_component_l_fmt_time(gt_tbl_dttm: GT):
 
 
 def test_create_body_component_l_fmt_datetime(gt_tbl_dttm: GT):
-
     gt_tbl_built = gt_tbl_dttm.fmt_datetime(
         columns="dttm", date_style="wday_month_day_year", time_style="h_m_s_p", pattern="{x} _"
     )._build_data(context="latex")
@@ -403,7 +366,6 @@ def test_create_body_component_l_fmt_datetime(gt_tbl_dttm: GT):
 
 
 def test_create_body_component_l_fmt_roman(gt_tbl_dec: GT):
-
     gt_tbl_built = gt_tbl_dec.fmt_roman(columns="x", rows=0, pattern="{x} _")._build_data(
         context="latex"
     )
@@ -412,7 +374,6 @@ def test_create_body_component_l_fmt_roman(gt_tbl_dec: GT):
 
 
 def test_create_wrap_start():
-
     assert create_wrap_start_l(use_longtable=False, tbl_pos=None) == "\\begin{table}[!t]"
     assert create_wrap_start_l(use_longtable=False, tbl_pos="!b") == "\\begin{table}[!b]"
     assert create_wrap_start_l(use_longtable=True, tbl_pos=None) == "\\begingroup"
@@ -420,25 +381,21 @@ def test_create_wrap_start():
 
 @mock.patch.dict(os.environ, {"QUARTO_BIN_PATH": "1"}, clear=True)
 def test_create_wrap_start_quarto():
-
     assert create_wrap_start_l(use_longtable=False, tbl_pos="!t") == "\\begin{table}"
     assert create_wrap_start_l(use_longtable=True, tbl_pos="!t") == "\\begingroup"
 
 
 def test_create_wrap_end_l():
-
     assert create_wrap_end_l(use_longtable=False) == "\\end{table}"
     assert create_wrap_end_l(use_longtable=True) == "\\endgroup"
 
 
 def test_create_table_end_l_longtable():
-
     assert create_table_end_l(use_longtable=False) == "\\bottomrule\n\\end{tabular*}"
     assert create_table_end_l(use_longtable=True) == "\\bottomrule\n\\end{longtable}"
 
 
 def test_create_table_start_l_longtable(gt_tbl: GT):
-
     gt_tbl_no_source_notes = gt_tbl._build_data(context="latex")
     gt_tbl_source_notes = gt_tbl.tab_source_note(source_note="Note")._build_data(context="latex")
 
@@ -460,7 +417,6 @@ def test_create_table_start_l_longtable(gt_tbl: GT):
 
 
 def test_create_table_start_l_float_tbl_pct(gt_tbl: GT):
-
     gt_tbl_new = gt_tbl.tab_options(table_width="50%")
 
     assert (
@@ -473,7 +429,6 @@ def test_create_table_start_l_float_tbl_pct(gt_tbl: GT):
 
 
 def test_create_table_start_l_float_tbl_px(gt_tbl: GT):
-
     gt_tbl_new = gt_tbl.tab_options(table_width="500px")
 
     assert (
@@ -486,7 +441,6 @@ def test_create_table_start_l_float_tbl_px(gt_tbl: GT):
 
 
 def test_create_table_start_l_float_tbl_auto(gt_tbl: GT):
-
     gt_tbl_new = gt_tbl.tab_options(table_width="auto")
 
     assert (
@@ -499,7 +453,6 @@ def test_create_table_start_l_float_tbl_auto(gt_tbl: GT):
 
 
 def test_snap_render_as_latex_longtable(snapshot):
-
     gt_tbl = (
         GT(
             gtcars[["mfr", "model", "hp", "trq", "msrp"]].head(5),
@@ -521,7 +474,6 @@ def test_snap_render_as_latex_longtable(snapshot):
 
 
 def test_snap_render_as_latex_floating_table(snapshot):
-
     gt_tbl = (
         GT(
             gtcars[["mfr", "model", "hp", "trq", "msrp"]].head(5),


### PR DESCRIPTION
Hello team,  

I ran `mypy` on our codebase and resolved around 60 reported errors in this PR (leaving 300+ errors still to address). Most of the changes involve refining type hints.  

Based on my observations, `mypy` seems to struggle with the following scenarios:  
* Redefining a variable within the same scope while changing its type.  
* Fully understanding the logic behind our `DataFrame` backend.  
* Recognizing that `GTSelf` is a `TypeVar` for `GTData`, which causes many `GT` attributes to be flagged as "not found."  
* Handling returned values that might include `None`, which can be challenging to annotate correctly.  

Feel free to accept, reject, or modify anything in this PR.
