### PR TITLE
Feat: accounting notation for `fmt_number()`, `fmt_percent()`, `fmt_integer()` and `fmt_currency()`

### DIFF
--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -22,15 +22,14 @@ from ._tbl_data import (
     DataFrameLike,
     PlExpr,
     SelectExpr,
+    _get_column_dtype,
     is_na,
     is_series,
     to_list,
-    _get_column_dtype,
 )
 from ._text import _md_html, escape_pattern_str_latex
 from ._utils import _str_detect, _str_replace
 from ._utils_nanoplots import _generate_nanoplot
-
 
 if TYPE_CHECKING:
     from ._types import GTSelf
@@ -213,8 +212,8 @@ def fmt_number(
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
     accounting
-        An option to use accounting style for values. Normally, negative values will be shown with a
-        minus sign but using accounting style will instead put any negative values in parentheses.
+        Whether to use accounting style, which wraps negative numbers in parentheses instead of
+        using a minus sign.
     scale_by
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
@@ -363,7 +362,6 @@ def fmt_number_context(
 
     # Implement minus sign replacement for `x_formatted` or use accounting style
     if is_negative:
-
         if accounting:
             x_formatted = f"({_remove_minus(x_formatted)})"
 
@@ -430,8 +428,8 @@ def fmt_integer(
         Since the `default` value is `1`, no values will be changed unless a different multiplier
         value is supplied.
     accounting
-        An option to use accounting style for values. Normally, negative values will be shown with a
-        minus sign but using accounting style will instead put any negative values in parentheses.
+        Whether to use accounting style, which wraps negative numbers in parentheses instead of
+        using a minus sign.
     compact
         A boolean value that allows for compact formatting of numeric values. Values will be scaled
         and decorated with the appropriate suffixes (e.g., `1230` becomes `1K`, and `1230000`
@@ -561,7 +559,6 @@ def fmt_integer_context(
 
     # Implement minus sign replacement for `x_formatted` or use accounting style
     if is_negative:
-
         if accounting:
             x_formatted = f"({_remove_minus(x_formatted)})"
 
@@ -931,8 +928,8 @@ def fmt_percent(
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
     accounting
-        An option to use accounting style for values. Normally, negative values will be shown with a
-        minus sign but using accounting style will instead put any negative values in parentheses.
+        Whether to use accounting style, which wraps negative numbers in parentheses instead of
+        using a minus sign.
     pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
@@ -1096,7 +1093,6 @@ def fmt_percent_context(
 
     # Implement minus sign replacement for `x_formatted` or use accounting style
     if is_negative:
-
         if accounting:
             x_formatted = f"({_remove_minus(x_formatted)})"
 
@@ -1185,8 +1181,8 @@ def fmt_currency(
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
     accounting
-        An option to use accounting style for values. Normally, negative values will be shown with a
-        minus sign but using accounting style will instead put any negative values in parentheses.
+        Whether to use accounting style, which wraps negative numbers in parentheses instead of
+        using a minus sign.
     scale_by
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
@@ -1371,7 +1367,6 @@ def fmt_currency_context(
 
     # Implement minus sign replacement for `x_formatted` or use accounting style
     if is_negative:
-
         if accounting:
             x_formatted = f"({_remove_minus(x_formatted)})"
 
@@ -3821,8 +3816,9 @@ class FmtImage:
         return span
 
     def to_latex(self, val: Any):
-        from ._gt_data import FormatterSkipElement
         from warnings import warn
+
+        from ._gt_data import FormatterSkipElement
 
         warn("fmt_image() is not currently implemented in LaTeX output.")
 

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -153,6 +153,7 @@ def fmt_number(
     drop_trailing_zeros: bool = False,
     drop_trailing_dec_mark: bool = True,
     use_seps: bool = True,
+    accounting: bool = False,
     scale_by: float = 1,
     compact: bool = False,
     pattern: str = "{x}",
@@ -211,6 +212,9 @@ def fmt_number(
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
+    accounting
+        An option to use accounting style for values. Normally, negative values will be shown with a
+        minus sign but using accounting style will instead put any negative values in parentheses.
     scale_by
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
@@ -294,6 +298,7 @@ def fmt_number(
         drop_trailing_zeros=drop_trailing_zeros,
         drop_trailing_dec_mark=drop_trailing_dec_mark,
         use_seps=use_seps,
+        accounting=accounting,
         scale_by=scale_by,
         compact=compact,
         sep_mark=sep_mark,
@@ -313,6 +318,7 @@ def fmt_number_context(
     drop_trailing_zeros: bool,
     drop_trailing_dec_mark: bool,
     use_seps: bool,
+    accounting: bool,
     scale_by: float,
     compact: bool,
     sep_mark: str,
@@ -355,10 +361,15 @@ def fmt_number_context(
             force_sign=force_sign,
         )
 
-    # Implement minus sign replacement for `x_formatted`
+    # Implement minus sign replacement for `x_formatted` or use accounting style
     if is_negative:
-        minus_mark = _context_minus_mark(context=context)
-        x_formatted = _replace_minus(x_formatted, minus_mark=minus_mark)
+
+        if accounting:
+            x_formatted = f"({_remove_minus(x_formatted)})"
+
+        else:
+            minus_mark = _context_minus_mark(context=context)
+            x_formatted = _replace_minus(x_formatted, minus_mark=minus_mark)
 
     # Use a supplied pattern specification to decorate the formatted value
     if pattern != "{x}":

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -873,6 +873,7 @@ def fmt_percent(
     drop_trailing_dec_mark: bool = True,
     scale_values: bool = True,
     use_seps: bool = True,
+    accounting: bool = False,
     pattern: str = "{x}",
     sep_mark: str = ",",
     dec_mark: str = ".",
@@ -932,6 +933,9 @@ def fmt_percent(
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
+    accounting
+        An option to use accounting style for values. Normally, negative values will be shown with a
+        minus sign but using accounting style will instead put any negative values in parentheses.
     pattern
         A formatting pattern that allows for decoration of the formatted value. The formatted value
         is represented by the `{x}` (which can be used multiple times, if needed) and all other
@@ -1019,6 +1023,7 @@ def fmt_percent(
         drop_trailing_zeros=drop_trailing_zeros,
         drop_trailing_dec_mark=drop_trailing_dec_mark,
         use_seps=use_seps,
+        accounting=accounting,
         scale_by=scale_by,
         sep_mark=sep_mark,
         dec_mark=dec_mark,
@@ -1038,6 +1043,7 @@ def fmt_percent_context(
     drop_trailing_zeros: bool,
     drop_trailing_dec_mark: bool,
     use_seps: bool,
+    accounting: bool,
     scale_by: float,
     sep_mark: str,
     dec_mark: str,
@@ -1091,10 +1097,15 @@ def fmt_percent_context(
     else:
         x_formatted = percent_pattern.replace("{x}", x_formatted)
 
-    # Implement minus sign replacement for `x_formatted`
+    # Implement minus sign replacement for `x_formatted` or use accounting style
     if is_negative:
-        minus_mark = _context_minus_mark(context="html")
-        x_formatted = _replace_minus(x_formatted, minus_mark=minus_mark)
+
+        if accounting:
+            x_formatted = f"({_remove_minus(x_formatted)})"
+
+        else:
+            minus_mark = _context_minus_mark(context=context)
+            x_formatted = _replace_minus(x_formatted, minus_mark=minus_mark)
 
     # Use a supplied pattern specification to decorate the formatted value
     if pattern != "{x}":

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -389,6 +389,7 @@ def fmt_integer(
     rows: int | list[int] | None = None,
     use_seps: bool = True,
     scale_by: float = 1,
+    accounting: bool = False,
     compact: bool = False,
     pattern: str = "{x}",
     sep_mark: str = ",",
@@ -429,6 +430,9 @@ def fmt_integer(
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
         value is supplied.
+    accounting
+        An option to use accounting style for values. Normally, negative values will be shown with a
+        minus sign but using accounting style will instead put any negative values in parentheses.
     compact
         A boolean value that allows for compact formatting of numeric values. Values will be scaled
         and decorated with the appropriate suffixes (e.g., `1230` becomes `1K`, and `1230000`
@@ -499,6 +503,7 @@ def fmt_integer(
         data=self,
         use_seps=use_seps,
         scale_by=scale_by,
+        accounting=accounting,
         compact=compact,
         sep_mark=sep_mark,
         force_sign=force_sign,
@@ -513,6 +518,7 @@ def fmt_integer_context(
     data: GTData,
     use_seps: bool,
     scale_by: float,
+    accounting: bool,
     compact: bool,
     sep_mark: str,
     force_sign: bool,
@@ -554,10 +560,15 @@ def fmt_integer_context(
             force_sign=force_sign,
         )
 
-    # Implement minus sign replacement for `x_formatted`
+    # Implement minus sign replacement for `x_formatted` or use accounting style
     if is_negative:
-        minus_mark = _context_minus_mark(context=context)
-        x_formatted = _replace_minus(x_formatted, minus_mark=minus_mark)
+
+        if accounting:
+            x_formatted = f"({_remove_minus(x_formatted)})"
+
+        else:
+            minus_mark = _context_minus_mark(context=context)
+            x_formatted = _replace_minus(x_formatted, minus_mark=minus_mark)
 
     # Use a supplied pattern specification to decorate the formatted value
     if pattern != "{x}":

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -3004,6 +3004,19 @@ def _replace_minus(string: str, minus_mark: str) -> str:
     return _str_replace(string, "-", minus_mark)
 
 
+def _remove_minus(string: str) -> str:
+    """
+    Removes all occurrences of the minus sign '-' in the given string.
+
+    Args:
+        string (str): The input string.
+
+    Returns:
+        str: The modified string with the minus sign removed.
+    """
+    return _str_replace(string, "-", "")
+
+
 T_dict = TypeVar("T_dict", bound=TypedDict)
 
 

--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -1128,6 +1128,7 @@ def fmt_currency(
     decimals: int | None = None,
     drop_trailing_dec_mark: bool = True,
     use_seps: bool = True,
+    accounting: bool = False,
     scale_by: float = 1,
     pattern: str = "{x}",
     sep_mark: str = ",",
@@ -1187,6 +1188,9 @@ def fmt_currency(
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
+    accounting
+        An option to use accounting style for values. Normally, negative values will be shown with a
+        minus sign but using accounting style will instead put any negative values in parentheses.
     scale_by
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
@@ -1290,6 +1294,7 @@ def fmt_currency(
         decimals=decimals,
         drop_trailing_dec_mark=drop_trailing_dec_mark,
         use_seps=use_seps,
+        accounting=accounting,
         scale_by=scale_by,
         sep_mark=sep_mark,
         dec_mark=dec_mark,
@@ -1309,6 +1314,7 @@ def fmt_currency_context(
     decimals: int,
     drop_trailing_dec_mark: bool,
     use_seps: bool,
+    accounting: bool,
     scale_by: float,
     sep_mark: str,
     dec_mark: str,
@@ -1367,10 +1373,15 @@ def fmt_currency_context(
     else:
         x_formatted = currency_pattern.replace("{x}", x_formatted)
 
-    # Implement minus sign replacement for `x_formatted`
+    # Implement minus sign replacement for `x_formatted` or use accounting style
     if is_negative:
-        minus_mark = _context_minus_mark(context=context)
-        x_formatted = _replace_minus(x_formatted, minus_mark=minus_mark)
+
+        if accounting:
+            x_formatted = f"({_remove_minus(x_formatted)})"
+
+        else:
+            minus_mark = _context_minus_mark(context=context)
+            x_formatted = _replace_minus(x_formatted, minus_mark=minus_mark)
 
     # Use a supplied pattern specification to decorate the formatted value
     if pattern != "{x}":

--- a/great_tables/_formats_vals.py
+++ b/great_tables/_formats_vals.py
@@ -55,6 +55,7 @@ def val_fmt_number(
     drop_trailing_zeros: bool = False,
     drop_trailing_dec_mark: bool = True,
     use_seps: bool = True,
+    accounting: bool = False,
     scale_by: float = 1,
     compact: bool = False,
     pattern: str = "{x}",
@@ -108,6 +109,9 @@ def val_fmt_number(
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
+    accounting
+        An option to use accounting style for values. Normally, negative values will be shown with a
+        minus sign but using accounting style will instead put any negative values in parentheses.
     scale_by
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
@@ -151,6 +155,7 @@ def val_fmt_number(
         drop_trailing_zeros=drop_trailing_zeros,
         drop_trailing_dec_mark=drop_trailing_dec_mark,
         use_seps=use_seps,
+        accounting=accounting,
         scale_by=scale_by,
         compact=compact,
         pattern=pattern,
@@ -168,6 +173,7 @@ def val_fmt_number(
 def val_fmt_integer(
     x: X,
     use_seps: bool = True,
+    accounting: bool = False,
     scale_by: float = 1,
     compact: bool = False,
     pattern: str = "{x}",
@@ -200,6 +206,9 @@ def val_fmt_integer(
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
         setting is `True` by default.
+    accounting
+        An option to use accounting style for values. Normally, negative values will be shown with a
+        minus sign but using accounting style will instead put any negative values in parentheses.
     scale_by
         All numeric values will be multiplied by the `scale_by` value before undergoing formatting.
         Since the `default` value is `1`, no values will be changed unless a different multiplier
@@ -235,6 +244,7 @@ def val_fmt_integer(
     gt_obj_fmt = gt_obj.fmt_integer(
         columns="x",
         use_seps=use_seps,
+        accounting=accounting,
         scale_by=scale_by,
         compact=compact,
         pattern=pattern,
@@ -376,6 +386,7 @@ def val_fmt_percent(
     drop_trailing_zeros: bool = False,
     drop_trailing_dec_mark: bool = True,
     scale_values: bool = True,
+    accounting: bool = False,
     use_seps: bool = True,
     pattern: str = "{x}",
     sep_mark: str = ",",
@@ -427,6 +438,9 @@ def val_fmt_percent(
         performed since the expectation is that incoming values are usually proportional. Setting to
         `False` signifies that the values are already scaled and require only the percent sign when
         formatted.
+    accounting
+        An option to use accounting style for values. Normally, negative values will be shown with a
+        minus sign but using accounting style will instead put any negative values in parentheses.
     use_seps
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
@@ -471,6 +485,7 @@ def val_fmt_percent(
         drop_trailing_zeros=drop_trailing_zeros,
         drop_trailing_dec_mark=drop_trailing_dec_mark,
         scale_values=scale_values,
+        accounting=accounting,
         use_seps=use_seps,
         pattern=pattern,
         sep_mark=sep_mark,
@@ -492,6 +507,7 @@ def val_fmt_currency(
     use_subunits: bool = True,
     decimals: int | None = None,
     drop_trailing_dec_mark: bool = True,
+    accounting: bool = False,
     use_seps: bool = True,
     scale_by: float = 1,
     pattern: str = "{x}",
@@ -543,6 +559,9 @@ def val_fmt_currency(
         A boolean value that determines whether decimal marks should always appear even if there are
         no decimal digits to display after formatting (e.g., `23` becomes `23.` if `False`). By
         default trailing decimal marks are not shown.
+    accounting
+        An option to use accounting style for values. Normally, negative values will be shown with a
+        minus sign but using accounting style will instead put any negative values in parentheses.
     use_seps
         The `use_seps` option allows for the use of digit group separators. The type of digit group
         separator is set by `sep_mark` and overridden if a locale ID is provided to `locale`. This
@@ -591,6 +610,7 @@ def val_fmt_currency(
         use_subunits=use_subunits,
         decimals=decimals,
         drop_trailing_dec_mark=drop_trailing_dec_mark,
+        accounting=accounting,
         use_seps=use_seps,
         scale_by=scale_by,
         pattern=pattern,

--- a/tests/__snapshots__/test_formats.ambr
+++ b/tests/__snapshots__/test_formats.ambr
@@ -11,6 +11,49 @@
   </tbody>
   '''
 # ---
+# name: test_format_accounting_snap
+  '''
+  class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
+  <thead>
+  
+  <tr class="gt_col_headings">
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="number">number</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="percent">percent</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="integer">integer</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="currency">currency</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="number_acc">number_acc</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="percent_acc">percent_acc</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="integer_acc">integer_acc</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="currency_acc">currency_acc</th>
+  </tr>
+  </thead>
+  <tbody class="gt_table_body">
+    <tr>
+      <td class="gt_row gt_right">−1.20</td>
+      <td class="gt_row gt_right">−5.23%</td>
+      <td class="gt_row gt_right">2,323</td>
+      <td class="gt_row gt_right">−$24,334.23</td>
+      <td class="gt_row gt_right">(1.20)</td>
+      <td class="gt_row gt_right">(5.23%)</td>
+      <td class="gt_row gt_right">2,323</td>
+      <td class="gt_row gt_right">($24,334.23)</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">23.60</td>
+      <td class="gt_row gt_right">36.30%</td>
+      <td class="gt_row gt_right">−23,213</td>
+      <td class="gt_row gt_right">$7,323.25</td>
+      <td class="gt_row gt_right">23.60</td>
+      <td class="gt_row gt_right">36.30%</td>
+      <td class="gt_row gt_right">(23,213)</td>
+      <td class="gt_row gt_right">$7,323.25</td>
+    </tr>
+  </tbody>
+  
+  
+  
+  '''
+# ---
 # name: test_format_repr_snap
   '''
   class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -68,6 +68,37 @@ def test_format_snap(snapshot):
     assert_rendered_body(snapshot, new_gt)
 
 
+def test_format_accounting_snap(snapshot):
+
+    df = pl.DataFrame(
+        {
+            "number": [-1.2, 23.6],
+            "percent": [-0.0523, 0.363],
+            "integer": [2323, -23213],
+            "currency": [-24334.23, 7323.253],
+        }
+    ).with_columns(
+        number_acc=pl.col("number"),
+        percent_acc=pl.col("percent"),
+        integer_acc=pl.col("integer"),
+        currency_acc=pl.col("currency"),
+    )
+
+    new_gt = (
+        GT(df)
+        .fmt_number(columns="number")
+        .fmt_percent(columns="percent")
+        .fmt_integer(columns="integer")
+        .fmt_currency(columns="currency")
+        .fmt_number(columns="number_acc", accounting=True)
+        .fmt_percent(columns="percent_acc", accounting=True)
+        .fmt_integer(columns="integer_acc", accounting=True)
+        .fmt_currency(columns="currency_acc", accounting=True)
+    )
+
+    assert_repr_html(snapshot, new_gt)
+
+
 def test_format_repr_snap(snapshot):
     new_gt = (
         GT(exibble)

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -69,7 +69,6 @@ def test_format_snap(snapshot):
 
 
 def test_format_accounting_snap(snapshot):
-
     df = pl.DataFrame(
         {
             "number": [-1.2, 23.6],


### PR DESCRIPTION
This introduces the `accounting=` arg to `fmt_number()`, `fmt_percent()`, `fmt_integer()` and `fmt_currency()`, allowing for accounting notation (e.g., `"-343.27"` -> `"(343.27)"`. This new functionality also extends to the same formatters in the `vals` module.

Here is an example table demonstrating usage:

```python
from great_tables import GT
import polars as pl

df = pl.DataFrame(
    {"number": [-1.2, 23.6], "percent": [-0.0523, 0.363], "integer": [2323, -23213], "currency": [-24334.23, 7323.253]}
).with_columns(number_acc = pl.col("number"), percent_acc = pl.col("percent"), integer_acc = pl.col("integer"), currency_acc = pl.col("currency"))

(
    GT(df)
    .fmt_number(columns="number")
    .fmt_percent(columns="percent")
    .fmt_integer(columns="integer")
    .fmt_currency(columns="currency")
    .fmt_number(columns="number_acc", accounting=True)
    .fmt_percent(columns="percent_acc", accounting=True)
    .fmt_integer(columns="integer_acc", accounting=True)
    .fmt_currency(columns="currency_acc", accounting=True)
    .tab_spanner(label="Default formatting", columns=[0, 1, 2, 3])
    .tab_spanner(label="Accounting notation", columns=[4, 5, 6, 7])
)
```

<img width="814" alt="image" src="https://github.com/user-attachments/assets/2a912bad-34d6-4e17-9c5f-fafa390263b6">

Fixes: #278 
