### PR TITLE
Enhance `GT.fmt_image()` to support http/https schema in the `columns` parameter

### DIFF
--- a/great_tables/_utils.py
+++ b/great_tables/_utils.py
@@ -281,3 +281,7 @@ def _migrate_unformatted_to_output(
 # Define the type of `data` as `TblData` when doing so won't result in a circular import
 def _get_visible_cells(data: TblData) -> list[tuple[str, int]]:
     return [(col, row) for col in get_column_names(data) for row in range(n_rows(data))]
+
+
+def is_valid_http_schema(url: str) -> bool:
+    return url.startswith("http://") or url.startswith("https://")

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1493,6 +1493,20 @@ def test_fmt_image_path_http(url: str):
 
 
 @pytest.mark.parametrize(
+    "url", ["http://posit.co/", "http://posit.co", "https://posit.co/", "https://posit.co"]
+)
+def test_fmt_image_http(url: str):
+    formatter = FmtImage(encode=False, height=30)
+    res = formatter.to_html(url)
+    dst_img = '<img src="{}" style="height: 30px;vertical-align: middle;">'.format(
+        url.removesuffix("/")
+    )
+    dst = formatter.SPAN_TEMPLATE.format(dst_img)
+
+    assert strip_windows_drive(res) == dst
+
+
+@pytest.mark.parametrize(
     "src,dst",
     [
         # 1. unit with superscript

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 from collections.abc import Generator
-from pathlib import Path
 import pytest
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 from collections.abc import Generator
+from pathlib import Path
 import pytest
+
 
 from great_tables import GT, exibble
 from great_tables._tbl_data import is_na
@@ -14,6 +16,7 @@ from great_tables._utils import (
     _migrate_unformatted_to_output,
     OrderedSet,
     _str_scalar_to_list,
+    is_valid_http_schema,
     heading_has_subtitle,
     heading_has_title,
     seq_groups,
@@ -215,3 +218,10 @@ def test_migrate_unformatted_to_output_html():
     )
 
     assert is_na(migrated._body.body, migrated._body.body["char"].tolist()).tolist() == [True, True]
+
+
+@pytest.mark.parametrize(
+    "url", ["http://posit.co/", "http://posit.co", "https://posit.co/", "https://posit.co"]
+)
+def test_is_valid_http_schema(url: str):
+    assert is_valid_http_schema(url)


### PR DESCRIPTION
Related PRs: #444, #451.

Currently, `GT.fmt_image()` supports formatting images from URLs by combining the `columns` and `path` parameters, as shown below:  
```python
import polars as pl
from great_tables import GT, vals, html

img_path = "https://raw.githubusercontent.com/posit-dev/great-tables/refs/heads/main/great_tables/data/metro_images/"

df = pl.DataFrame({"lines": ["tram_T6.svg", "tram_T7.svg", "tram_T8.svg"]})
GT(df).fmt_image("lines", path=img_path)
```  
![image](https://github.com/user-attachments/assets/d14dfd9e-33d8-4863-baf7-3c7cd13321c8)

<hr>

This PR proposes an enhancement to allow image formatting using only the `columns` parameter, enabling the following code to execute without errors:  
```python
df2 = df.with_columns(pl.lit(img_path).add(pl.col("lines")).alias("lines"))
```  
![image](https://github.com/user-attachments/assets/a141532c-3385-4d7c-8012-4647fa3b1a3c)

```python
GT(df2).fmt_image("lines")  # It produces the same table as the original approach.
```
This modification should benefit users who retrieve a list of URLs through a database query and store them as a column in the DataFrame. A possible scenario can be illustrated with the following pseudo-code:  

```python
...
urls: list[str] = db.execute("SELECT url FROM Foo")
df = pl.DataFrame({"urls": urls})
GT(df).fmt_image("urls")
```

<hr>

Additionally, this change would make it more convenient for users who want to place images in locations other than the body using `vals.fmt_image()`. For example:  
```python
header_imgs = vals.fmt_image(f"{img_path}tram_T5.svg")
GT(df2).fmt_image("lines").tab_header(title=html(header_imgs[0]))
```  
![image](https://github.com/user-attachments/assets/21dab93d-40dd-45c9-897d-f821c5d05f0c)

<hr>

I believe this improvement will enhance the user experience and better align with the documentation, which states that [complete http/https URLs should be accepted](https://posit-dev.github.io/great-tables/reference/GT.fmt_image.html#great_tables.GT.fmt_image). That said, I'm open to any suggestions or feedback!