### PR TITLE
Standardize imports by converting absolute imports to relative imports

### DIFF
--- a/great_tables/__init__.py
+++ b/great_tables/__init__.py
@@ -8,9 +8,7 @@ del _v
 # Main gt imports ----
 
 from .gt import GT
-from . import vals
-from . import loc
-from . import style
+from . import vals, loc, style
 from ._styles import FromColumn as from_column
 from ._helpers import (
     letters,

--- a/great_tables/_formats_vals.py
+++ b/great_tables/_formats_vals.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from pathlib import Path
 
-from great_tables import GT
-from great_tables.gt import GT, _get_column_of_values
 from typing_extensions import TypeAlias
 
+from .gt import GT, _get_column_of_values
 from ._gt_data import GTData
 from ._tbl_data import SeriesLike, to_frame
 

--- a/great_tables/_helpers.py
+++ b/great_tables/_helpers.py
@@ -8,9 +8,7 @@ from typing import Any, Callable, Literal
 
 from typing_extensions import Self, TypeAlias
 
-from great_tables._text import _md_html
-
-from ._text import BaseText, Html, Md
+from ._text import BaseText, Html, Md, _md_html
 
 FontStackName: TypeAlias = Literal[
     "system-ui",

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, fields, replace
 from typing import TYPE_CHECKING, ClassVar, cast, Iterable
 
-from great_tables import _utils
-from great_tables._helpers import FontStackName, GoogleFont, _intify_scaled_px, px
+from . import _utils
+from ._helpers import FontStackName, GoogleFont, _intify_scaled_px, px
 
 
 if TYPE_CHECKING:

--- a/great_tables/_utils.py
+++ b/great_tables/_utils.py
@@ -11,8 +11,8 @@ from ._tbl_data import _get_cell, _set_cell, get_column_names, n_rows
 from ._text import BaseText, _process_text
 
 if TYPE_CHECKING:
-    from great_tables._gt_data import FormatInfo, GTData
-    from great_tables._tbl_data import TblData
+    from ._gt_data import FormatInfo, GTData
+    from ._tbl_data import TblData
 
 
 def _try_import(name: str, pip_install_line: str | None = None) -> ModuleType:

--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from typing import Any, Callable
 
 import numpy as np
-from great_tables._tbl_data import Agnostic, is_na
-from great_tables._utils import _match_arg, _flatten_list
+from ._tbl_data import Agnostic, is_na
+from ._utils import _match_arg, _flatten_list
 
 REFERENCE_LINE_KEYWORDS = ["mean", "median", "min", "max", "q1", "q3"]
 

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING
 from typing_extensions import Self
 
-from great_tables._gt_data import GTData
+from ._gt_data import GTData
 
 # Main gt imports ----
-from great_tables._body import body_reassemble
-from great_tables._boxhead import cols_align, cols_label
-from great_tables._data_color import data_color
-from great_tables._export import as_raw_html, as_latex, save, show
-from great_tables._formats import (
+from ._body import body_reassemble
+from ._boxhead import cols_align, cols_label
+from ._data_color import data_color
+from ._export import as_raw_html, as_latex, save, show
+from ._formats import (
     fmt,
     fmt_bytes,
     fmt_currency,
@@ -27,15 +27,15 @@ from great_tables._formats import (
     fmt_time,
     fmt_units,
 )
-from great_tables._heading import tab_header
-from great_tables._helpers import random_id
-from great_tables._modify_rows import (
+from ._heading import tab_header
+from ._helpers import random_id
+from ._modify_rows import (
     row_group_order,
     tab_stub,
     with_id,
     with_locale,
 )
-from great_tables._options import (
+from ._options import (
     opt_align_table_header,
     opt_all_caps,
     opt_footnote_marks,
@@ -47,9 +47,9 @@ from great_tables._options import (
     opt_vertical_padding,
     tab_options,
 )
-from great_tables._render import infer_render_env_defaults
-from great_tables._source_notes import tab_source_note
-from great_tables._spanners import (
+from ._render import infer_render_env_defaults
+from ._source_notes import tab_source_note
+from ._spanners import (
     cols_hide,
     cols_move,
     cols_move_to_end,
@@ -57,13 +57,13 @@ from great_tables._spanners import (
     cols_width,
     tab_spanner,
 )
-from great_tables._stub import reorder_stub_df
-from great_tables._stubhead import tab_stubhead
-from great_tables._substitution import sub_missing, sub_zero
-from great_tables._tab_create_modify import tab_style
-from great_tables._tbl_data import _get_cell, n_rows
-from great_tables._utils import _migrate_unformatted_to_output
-from great_tables._utils_render_html import (
+from ._stub import reorder_stub_df
+from ._stubhead import tab_stubhead
+from ._substitution import sub_missing, sub_zero
+from ._tab_create_modify import tab_style
+from ._tbl_data import _get_cell, n_rows
+from ._utils import _migrate_unformatted_to_output
+from ._utils_render_html import (
     _get_table_defs,
     create_body_component_h,
     create_columns_component_h,

--- a/great_tables/shiny.py
+++ b/great_tables/shiny.py
@@ -5,7 +5,7 @@ __all__ = (
     "render_gt",
 )
 
-from great_tables import GT
+from .gt import GT
 from htmltools import Tag, div, HTML
 
 try:


### PR DESCRIPTION
This PR aims to ensure consistency by converting all absolute imports to relative imports across most of our modules, as the majority already use relative imports. However, for the `_data_color` folder, I felt it was more natural to retain absolute imports, so those have been left unchanged.