### PR TITLE
docs: add text about Pandas req for use of datasets

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -235,7 +235,8 @@ quartodoc:
       desc: >
         The **Great Tables** package is equipped with sixteen datasets that come in all shapes and
         sizes. Many examples thoughout the help docs use these datasets to quickly demonstrate the
-        awesome features of the package!
+        awesome features of the package! Please note that using any of these datasets requires the
+        Pandas library to be installed.
       contents:
         - data.countrypops
         - data.sza


### PR DESCRIPTION
This addresses a pyOpenSci reviewer comment. In the API reference section of the docs site, there is a note about a requirement for a Pandas installation when using any of the datasets from the `datasets` module.

Fixes: https://github.com/posit-dev/great-tables/issues/529