### PR TITLE
docs: add CITATION.cff file, link to CITATION text in README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,29 @@
+cff-version: 1.2.0
+message: 'If you wish to cite the "great-tables" package use:'
+type: software
+license: MIT
+title: "great-tables: Make awesome display tables using Python."
+version: 0.14.0
+abstract:
+  Build display tables from tabular data with an easy-to-use set of methods.
+  With its progressive approach, we can construct display tables with a cohesive set
+  of table parts. Table values can be formatted using any of the included formatting
+  functions. Cell styles can be precisely added through a location targeting system. The way
+  in which Great Tables handles things for you means that you don't often have to worry about
+  the fine details.
+authors:
+  - family-names: Iannone
+    given-names: Richard
+    email: rich@posit.co
+    orcid: https://orcid.org/0000-0003-3925-190X
+  - family-names: Michael
+    given-names: Chow
+    email: michael.chow@posit.co
+repository: https://pypi.org/project/great-tables/
+repository-code: https://github.com/posit-dev/great-tables
+url: https://posit-dev.github.io/great-tables/
+contact:
+  - family-names: Iannone
+    given-names: Richard
+    email: rich@posit.co
+    orcid: https://orcid.org/0000-0003-3925-190X

--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ Please note that the **Great Tables** project is released with a [contributor co
 
 © Posit Software, PBC.
 
+## Citation
+
+If you use **Great Tables** in your research/project/product, we would appreciate a citation to the package. You can cite the package using the following BibTeX entry:
+
+```bibtex
+@software{Iannone_great_tables,
+author = {Iannone, Richard and Chow, Michael},
+license = {MIT},
+title = {{great-tables: Make awesome display tables using Python.}},
+url = {https://github.com/posit-dev/great-tables},
+version = {0.14.0}
+}
+```
+
 ## 🏛️ Governance
 
 This project is primarily maintained by [Rich Iannone](https://twitter.com/riannone) and [Michael Chow](https://twitter.com/chowthedog).


### PR DESCRIPTION
This addresses a pyOpenSci reviewer comment related to citation information. The recommendation was to include a CITATION file and link to it from the README.md file (or other docs). Here, we have added the CITATION.cff file at the top level. A *Citation* section has been added to README.md file along with the bibtex citation text.

Fixes: https://github.com/posit-dev/great-tables/issues/531