### PR TITLE
test: update accounting table example test and snapshot

### DIFF
--- a/tests/__snapshots__/test_formats.ambr
+++ b/tests/__snapshots__/test_formats.ambr
@@ -31,21 +31,21 @@
     <tr>
       <td class="gt_row gt_right">−1.20</td>
       <td class="gt_row gt_right">−5.23%</td>
-      <td class="gt_row gt_right">2,323</td>
+      <td class="gt_row gt_right">−23,213</td>
       <td class="gt_row gt_right">−$24,334.23</td>
       <td class="gt_row gt_right">(1.20)</td>
       <td class="gt_row gt_right">(5.23%)</td>
-      <td class="gt_row gt_right">2,323</td>
+      <td class="gt_row gt_right">(23,213)</td>
       <td class="gt_row gt_right">($24,334.23)</td>
     </tr>
     <tr>
       <td class="gt_row gt_right">23.60</td>
       <td class="gt_row gt_right">36.30%</td>
-      <td class="gt_row gt_right">−23,213</td>
+      <td class="gt_row gt_right">2,323</td>
       <td class="gt_row gt_right">$7,323.25</td>
       <td class="gt_row gt_right">23.60</td>
       <td class="gt_row gt_right">36.30%</td>
-      <td class="gt_row gt_right">(23,213)</td>
+      <td class="gt_row gt_right">2,323</td>
       <td class="gt_row gt_right">$7,323.25</td>
     </tr>
   </tbody>

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -73,7 +73,7 @@ def test_format_accounting_snap(snapshot):
         {
             "number": [-1.2, 23.6],
             "percent": [-0.0523, 0.363],
-            "integer": [2323, -23213],
+            "integer": [-23213, 2323],
             "currency": [-24334.23, 7323.253],
         }
     ).with_columns(


### PR DESCRIPTION
PR https://github.com/posit-dev/great-tables/pull/513 was merged before a final, desired change to a test/snapshot was added. This PR makes that change, and modifies the input table such that negative numbers are consistently in first row of the table, and positive values are in the second row.

Fixes: https://github.com/posit-dev/great-tables/issues/554