### PR TITLE
chore: exclude `if TYPE_CHECKING:` lines from coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,0 @@
-[report]
-exclude_lines =
-    if TYPE_CHECKING:
-    pragma: no cover

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+exclude_lines =
+    if TYPE_CHECKING:
+    pragma: no cover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,8 @@ ignore = [
     "F841",    # local variable 'name' is assigned to but never used
     "E702",    # multiple statements on one line (semicolon)
 ]
+
+[tool.coverage.report]
+exclude_also = [
+    if TYPE_CHECKING:
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,5 +115,5 @@ ignore = [
 
 [tool.coverage.report]
 exclude_also = [
-    if TYPE_CHECKING:
+    "if TYPE_CHECKING:"
 ]


### PR DESCRIPTION
This addresses a pyOpenSci reviewer comment related to test coverage reporting. The recommendation was to exclude `if TYPE_CHECKING:` lines from coverage reporting since the condition is always False at runtime. This is done here globally through the addition of a `.coveragerc` file.

Fixes: https://github.com/posit-dev/great-tables/issues/547