### PR TITLE
Fix deprecation warning in `as_raw_html` for Python 3.13

### DIFF
--- a/great_tables/_scss.py
+++ b/great_tables/_scss.py
@@ -166,18 +166,18 @@ def compile_scss(
     gt_styles_default = (files("great_tables") / "css/gt_styles_default.scss").read_text()
 
     if compress:
-        gt_styles_default = re.sub(r"\s+", " ", gt_styles_default, 0, re.MULTILINE)
-        gt_styles_default = re.sub(r"}", "}\n", gt_styles_default, 0, re.MULTILINE)
+        gt_styles_default = re.sub(r"\s+", " ", gt_styles_default, count=0, flags=re.MULTILINE)
+        gt_styles_default = re.sub(r"}", "}\n", gt_styles_default, count=0, flags=re.MULTILINE)
 
     compiled_css = Template(gt_styles_default).substitute(final_params)
 
     if has_id:
-        compiled_css = re.sub(r"\.gt_", f"#{id} .gt_", compiled_css, 0, re.MULTILINE)
-        compiled_css = re.sub(r"thead", f"#{id} thead", compiled_css, 0, re.MULTILINE)
-        compiled_css = re.sub(r"^( p|p) \{", f"#{id} p {{", compiled_css, 0, re.MULTILINE)
+        compiled_css = re.sub(r"\.gt_", f"#{id} .gt_", compiled_css, count=0, flags=re.MULTILINE)
+        compiled_css = re.sub(r"thead", f"#{id} thead", compiled_css, count=0, flags=re.MULTILINE)
+        compiled_css = re.sub(r"^( p|p) \{", f"#{id} p {{", compiled_css, count=0, flags=re.MULTILINE)
 
     if all_important:
-        compiled_css = re.sub(r";", " !important;", compiled_css, 0, re.MULTILINE)
+        compiled_css = re.sub(r";", " !important;", compiled_css, count=0, flags=re.MULTILINE)
 
     finalized_css = f"{gt_table_class_str}\n\n{compiled_css}"
 


### PR DESCRIPTION
# Summary

At Polars we have an integration with `great-tables`. We are adding Python 3.13 support and noticed a DeprecationWarning coming from great-tables in our test suite. Looks like it comes from the `as_raw_html` method, e.g.:

This was a simple fix, so I figured I'd just open a PR. Let me know if you need more context/input.

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.
