### PR TITLE
Support `mask=` argument in `LocBody`

### DIFF
--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -839,8 +839,6 @@ def resolve_mask_i(
     excl_group: bool = True,
 ) -> list[tuple[int, int, str]]:
     """Return data for creating `CellPos`, based on expr"""
-    import polars as pl
-
     if not isinstance(expr, PlExpr):
         raise ValueError("Only Polars expressions can be passed to the `mask` argument.")
 
@@ -861,7 +859,7 @@ def resolve_mask_i(
         raise ValueError("The `mask` may reference columns not in the original DataFrame.")
 
     # Validate that row lengths are equal
-    if not (masked.select(pl.len()).item(0, "len") == frame.select(pl.len()).item(0, "len")):
+    if masked.height != frame.height:
         raise ValueError("The DataFrame length after applying `mask` differs from the original.")
 
     cellpos_data: list[tuple[int, int, str]] = []  # column, row, colname for `CellPos`

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -832,7 +832,7 @@ def resolve_rows_i(
     )
 
 
-def resolve_mask_i(
+def resolve_mask(
     data: GTData | list[str],
     expr: PlExpr,
     excl_stub: bool = True,
@@ -930,7 +930,7 @@ def _(loc: LocBody, data: GTData) -> list[CellPos]:
             CellPos(col[1], row[1], colname=col[0]) for col, row in itertools.product(cols, rows)
         ]
     else:
-        cellpos_data = resolve_mask_i(data=data, expr=loc.mask)
+        cellpos_data = resolve_mask(data=data, expr=loc.mask)
         cell_pos = [CellPos(*cellpos) for cellpos in cellpos_data]
     return cell_pos
 

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -905,8 +905,10 @@ def _(loc: LocStub, data: GTData) -> set[int]:
 @resolve.register
 def _(loc: LocBody, data: GTData) -> list[CellPos]:
     cols = resolve_cols_i(data=data, expr=loc.columns)
-    if loc.rows is not None and loc.mask is not None:
-        raise ValueError("Cannot specify both `row` and `mask` arguments at the same time.")
+    if (loc.columns is not None or loc.rows is not None) and loc.mask is not None:
+        raise ValueError(
+            "Cannot specify the `mask` argument along with `columns` or `rows` in `loc.body()`."
+        )
 
     if loc.mask is None:
         rows = resolve_rows_i(data=data, expr=loc.rows)

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -918,8 +918,8 @@ def _(loc: LocBody, data: GTData) -> list[CellPos]:
             CellPos(col[1], row[1], colname=col[0]) for col, row in itertools.product(cols, rows)
         ]
     else:
-        masks = resolve_mask_i(data=data, expr=loc.mask)
-        cell_pos = [CellPos(*mask) for mask in masks]
+        cellpos_data = resolve_mask_i(data=data, expr=loc.mask)
+        cell_pos = [CellPos(*cellpos) for cellpos in cellpos_data]
     return cell_pos
 
 

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -502,6 +502,14 @@ class LocBody(Loc):
     rows
         The rows to target. Can either be a single row name or a series of row names provided in a
         list.
+    mask
+        The cells to target. If the underlying wrapped DataFrame is a Polars DataFrame,
+        you can pass a Polars expression for cell-based selection. This argument must be used
+        exclusively and cannot be combined with the `columns=` or `rows=` arguments.
+
+    :::{.callout-warning}
+    `mask=` is still experimental.
+    :::
 
     Returns
     -------

--- a/tests/test_tab_create_modify.py
+++ b/tests/test_tab_create_modify.py
@@ -130,7 +130,9 @@ def test_tab_style_loc_body_mask_not_polars_expression_raises(gt2: GT):
 def test_tab_style_loc_body_mask_columns_not_inside_raises(gt2: GT):
     style = CellStyleFill(color="blue")
     mask = pl.len()
-    err_msg = "The `mask` may reference columns not in the original DataFrame."
+    err_msg = (
+        "The `mask` expression produces extra columns, with names not in the original DataFrame."
+    )
 
     with pytest.raises(ValueError) as exc_info:
         tab_style(gt2, style, LocBody(mask=mask))

--- a/tests/test_tab_create_modify.py
+++ b/tests/test_tab_create_modify.py
@@ -13,6 +13,11 @@ def gt():
     return GT(pd.DataFrame({"x": [1, 2], "y": [4, 5]}))
 
 
+@pytest.fixture
+def gt2():
+    return GT(pl.DataFrame({"x": [1, 2], "y": [4, 5]}))
+
+
 def test_tab_style(gt: GT):
     style = CellStyleFill(color="blue")
     new_gt = tab_style(gt, style, LocBody(["x"], [0]))
@@ -32,30 +37,6 @@ def test_tab_style_multiple_columns(gt: GT):
 
     assert len(new_gt._styles[0].styles) == 1
     assert new_gt._styles[0].styles[0] is style
-
-
-def test_tab_style_loc_body_mask():
-    gt = GT(pl.DataFrame({"x": [1, 2], "y": [4, 5]}))
-    style = CellStyleFill(color="blue")
-    new_gt = tab_style(gt, style, LocBody(mask=cs.numeric().gt(1.5)))
-
-    assert len(gt._styles) == 0
-    assert len(new_gt._styles) == 3
-
-    xy_0y, xy_1x, xy_1y = new_gt._styles
-
-    assert xy_0y.styles[0] is style
-    assert xy_1x.styles[0] is style
-    assert xy_1y.styles[0] is style
-
-    assert xy_0y.rownum == 0
-    assert xy_0y.colname == "y"
-
-    assert xy_1x.rownum == 1
-    assert xy_1x.colname == "x"
-
-    assert xy_1y.rownum == 1
-    assert xy_1y.colname == "y"
 
 
 def test_tab_style_google_font(gt: GT):
@@ -96,3 +77,51 @@ def test_tab_style_font_from_column():
 
     assert rendered_html.find('<td style="font-family: Helvetica;" class="gt_row gt_right">1</td>')
     assert rendered_html.find('<td style="font-family: Courier;" class="gt_row gt_right">2</td>')
+
+
+def test_tab_style_loc_body_mask(gt2: GT):
+    style = CellStyleFill(color="blue")
+    new_gt = tab_style(gt2, style, LocBody(mask=cs.numeric().gt(1.5)))
+
+    assert len(gt2._styles) == 0
+    assert len(new_gt._styles) == 3
+
+    xy_0y, xy_1x, xy_1y = new_gt._styles
+
+    assert xy_0y.styles[0] is style
+    assert xy_1x.styles[0] is style
+    assert xy_1y.styles[0] is style
+
+    assert xy_0y.rownum == 0
+    assert xy_0y.colname == "y"
+
+    assert xy_1x.rownum == 1
+    assert xy_1x.colname == "x"
+
+    assert xy_1y.rownum == 1
+    assert xy_1y.colname == "y"
+
+
+def test_tab_style_loc_body_raises(gt2: GT):
+    style = CellStyleFill(color="blue")
+    mask = cs.numeric().gt(1.5)
+    err_msg = "Cannot specify the `mask` argument along with `columns` or `rows` in `loc.body()`."
+
+    with pytest.raises(ValueError) as exc_info:
+        tab_style(gt2, style, LocBody(columns=["x"], mask=mask))
+    assert err_msg in exc_info.value.args[0]
+
+    with pytest.raises(ValueError) as exc_info:
+        tab_style(gt2, style, LocBody(rows=[0], mask=mask))
+
+    assert err_msg in exc_info.value.args[0]
+
+
+def test_tab_style_loc_body_mask_not_polars_expression_raises(gt2: GT):
+    style = CellStyleFill(color="blue")
+    mask = "fake expression"
+    err_msg = "Only Polars expressions can be passed to the `mask` argument."
+
+    with pytest.raises(ValueError) as exc_info:
+        tab_style(gt2, style, LocBody(mask=mask))
+    assert err_msg in exc_info.value.args[0]

--- a/tests/test_tab_create_modify.py
+++ b/tests/test_tab_create_modify.py
@@ -125,3 +125,23 @@ def test_tab_style_loc_body_mask_not_polars_expression_raises(gt2: GT):
     with pytest.raises(ValueError) as exc_info:
         tab_style(gt2, style, LocBody(mask=mask))
     assert err_msg in exc_info.value.args[0]
+
+
+def test_tab_style_loc_body_mask_columns_not_inside_raises(gt2: GT):
+    style = CellStyleFill(color="blue")
+    mask = pl.len()
+    err_msg = "The `mask` may reference columns not in the original DataFrame."
+
+    with pytest.raises(ValueError) as exc_info:
+        tab_style(gt2, style, LocBody(mask=mask))
+    assert err_msg in exc_info.value.args[0]
+
+
+def test_tab_style_loc_body_mask_rows_not_equal_raises(gt2: GT):
+    style = CellStyleFill(color="blue")
+    mask = pl.len().alias("x")
+    err_msg = "The DataFrame length after applying `mask` differs from the original."
+
+    with pytest.raises(ValueError) as exc_info:
+        tab_style(gt2, style, LocBody(mask=mask))
+    assert err_msg in exc_info.value.args[0]

--- a/tests/test_tab_create_modify.py
+++ b/tests/test_tab_create_modify.py
@@ -5,6 +5,7 @@ from great_tables import GT, style, loc, google_font, from_column
 from great_tables._locations import LocBody
 from great_tables._styles import CellStyleFill
 from great_tables._tab_create_modify import tab_style
+from polars import selectors as cs
 
 
 @pytest.fixture
@@ -31,6 +32,30 @@ def test_tab_style_multiple_columns(gt: GT):
 
     assert len(new_gt._styles[0].styles) == 1
     assert new_gt._styles[0].styles[0] is style
+
+
+def test_tab_style_mast():
+    gt = GT(pl.DataFrame({"x": [1, 2], "y": [4, 5]}))
+    style = CellStyleFill(color="blue")
+    new_gt = tab_style(gt, style, LocBody(mask=cs.numeric().gt(1.5)))
+
+    assert len(gt._styles) == 0
+    assert len(new_gt._styles) == 3
+
+    xy_0y, xy_1x, xy_1y = new_gt._styles
+
+    assert xy_0y.styles[0] is style
+    assert xy_1x.styles[0] is style
+    assert xy_1y.styles[0] is style
+
+    assert xy_0y.rownum == 0
+    assert xy_0y.colname == "y"
+
+    assert xy_1x.rownum == 1
+    assert xy_1x.colname == "x"
+
+    assert xy_1y.rownum == 1
+    assert xy_1y.colname == "y"
 
 
 def test_tab_style_google_font(gt: GT):

--- a/tests/test_tab_create_modify.py
+++ b/tests/test_tab_create_modify.py
@@ -34,7 +34,7 @@ def test_tab_style_multiple_columns(gt: GT):
     assert new_gt._styles[0].styles[0] is style
 
 
-def test_tab_style_mast():
+def test_tab_style_loc_body_mask():
     gt = GT(pl.DataFrame({"x": [1, 2], "y": [4, 5]}))
     style = CellStyleFill(color="blue")
     new_gt = tab_style(gt, style, LocBody(mask=cs.numeric().gt(1.5)))


### PR DESCRIPTION
Related Issue: #389.

Hello team,  

This is a rough idea for supporting the passing of `Polars` expressions to the `mask=` argument of `LobBody`.

The procedures are outlined as follows:  
1. Exclude the `stub` and `group` columns if necessary.  
2. Use `df.select()` to process the `Polars` expression and obtain a boolean-like matrix.  
3. Use two for-loops to iterate through the cells and select the desired cells based on whether their values are `True`.  

This idea is preliminary but should provide a foundation for further discussions.  


```python
import polars as pl
from great_tables import GT, loc, style
from great_tables.data import gtcars
from polars import selectors as cs

df_mini = pl.from_pandas(gtcars).head().pivot(on="year", index=["trim", "mfr"], values="hp")
(
    GT(df_mini,rowname_col="trim", groupname_col="mfr")
    .tab_style(
        style=style.text(color="red"),
        locations=loc.body(mask=cs.numeric().gt(600))
    )
)
```
![image](https://github.com/user-attachments/assets/585fcf3a-a910-442f-9c5d-1e4a44a7d043)

```python
print(df_mini.select(cs.numeric().gt(600)))
```
```
shape: (3, 4)
┌────────┬────────┬────────┬────────┐
│ 2017.0 ┆ 2015.0 ┆ 2014.0 ┆ 2016.0 │
│ ---    ┆ ---    ┆ ---    ┆ ---    │
│ bool   ┆ bool   ┆ bool   ┆ bool   │
╞════════╪════════╪════════╪════════╡
│ true   ┆ null   ┆ null   ┆ null   │
│ null   ┆ false  ┆ false  ┆ true   │
│ null   ┆ false  ┆ null   ┆ null   │
└────────┴────────┴────────┴────────┘
```
