### PR TITLE
fix: support `pl.UInt` type in nanoplot

### DIFF
--- a/great_tables/_formats.py
+++ b/great_tables/_formats.py
@@ -4601,7 +4601,11 @@ def fmt_nanoplot(
 
     col_class = str(column_d_type).lower()
 
-    if _str_detect(col_class, "int") or _str_detect(col_class, "float"):
+    if (
+        _str_detect(col_class, "int")
+        or _str_detect(col_class, "uint")
+        or _str_detect(col_class, "float")
+    ):
         scalar_vals = True
     else:
         scalar_vals = False

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -379,7 +379,11 @@ class Boxhead(_Sequence[ColInfo]):
                 align.append("left")
             elif col_class == "string":
                 align.append("left")
-            elif _str_detect(col_class, "int") or _str_detect(col_class, "float"):
+            elif (
+                _str_detect(col_class, "int")
+                or _str_detect(col_class, "uint")
+                or _str_detect(col_class, "float")
+            ):
                 align.append("right")
             elif _str_detect(col_class, "date"):
                 align.append("right")

--- a/tests/test__boxhead.py
+++ b/tests/test__boxhead.py
@@ -99,7 +99,9 @@ def test_cols_align_columns_list_of_str():
 
 
 def test_cols_align_pl_expr():
-    df = pl.DataFrame({"col1": [1, 2], "col2": [3.3, 4.4], "c": ["x", "y"]})
+    df = pl.DataFrame({"col1": [1, 2], "col2": [3.3, 4.4], "c": ["x", "y"]}).with_columns(
+        pl.col("col1").cast(pl.UInt8).alias("d")
+    )
     table = gt.GT(df)
 
     # Select columns by polars expressions
@@ -110,6 +112,7 @@ def test_cols_align_pl_expr():
         "center",  # manually assign
         "center",  # manually assign
         "left",  # `auto_align` for `str` is "left"
+        "right",  # `auto_align` for `pl.UInt` is "right"
     ]
 
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -2236,6 +2236,18 @@ def test_fmt_nanoplot_multi_vals_bar_ref_line_ref_area():
     )
 
 
+def test_fmt_nanoplot_accept_pl_uint():
+    """
+    https://github.com/posit-dev/great-tables/issues/571
+    """
+    single_vals_df = pl.DataFrame({"bars": [1, 2, 3, 5]})
+
+    # Call `as_raw_html()` to trigger `_generate_nanoplot()` and expose the rendering issue.
+    single_vals_df.select("bars").cast(pl.UInt32).style.fmt_nanoplot(
+        columns="bars", plot_type="bar"
+    ).as_raw_html()
+
+
 @pytest.mark.parametrize(
     "plot_type",
     [


### PR DESCRIPTION
Fix: #571  

It seems the issue stems from the input being a type we didn’t anticipate. While more advanced types like `pl.Enum`, `pl.Categorical`, `pl.Array`, `pl.List` or `pl.Struct` could introduce additional complexity, this PR addresses the simpler part for now.  

Since `_str_detect()` is clearly an internal function, we could consider modifying it. However, if we switch to using `re.search()`, the following test cases will fail:  
```bash
- FAILED `tests/test_formats.py::test_fmt_nanoplot_polars_listcol` - assert [- snapshot] == [+ received]  
- FAILED `tests/test_utils_render_html.py::test_render_polars_list_col` - assert [- snapshot] == [+ received]  
```
If we opt not to modify `_str_detect()`, we need to handle `uint` as a numerical type, as implemented in this PR.  

Additionally, I noticed that the alignment of `pl.UInt` might require adjustment.