### PR TITLE
fix: update dtype of `year` col in `gtcars` dataset

### DIFF
--- a/great_tables/data/__init__.py
+++ b/great_tables/data/__init__.py
@@ -32,7 +32,7 @@ _gtcars_fname = DATA_MOD / "03-gtcars.csv"
 _gtcars_dtype = {
     "mfr": "object",
     "model": "object",
-    "year": "float64",
+    "year": "int64",
     "trim": "object",
     "bdy_style": "object",
     "hp": "float64",


### PR DESCRIPTION
This updates the dtype of the `year` col in the `gtcars` (from `float64` to `int64`).