### PR TITLE
ci: use deploy-pypi environment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @rich-iannone @machow

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -103,6 +103,7 @@ jobs:
   release-pypi:
     name: "Release to pypi"
     runs-on: ubuntu-latest
+    environment: deploy-pypi
     needs: [build, test-pandas]
     if: github.event_name == 'release'
     steps:


### PR DESCRIPTION
This PR moves our pypi-token into a github environment, so we can require review before a github release pushes to pypi.