### PR TITLE
feat: add `tab_spanner_delim()` method

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -110,6 +110,7 @@ quartodoc:
       contents:
         - GT.tab_header
         - GT.tab_spanner
+        - GT.tab_spanner_delim
         - GT.tab_stub
         - GT.tab_stubhead
         - GT.tab_source_note

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -248,7 +248,7 @@ class SpannerTransformer:
 
         self._split_func = self._get_split_func()
         self._d: dict[str, list[str]] = {}
-        self._rectangle = None
+        self._rectangle: list[list[str]] = []
 
     def _get_split_func(self):
         if self._split == "first":
@@ -269,11 +269,14 @@ class SpannerTransformer:
         return self._d
 
     def get_rectangle(self):
-        d = self.split()  # get the intermediate representation
-        values = [list(v) for v in itertools.zip_longest(*d.values())]
-        if self._reverse:
-            return [list(d.keys()), *values]
-        return [list(d.keys()), *values[::-1]]
+        if not self._rectangle:
+            d = self.split()  # get the intermediate representation
+            values = [list(v) for v in itertools.zip_longest(*d.values())]
+            if self._reverse:
+                self._rectangle = [list(d.keys()), *values]
+            else:
+                self._rectangle = [list(d.keys()), *values[::-1]]
+        return self._rectangle
 
     def __repr__(self):
         cls_name = type(self).__name__

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -406,6 +406,7 @@ def tab_spanner_delim(
 
     ```{python}
     import polars as pl
+    import polars.selectors as cs
     from great_tables import GT
 
     data = {
@@ -417,6 +418,29 @@ def tab_spanner_delim(
 
     gt = GT(pl.DataFrame(data))
     gt.tab_spanner_delim()
+    ```
+
+    ```{python}
+    gt.tab_spanner_delim(limit=1)
+    ```
+
+    ```{python}
+    # the name "province" repeats in the styled table,
+    # because the first spanner is column names
+    gt.tab_spanner_delim(reverse=True)
+    ```
+
+
+    ```{python}
+    from great_tables.data import towny
+
+    lil_towny = (
+        pl.DataFrame(towny)
+        .select("name", cs.starts_with("population"))
+        .head()
+    )
+
+    GT(lil_towny).tab_spanner_delim(delim="_")
     ```
     """
 

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -352,10 +352,10 @@ def tab_spanner_delim(
     limit: int = -1,
     reverse: bool = False,
 ) -> GTSelf:
-    """
-    `tab_spanner_delim()` can take specially-crafted column names and generate one or more spanners
-    (and revise column labels at the same time). This is done by splitting the column name by the
-    specified delimiter text (delim) and placing the fragments from top to bottom (i.e.,
+    """Insert spanners by splitting column names with a delimiter.
+
+    This generates one or more spanners (and sets column labels), by splitting the column name by
+    the specified delimiter text (delim) and placing the fragments from top to bottom (i.e.,
     higher-level spanners to the column labels) or vice versa. Furthermore, neighboring text
     fragments on different spanner levels that have the same text will be coalesced together.
     For instance, having the three side-by-side column names rating_1, rating_2, and rating_3 will

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import copy
 import itertools
-from typing import TYPE_CHECKING
+from collections import defaultdict
+from typing import TYPE_CHECKING, TypedDict
 
+from typing_extensions import TypeAlias
+
+from ._boxhead import cols_label
 from ._gt_data import SpannerInfo, Spanners
+from ._helpers import random_id
 from ._locations import resolve_cols_c
 from ._tbl_data import SelectExpr
 from ._text import BaseText, Text
 from ._utils import OrderedSet, _assert_list_is_subset
-from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
     from ._gt_data import Boxhead
@@ -223,6 +228,125 @@ def tab_spanner(
     return new_data
 
 
+def tab_spanner_delim(
+    self: GTSelf,
+    delim: str = ".",
+    columns: SelectExpr = None,
+    split: str = "last",
+    limit: int = -1,
+    reverse: bool = False,
+) -> GTSelf:
+    """
+    `tab_spanner_delim()` can take specially-crafted column names and generate one or more spanners
+    (and revise column labels at the same time). This is done by splitting the column name by the
+    specified delimiter text (delim) and placing the fragments from top to bottom (i.e.,
+    higher-level spanners to the column labels) or vice versa. Furthermore, neighboring text
+    fragments on different spanner levels that have the same text will be coalesced together.
+    For instance, having the three side-by-side column names rating_1, rating_2, and rating_3 will
+    (in the default case at least) result in a spanner with the label "rating" above columns with
+    the labels "1", "2", and "3".
+
+    Parameters
+    ----------
+    delim
+        Delimiter for splitting, default to `"."`.
+
+    columns
+        The columns to target. Can either be a single column name or a series of column names
+        provided in a list.
+
+    split
+        Should the delimiter splitting occur from the "last" instance of the delim character or
+        from the "first"? The default here uses the "last" keyword, and splitting begins at the
+        last instance of the delimiter in the column name. This option only has some consequence
+        when there is a limit value applied that is lesser than the number of delimiter characters
+        for a given column name (i.e., number of splits is not the maximum possible number).
+
+    limit
+        Limit for splitting. An optional limit to place on the splitting procedure. The default -1
+        means that a column name will be split as many times are there are delimiter characters.
+        In other words, the default means there is no limit. If an integer value is given to limit
+        then splitting will cease at the iteration given by limit. This works in tandem with split
+        since we can adjust the number of splits from either the right side (split = "last") or
+        left side (split = "first") of the column name.
+
+    reverse
+        Should the order of split names be reversed? By default, this is `False`.
+
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+
+    Examples
+    --------
+    Let's create a table table that includes the column names province.NL_ZH.pop, province.NL_ZH.gdp,
+    province.NL_NH.pop, and province.NL_NH.gdp, we can see that we have a naming system that has
+    a well-defined structure. We start with the more general to the left ("province") and move to
+    the more specific on the right ("pop"). If the columns are in the table in this exact order,
+    then things are in an ideal state as the eventual spanner labels will form from this neighboring.
+    When using tab_spanner_delim() here with delim set as "." we get the following table:
+
+    ```{python}
+    import polars as pl
+    from great_tables import GT
+
+    data = {
+        "province.NL_ZH.pop": [1, 2, 3],
+        "province.NL_ZH.gdp": [4, 5, 6],
+        "province.NL_NH.pop": [7, 8, 9],
+        "province.NL_NH.gdp": [10, 11, 12],
+    }
+
+    gt = GT(pl.DataFrame(data))
+    gt.tab_spanner_delim()
+    ```
+    """
+    if split == "first":
+        split_ = "split"
+    elif split == "last":
+        split_ = "rsplit"
+    else:
+        raise ValueError("The `split=` parameter accepts only `first` or `last` as input.")
+
+    split_func = getattr(str, split_)  # get `str.split` or `str.rsplit`
+
+    class SpInfo(TypedDict):
+        level: int
+        root_col: str
+
+    info_list: list[dict[str, list[SpInfo]]] = []
+
+    sel_cols = resolve_cols_c(data=self, expr=columns)
+    for sel_col in sel_cols:
+        col_names = split_func(sel_col, delim, limit)  # split for one column
+        info_dict: dict[str, list[SpInfo]] = defaultdict(list)
+        for level, col_name in zip(reversed(range(len(col_names))), col_names):
+            # `level` value is recorded from high to low
+            spinfo_dict: SpInfo = {"level": level, "root_col": sel_col}
+            info_dict[col_name].append(spinfo_dict)
+        info_list.append(info_dict)
+
+    new_obj = copy.copy(self)
+    for info_d in info_list:
+        for col_name, spinfo_list in info_d.items():
+            for spinfo in spinfo_list:
+                level, root_col = spinfo["level"], spinfo["root_col"]
+                if level != 0:
+                    new_obj = tab_spanner(
+                        new_obj,
+                        label=col_name,
+                        columns=root_col,
+                        level=level,
+                        id=random_id(),
+                    )
+                else:
+                    # if `level=0`, call `cols_label()` instead of `tab_spanner()`
+                    new_obj = cols_label(new_obj, {root_col: col_name})
+    return new_obj
+
+
 def _validate_sel_cols(sel_cols: list[str], col_vars: list[str]) -> None:
     if not len(sel_cols):
         raise Exception("No columns selected.")
@@ -307,7 +431,11 @@ def cols_move(self: GTSelf, columns: SelectExpr, after: str) -> GTSelf:
     other_columns = [col for col in col_vars if col not in moving_columns]
 
     indx = other_columns.index(after)
-    final_vars = [*other_columns[: indx + 1], *moving_columns, *other_columns[indx + 1 :]]
+    final_vars = [
+        *other_columns[: indx + 1],
+        *moving_columns,
+        *other_columns[indx + 1 :],
+    ]
 
     new_boxhead = self._boxhead.reorder(final_vars)
     return self._replace(_boxhead=new_boxhead)

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -54,6 +54,7 @@ from ._spanners import (
     cols_move_to_start,
     cols_width,
     tab_spanner,
+    tab_spanner_delim,
 )
 from ._stub import reorder_stub_df
 from ._stubhead import tab_stubhead
@@ -261,6 +262,7 @@ class GT(
     tab_header = tab_header
     tab_source_note = tab_source_note
     tab_spanner = tab_spanner
+    tab_spanner_delim = tab_spanner_delim
     tab_stubhead = tab_stubhead
     tab_style = tab_style
     tab_options = tab_options

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -490,6 +490,9 @@ def test_tab_spanner_delim_level_one():
     assert info2.spanner_id == "span_2"
     assert info2.spanner_level == 0
 
+    # note that span_1 for col "a" and "c" does not gather
+    # so two span_1 labels are shown. This emerges from these
+    # columns not having been moved next to each other.
     assert len(gt._boxhead) == 3
     assert gt._boxhead[0].column_label == "a"
     assert gt._boxhead[1].column_label == "b"


### PR DESCRIPTION
Fix issue: #582.

Hello team:

This PR sets up a scaffold for `tab_spanner_delim()`.  

### Basic Logic:
1. Use `str.split` or `str.rsplit` to split column names, corresponding to `delimi=` and `limit=` parameters.  
2. Iterate through selected columns, splitting each name and recording its `level` and `root_col` (original column).  
3. Process the recorded info:  
   - If `level != 0`, call `tab_spanner()`.  
   - If `level == 0`, call `cols_label()`.  

### Example:  
```python
import polars as pl
from great_tables import GT

data = {
    "province.NL_ZH.pop": [1, 2, 3],
    "province.NL_ZH.gdp": [4, 5, 6],
    "province.NL_NH.pop": [7, 8, 9],
    "province.NL_NH.gdp": [10, 11, 12],
}

gt = GT(pl.DataFrame(data))
gt.tab_spanner_delim()
```
![image](https://github.com/user-attachments/assets/cd4dfbf9-b0c6-4ee8-959e-e655bdabe2db)

```python
gt.tab_spanner_delim(limit=1)
```
![image](https://github.com/user-attachments/assets/18b7ce2a-63da-4e36-a4aa-59f536cfbb71)

```python
gt.tab_spanner_delim(split="first", limit=1)
```
![image](https://github.com/user-attachments/assets/663e7731-b6a2-47b4-83c7-7e1684e6df61)

### Remaining Tasks:
* [ ] The `reverse=` logic is not implemented—need the team's help to clarify the expected behavior. 
* [ ] Docs are ported from `{gt}` but need refinement.  
* [ ] Tests are missing since the logic isn't fully settled yet.