### PR TITLE
fix: correctly pass non-ints to nanoplot options

### DIFF
--- a/great_tables/_helpers.py
+++ b/great_tables/_helpers.py
@@ -1138,9 +1138,9 @@ def _normalize_listable_nanoplot_options(nano_opt: Any, option_type: Any) -> lis
     if not isinstance(nano_opt, (option_type, list)):
         raise ValueError(f"Nanoplot option must be a {option_type} or a list of {option_type}s")
 
-    # If it is a list, check that the values are integers
+    # If it is a list, check that the values are same as `option_type`
     if isinstance(nano_opt, list):
-        if not all(isinstance(x, int) for x in nano_opt):
+        if not all(isinstance(x, option_type) for x in nano_opt):
             raise ValueError(f"Nanoplot option must be a list of {option_type}s")
 
     # If it is a single value, convert it to a list

--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from typing import Any, Callable
 
 import numpy as np
+
 from ._tbl_data import Agnostic, is_na
-from ._utils import _match_arg, _flatten_list
+from ._utils import _flatten_list, _match_arg
 
 REFERENCE_LINE_KEYWORDS = ["mean", "median", "min", "max", "q1", "q3"]
 
@@ -121,7 +122,7 @@ def _format_number_compactly(
     Format a single numeric value compactly, using a currency if provided.
     """
 
-    from great_tables.vals import fmt_currency, fmt_scientific, fmt_integer, fmt_number
+    from great_tables.vals import fmt_currency, fmt_integer, fmt_number, fmt_scientific
 
     if fn is not None and isinstance(fn, Callable):
         res = fn(val)

--- a/tests/test__utils_nanoplots.py
+++ b/tests/test__utils_nanoplots.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pytest
+import polars as pl
+from great_tables import GT, nanoplot_options
 
 
 from typing import Any, Union
@@ -2036,3 +2038,26 @@ def test_get_n_intlike(nums: list[Any], n: int):
 )
 def test_remove_exponent(n: "int | float | str", result: int):
     assert _remove_exponent(n) == result
+
+
+def test_noerror_list_of_strings() -> None:
+    random_numbers_df = pl.DataFrame(
+        {
+            "example": ["Row " + str(x) for x in range(1, 5)],
+            "numbers": [
+                "20 23 6",
+                "2.3 6.8 9.2",
+                "-12 -5 6",
+                "2 0 15",
+            ],
+        }
+    )
+
+    GT(random_numbers_df).fmt_nanoplot(
+        columns="numbers",
+        options=nanoplot_options(
+            data_point_radius=5,
+            data_point_stroke_color=["black", "red", "black"],
+            show_data_area=False,
+        ),
+    )


### PR DESCRIPTION
This addresses #592 , I simply implemented the issue's author's fix. I added a new test that asserts the example passes without error. I'm happy to make any additions/changes to meet your project requirements!