### PR TITLE
docs: add `style.css` entry to API reference docs

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -20,7 +20,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install ".[all]"
-          python -m pip install pointblank
       - uses: quarto-dev/quarto-actions/setup@v2
         with:
           tinytex: true

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -179,6 +179,7 @@ quartodoc:
         - style.fill
         - style.text
         - style.borders
+        - style.css
     - title: Helper functions
       desc: >
         An assortment of helper functions is available in the **Great Tables** package. The

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import itertools
 from typing import TYPE_CHECKING
 
+from typing_extensions import TypeAlias
+
 from ._gt_data import SpannerInfo, Spanners
 from ._locations import resolve_cols_c
 from ._tbl_data import SelectExpr
 from ._text import BaseText, Text
 from ._utils import OrderedSet, _assert_list_is_subset
-from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
     from ._gt_data import Boxhead
@@ -92,7 +93,7 @@ def tab_spanner(
     performance under a unifying label.
 
     ```{python}
-    from great_tables import GT
+    from great_tables import GT, md
     from great_tables.data import gtcars
 
     colnames = ["model", "hp", "hp_rpm", "trq", "trq_rpm", "mpg_c", "mpg_h"]

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Union
 
 from typing_extensions import Self, TypeAlias
 
-from ._helpers import px, GoogleFont
+from ._helpers import GoogleFont, px
 from ._tbl_data import PlExpr, TblData, _get_cell, eval_transform
 
 if TYPE_CHECKING:
@@ -127,6 +127,29 @@ class CellStyle:
 
 @dataclass
 class CellStyleCss(CellStyle):
+    """A style specification for custom CSS rules.
+
+    The `style.css()` class is to be used with the `tab_style()` method, which itself allows for
+    the setting of custom styles to one or more cells. With `style.css()`, you can specify any CSS
+    rule that you would like to apply to the targeted cells.
+
+    Parameters
+    ----------
+    rule
+        The CSS rule to apply to the targeted cells. This can be any valid CSS rule, such as
+        `background-color: red;` or `font-size: 14px;`.
+
+    Returns
+    -------
+    CellStyleCss
+        A CellStyleCss object, which is used for a `styles` argument if specifying a custom CSS
+        rule.
+
+    Examples
+    --------
+    See [`GT.tab_style()`](`great_tables.GT.tab_style`).
+    """
+
     rule: str
 
     def _to_html_style(self):


### PR DESCRIPTION
The `style.css` class has been available for awhile but it wasn't present in the API reference docs. This PR adds a basic docstring for `style.css` and makes it available in the docs.

Fixes: https://github.com/posit-dev/great-tables/issues/433