### PR TITLE
feat: add `cols_unhide()` method

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -157,6 +157,7 @@ quartodoc:
         - GT.cols_move_to_start
         - GT.cols_move_to_end
         - GT.cols_hide
+        - GT.cols_unhide
     - title: Location Targeting and Styling Classes
       desc: >
         Location targeting is a powerful feature of **Great Tables**. It allows for the precise

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -311,17 +311,28 @@ class Boxhead(_Sequence[ColInfo]):
 
         return self.__class__(new_cols)
 
-    def set_cols_hidden(self, colnames: list[str]) -> Self:
+    def _set_cols_visible(self, colnames: list[str], is_hidden: bool) -> Self:
         # TODO: validate that colname is in the boxhead
+        if is_hidden:
+            visibility_type = ColInfoTypeEnum.hidden
+        else:
+            visibility_type = ColInfoTypeEnum.default
+
         res: list[ColInfo] = []
         for col in self._d:
             if col.var in colnames:
-                new_col = replace(col, type=ColInfoTypeEnum.hidden)
+                new_col = replace(col, type=visibility_type)
                 res.append(new_col)
             else:
                 res.append(col)
 
         return self.__class__(res)
+
+    def set_cols_hidden(self, colnames: list[str]) -> Self:
+        return self._set_cols_visible(colnames=colnames, is_hidden=True)
+
+    def set_cols_unhidden(self, colnames: list[str]) -> Self:
+        return self._set_cols_visible(colnames=colnames, is_hidden=False)
 
     def align_from_data(self, data: TblData) -> Self:
         """Updates align attribute in entries based on data types."""

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -311,17 +311,12 @@ class Boxhead(_Sequence[ColInfo]):
 
         return self.__class__(new_cols)
 
-    def _set_cols_visible(self, colnames: list[str], is_hidden: bool) -> Self:
+    def _set_cols_info(self, colnames: list[str], colinfo_type: ColInfoTypeEnum) -> Self:
         # TODO: validate that colname is in the boxhead
-        if is_hidden:
-            visibility_type = ColInfoTypeEnum.hidden
-        else:
-            visibility_type = ColInfoTypeEnum.default
-
         res: list[ColInfo] = []
         for col in self._d:
             if col.var in colnames:
-                new_col = replace(col, type=visibility_type)
+                new_col = replace(col, type=colinfo_type)
                 res.append(new_col)
             else:
                 res.append(col)
@@ -329,10 +324,10 @@ class Boxhead(_Sequence[ColInfo]):
         return self.__class__(res)
 
     def set_cols_hidden(self, colnames: list[str]) -> Self:
-        return self._set_cols_visible(colnames=colnames, is_hidden=True)
+        return self._set_cols_info(colnames=colnames, colinfo_type=ColInfoTypeEnum.hidden)
 
     def set_cols_unhidden(self, colnames: list[str]) -> Self:
-        return self._set_cols_visible(colnames=colnames, is_hidden=False)
+        return self._set_cols_info(colnames=colnames, colinfo_type=ColInfoTypeEnum.default)
 
     def align_from_data(self, data: TblData) -> Self:
         """Updates align attribute in entries based on data types."""

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -311,7 +311,7 @@ class Boxhead(_Sequence[ColInfo]):
 
         return self.__class__(new_cols)
 
-    def _set_cols_info(self, colnames: list[str], colinfo_type: ColInfoTypeEnum) -> Self:
+    def _set_cols_info_type(self, colnames: list[str], colinfo_type: ColInfoTypeEnum) -> Self:
         # TODO: validate that colname is in the boxhead
         res: list[ColInfo] = []
         for col in self._d:
@@ -324,10 +324,10 @@ class Boxhead(_Sequence[ColInfo]):
         return self.__class__(res)
 
     def set_cols_hidden(self, colnames: list[str]) -> Self:
-        return self._set_cols_info(colnames=colnames, colinfo_type=ColInfoTypeEnum.hidden)
+        return self._set_cols_info_type(colnames=colnames, colinfo_type=ColInfoTypeEnum.hidden)
 
     def set_cols_unhidden(self, colnames: list[str]) -> Self:
-        return self._set_cols_info(colnames=colnames, colinfo_type=ColInfoTypeEnum.default)
+        return self._set_cols_info_type(colnames=colnames, colinfo_type=ColInfoTypeEnum.default)
 
     def align_from_data(self, data: TblData) -> Self:
         """Updates align attribute in entries based on data types."""

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -559,6 +559,65 @@ def cols_hide(self: GTSelf, columns: SelectExpr) -> GTSelf:
     return self._replace(_boxhead=new_boxhead)
 
 
+def cols_unhide(self: GTSelf, columns: SelectExpr) -> GTSelf:
+    """Unhide one or more columns.
+
+    The `cols_unhide()` method allows us to unhide one or more columns from appearing in the final
+    output table. This may be important in cases where the user obtains a `GT` instance with hidden
+    columns and there is motivation to reveal one or more of those.
+
+    Parameters
+    ----------
+    columns
+        The columns to unhide in the output display table. Can either be a single column name or a
+        series of column names provided in a list.
+
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+
+
+    Examples
+    --------
+    For this example, we'll use a portion of the `countrypops` dataset to create a simple table.
+    We'll hide the `year` column using `cols_hide()` and then unhide it with `cols_unhide()`,
+    ensuring that the `year` column remains visible in the table.
+
+    ```{python}
+    from great_tables import GT
+    from great_tables.data import countrypops
+
+    countrypops_mini = countrypops.loc[countrypops["country_name"] == "Benin"][
+        ["country_name", "year", "population"]
+    ].tail(5)
+
+    GT(countrypops_mini).cols_hide(columns="year").cols_unhide(columns="year")
+    ```
+
+    See Also
+    --------
+    The counterpart of this function,
+    [`cols_hide()`](`great_tables._spanners.cols_hide`), allows you to hide one or more columns.
+    """
+
+    # If `columns` is a string, convert it to a list
+    if isinstance(columns, str):
+        columns = [columns]
+
+    sel_cols = resolve_cols_c(data=self, expr=columns)
+
+    col_vars = [col.var for col in self._boxhead]
+
+    _validate_sel_cols(sel_cols, col_vars)
+
+    # New boxhead with hidden columns
+    new_boxhead = self._boxhead.set_cols_unhidden(sel_cols)
+
+    return self._replace(_boxhead=new_boxhead)
+
+
 def spanners_print_matrix(
     spanners: Spanners,
     boxhead: Boxhead,

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -599,7 +599,7 @@ def cols_unhide(self: GTSelf, columns: SelectExpr) -> GTSelf:
     See Also
     --------
     The counterpart of this function,
-    [`cols_hide()`](`great_tables._spanners.cols_hide`), allows you to hide one or more columns.
+    [`cols_hide()`](`great_tables.GT.cols_hide`), allows you to hide one or more columns.
     """
 
     # If `columns` is a string, convert it to a list

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -52,6 +52,7 @@ from ._spanners import (
     cols_move,
     cols_move_to_end,
     cols_move_to_start,
+    cols_unhide,
     cols_width,
     tab_spanner,
 )
@@ -257,6 +258,7 @@ class GT(
     cols_move_to_start = cols_move_to_start
     cols_move_to_end = cols_move_to_end
     cols_hide = cols_hide
+    cols_unhide = cols_unhide
 
     tab_header = tab_header
     tab_source_note = tab_source_note

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -11,6 +11,7 @@ from great_tables._spanners import (
     cols_move,
     cols_move_to_end,
     cols_move_to_start,
+    cols_unhide,
     empty_spanner_matrix,
     spanners_print_matrix,
     tab_spanner,
@@ -375,6 +376,25 @@ def test_cols_hide_multi_cols(DF, columns):
     src_gt = GT(df)
     new_gt = cols_hide(src_gt, columns=columns)
     assert [col.var for col in new_gt._boxhead if col.visible] == ["b", "c"]
+
+
+@pytest.mark.parametrize("DF, columns", [(pd.DataFrame, "c"), (pl.DataFrame, cs.starts_with("c"))])
+def test_cols_unhide_single_col(DF, columns):
+    df = DF({"a": [1, 2], "b": [3, 4], "c": [5, 6], "d": [7, 8]})
+    src_gt = GT(df)
+    new_gt = cols_unhide(cols_hide(src_gt, columns=columns), columns=columns)
+    assert [col.var for col in new_gt._boxhead if col.visible] == ["a", "b", "c", "d"]
+
+
+@pytest.mark.parametrize(
+    "DF, columns",
+    [(pd.DataFrame, ["a", "d"]), (pl.DataFrame, cs.starts_with("a") | cs.ends_with("d"))],
+)
+def test_cols_unhide_multi_cols(DF, columns):
+    df = DF({"a": [1, 2], "b": [3, 4], "c": [5, 6], "d": [7, 8]})
+    src_gt = GT(df)
+    new_gt = cols_unhide(cols_hide(src_gt, columns=columns), columns=columns)
+    assert [col.var for col in new_gt._boxhead if col.visible] == ["a", "b", "c", "d"]
 
 
 def test_validate_sel_cols():


### PR DESCRIPTION
Hello team,  

This PR ports the [cols_unhide()](https://gt.rstudio.com/reference/cols_unhide.html) function from `{gt}` to Great Tables.  

With this addition, users now have full control over column visibility at any state.  

Note that `Boxhead.set_cols_hidden()` and `Boxhead.set_cols_unhidden()` now rely on `Boxhead._set_cols_info_type()`.  
I'm unsure if this is the best approach—suggestions and feedback are welcome.  