### PR TITLE
fix!: move `css-inline` pkg to extra group

### DIFF
--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -217,6 +217,10 @@ def as_raw_html(
     gt_tbl.as_raw_html(inline_css=True)
     ```
     """
+
+    if inline_css:
+        _try_import(name="css-inline", pip_install_line="pip install css-inline")
+
     built_table = self._build_data(context="html")
 
     if not inline_css:

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -235,10 +235,6 @@ def as_raw_html(
             # Obtain the `table_id` value from the Options (might be set, might be None)
             table_id = self._options.table_id.value
 
-            import pdb
-
-            pdb.set_trace()
-
             if table_id is None:
                 id = random_id()
             else:

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -9,7 +9,6 @@ from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-from css_inline import inline, inline_fragment
 from typing_extensions import TypeAlias
 
 from ._helpers import random_id
@@ -218,42 +217,39 @@ def as_raw_html(
     ```
     """
 
-    if inline_css:
-        _try_import(name="css-inline", pip_install_line="pip install css-inline")
-
     built_table = self._build_data(context="html")
-
-    if not inline_css:
-        html_table = built_table._render_as_html(
-            make_page=make_page,
-            all_important=all_important,
-        )
-
-        return html_table
 
     table_html = built_table._render_as_html(
         make_page=make_page,
         all_important=all_important,
     )
 
-    if make_page:
-        inlined = inline(html=table_html)
+    if inline_css:
+        _try_import(name="css_inline", pip_install_line="pip install css-inline")
+        from css_inline import inline, inline_fragment
 
-    else:
-        # Obtain the `table_id` value from the Options (might be set, might be None)
-        table_id = self._options.table_id.value
+        if make_page:
+            return inline(html=table_html)
 
-        if table_id is None:
-            id = random_id()
         else:
-            id = table_id
+            # Obtain the `table_id` value from the Options (might be set, might be None)
+            table_id = self._options.table_id.value
 
-        # Compile the SCSS as CSS
-        table_css = str(compile_scss(self, id=id, compress=False, all_important=all_important))
+            import pdb
 
-        inlined = inline_fragment(html=table_html, css=table_css)
+            pdb.set_trace()
 
-    return inlined
+            if table_id is None:
+                id = random_id()
+            else:
+                id = table_id
+
+            # Compile the SCSS as CSS
+            table_css = str(compile_scss(self, id=id, compress=False, all_important=all_important))
+
+            return inline_fragment(html=table_html, css=table_css)
+
+    return table_html
 
 
 def as_latex(self: GT, use_longtable: bool = False, tbl_pos: str | None = None) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ classifiers = [
 ]
 dependencies = [
     "commonmark>=0.9.1",
-    "css-inline>=0.14.1",
     "faicons>=0.2.2",
     "htmltools>=0.4.1",
     "importlib-metadata",
@@ -57,6 +56,7 @@ all = [
 ]
 
 extra = [
+    "css-inline>=0.14.1",
     "selenium>=4.18.1",
     "Pillow>=10.2.0",
 ]


### PR DESCRIPTION
Given that `css-inline` does not work with pyodide and is really only ever used in `as_raw_html()`, this PR makes this library and optional dependency. It's placed in the 'extra' optional install group (along with packages for other export functions like `save()`).

Fixes: https://github.com/posit-dev/great-tables/issues/567