### PR TITLE
feat: Support pickling

### DIFF
--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -283,10 +283,10 @@ class Boxhead(_Sequence[ColInfo]):
         rowname_col: str | None = None,
         groupname_col: str | None = None,
     ):
-        self._data = data
+        pass
 
     def __getnewargs__(self):
-        return (self._data,)
+        return (self._d,)
 
     def set_stub_cols(self, rowname_col: str | None, groupname_col: str | None) -> Self:
         # Note that None unsets a column

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -283,7 +283,10 @@ class Boxhead(_Sequence[ColInfo]):
         rowname_col: str | None = None,
         groupname_col: str | None = None,
     ):
-        pass
+        self._data = data
+
+    def __getnewargs__(self):
+        return (self._data,)
 
     def set_stub_cols(self, rowname_col: str | None, groupname_col: str | None) -> Self:
         # Note that None unsets a column

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,4 +1,3 @@
-import pickle
 import sys
 import tempfile
 import time
@@ -163,6 +162,8 @@ def test_snap_as_latex(snapshot):
 
 
 def test_pickle():
+    import pickle
+
     import polars as pl
     from polars.testing import assert_frame_equal
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,3 +1,4 @@
+import pickle
 import sys
 import tempfile
 import time
@@ -159,3 +160,22 @@ def test_snap_as_latex(snapshot):
     latex_str_as_latex = gt_tbl.as_latex(use_longtable=True)
 
     assert snapshot == latex_str_as_latex
+
+
+def test_pickle():
+    import polars as pl
+    from polars.testing import assert_frame_equal
+
+    from great_tables.gt import _get_column_labels
+
+    df = pl.DataFrame({"col": [1, 2, 3]})
+    gt_tbl = GT(df).cols_label({"col": "new_col"})
+
+    pickled = pickle.dumps(gt_tbl)
+    gt_tbl2 = pickle.loads(pickled)
+
+    # ensure the DataFrame remains unchanged after pickling
+    assert_frame_equal(gt_tbl2._tbl_data, df)
+
+    # verify that column label is preserved
+    assert _get_column_labels(gt=gt_tbl2, context="html")[0] == "new_col"


### PR DESCRIPTION
Fixes: #640 

This PR adds support for pickling `GT`. The `__getnewargs__` method is relatively new to me, but the implementation appears to be straightforward.

Edit: Based on the error message, it seems that providing only the `data=` parameter is sufficient, but I'm unsure if the other three parameters—`auto_align=`, `rowname_col=`, and `groupname_col=`—are also required.