### PR TITLE
docs: add note about using `.show("browser")` when in VS Code

### DIFF
--- a/docs/get-started/basic-styling.qmd
+++ b/docs/get-started/basic-styling.qmd
@@ -23,7 +23,7 @@ gt_pl_air = GT(pl.from_pandas(air_head))
 
 
 :::{.callout-note}
-When using Great Tables with VS Code, some forms of table styling can be suppressed by the IDE's special handling of table outputs. For this reason, it's strongly recommended that `.show("browser")` be called on GT objects when using VS Code.
+When using Great Tables with VS Code, the IDE suppresses some forms of table styling displayed in notebooks. For example, border styles might not appear. Use `.show("browser")` to see the styled GT table in a separate browser window.
 :::
 
 ## Style basics

--- a/docs/get-started/basic-styling.qmd
+++ b/docs/get-started/basic-styling.qmd
@@ -23,7 +23,7 @@ gt_pl_air = GT(pl.from_pandas(air_head))
 
 
 :::{.callout-note}
-When using Great Tables with VS Code, some forms of table styling can be suppressed by their special handling of table outputs. For this reason, it's strongly recommended that `.show("browser")` be called on GT objects when using VS Code.
+When using Great Tables with VS Code, some forms of table styling can be suppressed by the IDE's special handling of table outputs. For this reason, it's strongly recommended that `.show("browser")` be called on GT objects when using VS Code.
 :::
 
 ## Style basics

--- a/docs/get-started/basic-styling.qmd
+++ b/docs/get-started/basic-styling.qmd
@@ -21,6 +21,11 @@ gt_air = GT(air_head)
 gt_pl_air = GT(pl.from_pandas(air_head))
 ```
 
+
+:::{.callout-note}
+When using Great Tables with VS Code, some forms of table styling can be suppressed by their special handling of table outputs. For this reason, it's strongly recommended that `.show("browser")` be called on GT objects when using VS Code.
+:::
+
 ## Style basics
 
 We use the [`tab_style()`](`great_tables.GT.tab_style`) method in combination with [`loc.body()`](`great_tables.loc.body`) to set styles on cells of data in the table body. For example, the table-making code below applies a yellow background color to specific cells.


### PR DESCRIPTION
A frequent point of confusion is styling tables in VS Code using Jupyter and not seeing styles being applied. While we fixed a few issues with the display of tables there, it seems impractical to try to fix them all. A better recommendation is to view the table in a browser through `.show("browser")` when using VS Code.

To get the word out about this, it was brought up that a good place to inform users about this is in the docs. In this PR, a callout note is placed near the beginning of the [Styling the Table Body](https://posit-dev.github.io/great-tables/get-started/basic-styling.html) article in the Get Started guide.

Fixes: https://github.com/posit-dev/great-tables/issues/142