### PR TITLE
docs: suppress the warning message from `cols_width()` in the docs

### DIFF
--- a/docs/blog/introduction-0.3.0/index.qmd
+++ b/docs/blog/introduction-0.3.0/index.qmd
@@ -16,8 +16,10 @@ Before `v0.3.0`, you could not alter the widths of individual columns. This mean
 Here's an example where the widths of all columns are set with our preferred length values (in `px`).
 
 ```{python}
+import warnings
 from great_tables import GT, exibble
 
+warnings.filterwarnings("ignore")
 exibble_mini = exibble[["num", "char", "date", "datetime", "row"]].head(5)
 
 (

--- a/docs/examples/index.qmd
+++ b/docs/examples/index.qmd
@@ -220,9 +220,11 @@ sza_pivot = (
 
 ```{python}
 # | echo: false
+import warnings
 from great_tables import GT, md, html, system_fonts
 import pandas as pd
 
+warnings.filterwarnings("ignore")
 power_cie_prepared_tbl = pd.read_csv("./_data/power_cie_prepared_tbl.csv")
 
 

--- a/great_tables/_render_checks.py
+++ b/great_tables/_render_checks.py
@@ -35,7 +35,7 @@ def _render_check_quarto(data: GTData):
     is_all_pct = all([width is None or width.rstrip().endswith("%") for width in col_widths])
     if is_any_set and not is_all_pct:
         warnings.warn(
-            "Rendering table with .col_widths() in Quarto may result in unexpected behavior."
+            "Rendering table with .cols_width() in Quarto may result in unexpected behavior."
             " This is because Quarto performs custom table processing."
             " Either use all percentage widths, or set .tab_options(quarto_disable_processing=True)"
             " to disable Quarto table processing.",

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -719,8 +719,10 @@ def cols_width(self: GTSelf, cases: dict[str, str] | None = None, **kwargs: str)
     affected (their widths will be automatically set by their content).
 
     ```{python}
+    import warnings
     from great_tables import GT, exibble
 
+    warnings.filterwarnings("ignore")
     exibble_mini = exibble[["num", "char", "date", "datetime", "row"]].head(5)
 
     (


### PR DESCRIPTION
Hello team,

I noticed a warning message appearing in the documentation and would like to propose suppressing it for a better reading experience. I also corrected the function name in the warning message from `col_widths()` to `cols_width()`.