### PR TITLE
Add truncate option to data_color

### DIFF
--- a/tests/data_color/test_data_color.py
+++ b/tests/data_color/test_data_color.py
@@ -331,24 +331,17 @@ def test_all_values_have_zero_range_domain_pl(snapshot: str):
     assert_rendered_body(snapshot, new_gt)
 
 
-def test_data_color_viridis_snap(snapshot: str):
-    df = pd.DataFrame(
-        {
-            "A": [1, 2, 3, 4, 5],
-            "B": [6, 7, 8, 9, 10],
-            "C": ["one", "two", "three", "four", "five"],
-        }
-    )
-
+# test for data_color with truncate=True
+def test_data_color_truncate(df: DataFrameLike):
     new_gt = GT(df).data_color(
-        columns=["A", "B"],
-        domain=[2, 7],
+        columns=["num", "currency"],
+        domain=[10, 40],
         palette=["#654321", "white", "#123456"],
         truncate=True,
     )
 
     # check if all cells are colored
-    assert len(new_gt._styles) == 10
+    assert len(new_gt._styles) == 8
     # check if the last cell (out of range of domain) is colored with the last color in the palette
     assert get_first_style(new_gt._styles[-1], style.fill).color == "#123456"
     # check if the first cell (out of range of domain) is colored with the first color in the palette

--- a/tests/data_color/test_data_color.py
+++ b/tests/data_color/test_data_color.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import polars as pl
 import pytest
+
 from great_tables import GT, style
 from great_tables._gt_data import CellStyle, StyleInfo
 from great_tables._tbl_data import DataFrameLike
@@ -12,7 +13,10 @@ from great_tables.data import exibble
 
 T_CellStyle = TypeVar("T_CellStyle", bound=CellStyle)
 
-params_frames = [pytest.param(pd.DataFrame, id="pandas"), pytest.param(pl.DataFrame, id="polars")]
+params_frames = [
+    pytest.param(pd.DataFrame, id="pandas"),
+    pytest.param(pl.DataFrame, id="polars"),
+]
 
 
 @pytest.fixture(params=params_frames, scope="function")
@@ -111,7 +115,11 @@ def test_data_color_domain_na_color_snap(snapshot: str, df: DataFrameLike):
 def test_data_color_domain_na_color_reverse_snap(snapshot: str, df: DataFrameLike):
     """`data_color` works with `domain`, `na_color`, and `reverse`."""
     gt = GT(df).data_color(
-        columns="currency", palette=["red", "green"], domain=[0, 50], na_color="blue", reverse=True
+        columns="currency",
+        palette=["red", "green"],
+        domain=[0, 50],
+        na_color="blue",
+        reverse=True,
     )
 
     assert_rendered_body(snapshot, gt)
@@ -321,3 +329,27 @@ def test_all_values_have_zero_range_domain_pl(snapshot: str):
     new_gt = GT(df).data_color("x", palette=["green", "blue"], domain=[0, 0])
 
     assert_rendered_body(snapshot, new_gt)
+
+
+def test_data_color_viridis_snap(snapshot: str):
+    df = pd.DataFrame(
+        {
+            "A": [1, 2, 3, 4, 5],
+            "B": [6, 7, 8, 9, 10],
+            "C": ["one", "two", "three", "four", "five"],
+        }
+    )
+
+    new_gt = GT(df).data_color(
+        columns=["A", "B"],
+        domain=[2, 7],
+        palette=["#654321", "white", "#123456"],
+        truncate=True,
+    )
+
+    # check if all cells are colored
+    assert len(new_gt._styles) == 10
+    # check if the last cell (out of range of domain) is colored with the last color in the palette
+    assert get_first_style(new_gt._styles[-1], style.fill).color == "#123456"
+    # check if the first cell (out of range of domain) is colored with the first color in the palette
+    assert get_first_style(new_gt._styles[0], style.fill).color == "#654321"


### PR DESCRIPTION
## Summary

This PR adds a new boolean parameter `truncate` to the `data_color` method. When `truncate=True`, values outside the specified domain will be assigned the color of the domain's minimum or maximum value instead of being treated as NaN. The default is set to `truncate=False`, which follows the previous functionality.

Changes include:
- Added the `truncate` parameter (default: False)
- Updated the `_rescale_numeric` function to support truncation
- Added unit tests `test_data_color_truncate` in `tests/data_color/test_data_color.py` to verify that truncation works correctly

This close #430  