### PR TITLE
feat: Add `fmt_image_circle()` and `vals.fmt_image_circle()` functions

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -135,6 +135,7 @@ quartodoc:
         - GT.fmt_markdown
         - GT.fmt_units
         - GT.fmt_image
+        - GT.fmt_image_circle
         - GT.fmt_icon
         - GT.fmt_flag
         - GT.fmt_nanoplot
@@ -246,6 +247,7 @@ quartodoc:
         - vals.fmt_time
         - vals.fmt_markdown
         - vals.fmt_image
+        - vals.fmt_image_circle
     - title: Built in datasets
       desc: >
         The **Great Tables** package is equipped with sixteen datasets that come in all shapes and

--- a/great_tables/_formats_vals.py
+++ b/great_tables/_formats_vals.py
@@ -1051,7 +1051,7 @@ def val_fmt_markdown(
 def val_fmt_image(
     x: X,
     height: str | int | None = None,
-    width: str | int | None = None,
+    width: str | None = None,
     sep: str = " ",
     path: str | Path | None = None,
     file_pattern: str = "{}",
@@ -1107,6 +1107,92 @@ def val_fmt_image(
         columns="x",
         height=height,
         width=width,
+        sep=sep,
+        path=path,
+        file_pattern=file_pattern,
+        encode=encode,
+    )
+
+    vals_fmt = _get_column_of_values(gt=gt_obj_fmt, column_name="x", context="html")
+
+    return vals_fmt
+
+
+def val_fmt_image_circle(
+    x: X,
+    height: str | int | None = None,
+    width: str | None = None,
+    border_radius: str | None = "50%",
+    border_width: str | int | None = None,
+    border_color: str | None = None,
+    border_style: str | None = None,
+    sep: str = " ",
+    path: str | Path | None = None,
+    file_pattern: str = "{}",
+    encode: bool = True,
+) -> list[str]:
+    """Format image paths to generate circular images within table cells.
+    `fmt_image_circle()` is a utility function similar to [`fmt_image()`](`great_tables.fmt_image`),
+    but it also accepts additional parameters for customizing the image border:
+    `border_radius=`, `border_width=`, `border_color=`, and `border_style=`.
+
+    When calling `fmt_image_circle()`, **Great Tables** automatically sets `border_radius="50%"` to
+    create a full circle. However, we can't assume whether you want the border to be visible.
+    Therefore, you should supply at least one of the following: `border_width=`, `border_color=`,
+    or `border_style=`. Based on your input, sensible defaults will be applied for any unset border
+    properties.
+
+    Parameters
+    ----------
+    x
+        A list of values to be formatted.
+    height
+        The height of the rendered images.
+    width
+        The width of the rendered images.
+    border_radius
+        The radius of the image border. Accepts values in pixels (`px`) or percentages (`%`).
+        Defaults to `50%` to create a circular image.
+    border_width
+        The width of the image border.
+    border_color
+        The color of the image border.
+    border_style
+        The style of the image border (e.g., solid, dashed, dotted).
+    sep
+        In the output of images within a body cell, `sep=` provides the separator between each
+        image.
+    path
+        An optional path to local image files or an HTTP/HTTPS URL.
+        This is combined with the filenames to form the complete image paths.
+    file_pattern
+        The pattern to use for mapping input values in the body cells to the names of the graphics
+        files. The string supplied should use `"{}"` in the pattern to map filename fragments to
+        input strings.
+    encode
+        The option to always use Base64 encoding for image paths that are determined to be local. By
+        default, this is `True`.
+
+    Returns
+    -------
+    list[str]
+        A list of formatted values is returned.
+
+    See Also
+    --------
+    Check out our blog post, [Rendering images anywhere in Great Tables](https://posit-dev.github.io/great-tables/blog/rendering-images/),
+    which walks through how to use `vals.fmt_image()`.
+    """
+    gt_obj: GTData = _make_one_col_table(vals=x)
+
+    gt_obj_fmt = gt_obj.fmt_image_circle(
+        columns="x",
+        height=height,
+        width=width,
+        border_radius=border_radius,
+        border_width=border_width,
+        border_color=border_color,
+        border_style=border_style,
         sep=sep,
         path=path,
         file_pattern=file_pattern,

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -18,6 +18,7 @@ from ._formats import (
     fmt_flag,
     fmt_icon,
     fmt_image,
+    fmt_image_circle,
     fmt_integer,
     fmt_markdown,
     fmt_nanoplot,
@@ -233,6 +234,7 @@ class GT(
     fmt_datetime = fmt_datetime
     fmt_markdown = fmt_markdown
     fmt_image = fmt_image
+    fmt_image_circle = fmt_image_circle
     fmt_icon = fmt_icon
     fmt_flag = fmt_flag
     fmt_units = fmt_units

--- a/great_tables/vals.py
+++ b/great_tables/vals.py
@@ -14,4 +14,5 @@ from ._formats_vals import (
     val_fmt_time as fmt_time,
     val_fmt_markdown as fmt_markdown,
     val_fmt_image as fmt_image,
+    val_fmt_image_circle as fmt_image_circle,
 )

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1554,11 +1554,13 @@ def test_fmt_image_height_int():
     assert strip_windows_drive(res) == dst
 
 
-def test_fmt_image_width_int():
+def test_fmt_image_width_int_raises():
     formatter = FmtImage(encode=False, width=20)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError) as exc_info:
         formatter.to_html("/a")
+
+    assert "The `width=` argument must be specified as a string." in exc_info.value.args[0]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="uses linux specific paths")
@@ -1580,6 +1582,46 @@ def test_fmt_image_path_http(url: str):
     dst = formatter.SPAN_TEMPLATE.format(dst_img)
 
     assert strip_windows_drive(res) == dst
+
+
+def test_fmt_image_circle_single():
+    formatter = FmtImage(border_radius="50%", sep=" ", file_pattern="{}.svg", encode=False)
+    res = formatter.to_html("/a")
+    dst = formatter.SPAN_TEMPLATE.format(
+        '<img src="/a.svg" style="border-radius: 50%;vertical-align: middle;">'
+    )
+
+    assert strip_windows_drive(res) == dst
+
+
+def test_fmt_image_circle_multiple():
+    formatter = FmtImage(border_radius="50%", sep="---", file_pattern="{}.svg", encode=False)
+    res = formatter.to_html("/a,/b")
+    dst = formatter.SPAN_TEMPLATE.format(
+        '<img src="/a.svg" style="border-radius: 50%;vertical-align: middle;">'
+        "---"
+        '<img src="/b.svg" style="border-radius: 50%;vertical-align: middle;">'
+    )
+
+    assert strip_windows_drive(res) == dst
+
+
+def test_fmt_image_circle_border_radius_raises1():
+    formatter = FmtImage(encode=False, border_radius=20)
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        formatter.to_html("/a")
+    assert "The `border_radius=` argument must be specified as a string." in exc_info.value.args[0]
+
+
+def test_fmt_image_circle_border_radius_raises2():
+    formatter = FmtImage(encode=False, border_radius="20")
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        formatter.to_html("/a")
+    assert (
+        'The `border_radius=` argument must end with either "px" or "%"' in exc_info.value.args[0]
+    )
 
 
 def test_fmt_icon_one_per_cell():

--- a/tests/test_formats_vals.py
+++ b/tests/test_formats_vals.py
@@ -29,3 +29,29 @@ def test_val_fmt_image_multiple(img_paths: Path):
 
     assert 'img src="data:image/svg+xml;base64' in img1
     assert 'img src="data:image/svg+xml;base64' in img2
+
+
+def test_locate_val_fmt_image_circle(img_paths: Path):
+    imgs = vals.fmt_image_circle(
+        "1", border_style="solid", path=img_paths, file_pattern="metro_{}.svg"
+    )
+    with open(img_paths / "metro_1.svg", "rb") as f:
+        encoded = base64.b64encode(f.read()).decode()
+
+    assert encoded in imgs[0]
+
+
+def test_val_fmt_image_circle_single(img_paths: Path):
+    imgs = vals.fmt_image_circle(
+        "1", border_style="solid", path=img_paths, file_pattern="metro_{}.svg"
+    )
+    assert 'img src="data:image/svg+xml;base64' in imgs[0]
+
+
+def test_val_fmt_image_circle_multiple(img_paths: Path):
+    img1, img2 = vals.fmt_image_circle(
+        ["1", "2"], border_style="solid", path=img_paths, file_pattern="metro_{}.svg"
+    )
+
+    assert 'img src="data:image/svg+xml;base64' in img1
+    assert 'img src="data:image/svg+xml;base64' in img2


### PR DESCRIPTION
Hello team,

This PR addresses #354.

Rather than modifying the existing `fmt_image()` to accommodate border-related parameters, I have renamed the current `fmt_image()` to `_fmt_image()`, and introduced new `fmt_image()` and `fmt_image_circle()` functions as thin wrappers around it. Keeping `_fmt_image()` and `FmtImage` under our control gives us greater flexibility to add more parameters in the future if needed.

Here’s a short demo to illustrate the usage:
```python
import polars as pl
from great_tables import GT, vals, html

posit_avatar = "https://avatars.githubusercontent.com/u/107264312?s=200&v=4"
rich_avatar = "https://avatars.githubusercontent.com/u/5612024?v=4"
michael_avatar = "https://avatars.githubusercontent.com/u/2574498?v=4"

title_img = vals.fmt_image_circle(posit_avatar, height=100, border_color="#D3D3D3")[0]
df = pl.DataFrame({"@rich-iannone": [rich_avatar], "@machow": [michael_avatar]})

(
    GT(df)
    .fmt_image_circle(height=150, border_width=5)
    .tab_header(html(title_img))
    .cols_align("center")
    .opt_stylize(color="green", style=6)
)
```
![image](https://github.com/user-attachments/assets/ac3de7bb-c3d5-41c8-9d95-432f48266bad)

One thing that seems odd to me is that `NotImplementedError` doesn’t appear to be raised as expected during execution, yet our tests still pass.  

For instance, when running the following code, I would expect it to break, but instead, the print statement after `vals.fmt_image()` is executed successfully, which feels strange.
```python
import polars as pl
from great_tables import GT

df = pl.DataFrame({"col1": ["https://avatars.githubusercontent.com/u/107264312?s=200&v=4"]})

print(GT(df).fmt_image(width=100)) # Is `NotImplementedError` actually being raised?
print("still running???")
```
