### PR TITLE
tests: add no pandas dependency test of vals function

### DIFF
--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -18,3 +18,10 @@ def test_no_pandas_import_exibble_raises():
 
 def test_no_pandas_import():
     from great_tables import GT
+
+
+def test_no_pandas_vals_funcs_polars():
+    from great_tables import vals
+    import polars as pl
+
+    assert vals.fmt_percent(pl.Series([0.11, 0.22]), decimals=0) == ["11%", "22%"]


### PR DESCRIPTION
This PR adds a test of a vals function, that demonstrates it working on a Polars series, without having Pandas installed.

This is intended to provide a simple test of https://github.com/posit-dev/great-tables/issues/675, showing Pandas is not required to use vals. However, it's fairly simple, so more testing / looking around may be needed.