### PR TITLE
Add no pandas dep test make one column table

### DIFF
--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,6 +1,7 @@
 # Tests to be run with pandas uninstalled.
 
 import pytest
+from great_tables._formats_vals import _make_one_col_table
 
 # mark file as nopandas
 pytestmark = pytest.mark.no_pandas
@@ -18,3 +19,9 @@ def test_no_pandas_import_exibble_raises():
 
 def test_no_pandas_import():
     from great_tables import GT
+
+
+def test_one_column_table_no_lib() -> None:
+    vals = [1, 2, 3]
+
+    _make_one_col_table(vals=vals)


### PR DESCRIPTION
This is a response to #689 that tests the ability to pass a non-polars series to a table. I'm curious to see if this runs in no pandas mode, I was under the impression it wasn't