### PR TITLE
Fix/spanner

### DIFF
--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -277,13 +277,12 @@ def create_columns_component_h(data: GTData) -> str:
                 # If colspans[i] == 0, it means that a previous cell's
                 # `colspan` will cover us
                 if colspans[ii] > 0:
-                    # Filter by column label / id, join with overall column labels style
-                    # TODO check this filter logic
+                    # Filter by spanner label / id, join with overall column labels style
                     styles_i = [
                         x
                         for x in styles_spanner_label
-                        # TODO: refactor use of set
-                        if set(x.grpname) & set([spanner_ids_level_1_index[ii]])
+                        if spanner_ids_level_1_index[ii]
+                        and spanner_ids_level_1_index[ii] in x.grpname
                     ]
 
                     level_1_spanners.append(
@@ -366,13 +365,9 @@ def create_columns_component_h(data: GTData) -> str:
 
             for colspan, span_label in zip(colspans, spanners_row.values()):
                 if colspan > 0:
-                    # Filter by column label / id, join with overall column labels style
-                    # TODO check this filter logic
+                    # Filter by spanner label / id, join with overall column labels style
                     styles_i = [
-                        x
-                        for x in styles_column_label
-                        # TODO: refactor use of set
-                        if set(x.grpname) & set([colspan, span_label])
+                        x for x in styles_spanner_label if span_label and span_label in x.grpname
                     ]
 
                     if span_label:
@@ -391,6 +386,7 @@ def create_columns_component_h(data: GTData) -> str:
                             colspan=colspan,
                             style=_flatten_styles(styles_column_labels + styles_i),
                             scope="colgroup" if colspan > 1 else "col",
+                            id=_create_element_id(table_id, span_label),
                         )
                     )
 

--- a/tests/__snapshots__/test_utils_render_html.ambr
+++ b/tests/__snapshots__/test_utils_render_html.ambr
@@ -89,10 +89,10 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col">
       <span>&nbsp</span>
     </th>
-    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="3" scope="colgroup">
+    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="3" scope="colgroup" id="E">
       <span class="gt_column_spanner">E</span>
     </th>
-    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="4" scope="colgroup">
+    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="4" scope="colgroup" id="">
       <span>&nbsp;</span>
     </th>
   </tr>
@@ -100,13 +100,13 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col">
       <span>&nbsp</span>
     </th>
-    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="2" scope="colgroup">
+    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="2" scope="colgroup" id="">
       <span>&nbsp;</span>
     </th>
-    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="3" scope="colgroup">
+    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="3" scope="colgroup" id="D">
       <span class="gt_column_spanner">D</span>
     </th>
-    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="2" scope="colgroup">
+    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="2" scope="colgroup" id="">
       <span>&nbsp;</span>
     </th>
   </tr>
@@ -114,13 +114,13 @@
     <th class="gt_col_heading gt_columns_bottom_border gt_left" rowspan="1" colspan="1" scope="col">
       <span>&nbsp</span>
     </th>
-    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="2" scope="colgroup">
+    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="2" scope="colgroup" id="C">
       <span class="gt_column_spanner">C</span>
     </th>
-    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col">
+    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="1" scope="col" id="B">
       <span class="gt_column_spanner">B</span>
     </th>
-    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="4" scope="colgroup">
+    <th class="gt_center gt_columns_bottom_border gt_columns_top_border gt_column_spanner_outer" rowspan="1" colspan="4" scope="colgroup" id="">
       <span>&nbsp;</span>
     </th>
   </tr>


### PR DESCRIPTION
# Summary

Fixes #688.

`loc.spanner_labels()` styling was not working for spanner labels at levels above the lowest level. Styles applied to higher-level spanners using `tab_style()` with `loc.spanner_labels()` were ignored.

## Cause
Higher-level spanner elements in the HTML output were missing `id` attributes, which prevented the styling logic from targeting them.

## Solution
- Added `id` attributes to all spanner levels in `create_columns_component_h()`
- Fixed filtering logic to correctly apply styles to higher-level spanners
- Updated test snapshots to reflect the new (correct) HTML structure

## Testing
- Visually verified multi-level spanner styling now works in issue example and one other (see below).
- All existing tests passed except one, which required an update to the snapshot to include `id` attributes where they were previously missing.

# Related GitHub Issues and PRs

- Ref: #688 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.

# New example:

Here is another example which demonstrates the bug fix working.

```python
from great_tables import GT, exibble, loc, style
(
    GT(exibble, rowname_col="row", groupname_col="group")
    .tab_spanner("A", ["num", "char", "fctr"])
    .tab_spanner("B", ["fctr"])
    .tab_spanner("C", ["num", "char"])
    .tab_spanner("D", ["fctr", "date", "time"])
    .tab_spanner("E", spanners=["B", "C"])
    .tab_stubhead(label="Group")
    # Add styling to test multi-level spanner support
    .tab_style(style=style.fill(color="#b15928"), locations=loc.spanner_labels(ids=["E"]))
    .tab_style(style=style.fill(color="#2166ac"), locations=loc.spanner_labels(ids=["A"]))
    .tab_style(style=style.fill(color="#5aae61"), locations=loc.spanner_labels(ids=["D"]))
)
```

After:
<img width="715" alt="Screenshot 2025-06-07 at 11 08 42" src="https://github.com/user-attachments/assets/b15eaf52-45ec-458a-8d12-be6706f41ecd" />

Before:
<img width="715" alt="Screenshot 2025-06-07 at 11 08 19" src="https://github.com/user-attachments/assets/27c3c40d-ff8c-4006-b268-7ffecd657782" />

