### PR TITLE
docs: add cols_label_rotate method

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -153,6 +153,7 @@ quartodoc:
         - GT.cols_align
         - GT.cols_width
         - GT.cols_label
+        - GT.cols_label_rotate
         - GT.cols_move
         - GT.cols_move_to_start
         - GT.cols_move_to_end

--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -302,7 +302,7 @@ def cols_label_rotate(
 
     Note
     --------
-    The dir parameter uses the following keywords to alter the direction of the column label text.
+    The `dir` parameter uses the following keywords to alter the direction of the column label text.
 
     ##### `"sideways-lr"`
 
@@ -323,7 +323,7 @@ def cols_label_rotate(
     """
     # Throw if `align` is not one of the four allowed values
     if align not in ["none", "left", "center", "right"]:
-        raise ValueError("Align must be one of 'left', 'center', or 'right'.")
+        raise ValueError("Align must be one of 'none', 'left', 'center', or 'right'.")
 
     # Throw if `dir` is not one of the three allowed values
     if dir not in ["sideways-lr", "sideways-rl", "vertical-lr"]:

--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -229,29 +229,28 @@ def cols_label_rotate(
     align: str = "none",
     padding: int = 8,
 ) -> GTSelf:
-    # Todo arabic/hebrew check rotations
-    # Todo overflowed text across different dir
-    # Todo padding (8px)
     # Example with format_tf
     # Todo different browsers
 
     """
-    Rotate the column label
+    Rotate the column label for one or more columns.
 
     The `cols_label_rotate()` method sets the orientation of the column label text to make it flow
-    vertically. The `dir` argument
+    vertically. The `dir` argument can be set to one of `"sideways-lr"`, `"sideways-rl"`, or
+    `"vertical-lr"`, and the `columns` argument can be used to specify which columns to apply the
+    alignment to. If `columns` is not specified, the alignment is applied to all columns.
 
     Parameters
     ----------
-    dir
-        A string that gives the direction of the text. Options: `"sideways-lr"`, `"sideways-rl"`,
-        `"vertical-lr"`, `"vertical-rl"`. See note for information on text layout.
     columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list. If `None`, the alignment is applied to all columns.
+    dir
+        A string that gives the direction of the text. Options: `"sideways-lr"`, `"sideways-rl"`,
+        `"vertical-lr"`. See note for information on text layout.
     align
-        The alignment to apply. Must be one of `"left"`, `"center"`, or `"right"`. If text is laid
-        out vertically, this affects alignment along the vertical axis.
+        The alignment to apply. Must be one of `"left"`, `"center"`, `"right", or "none"`. If text
+        is laid out vertically, this affects alignment along the vertical axis.
     padding
         The vertical padding to apply to the column labels.
 
@@ -304,7 +303,7 @@ def cols_label_rotate(
 
     ##### `"vertical-lr"`
 
-    Identical to sideways-rl, but overflow lines are appended to the right.
+    Identical to `"sideways-rl"`, but overflow lines are appended to the right.
 
     """
     # Throw if `align` is not one of the four allowed values

--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -249,7 +249,7 @@ def cols_label_rotate(
         A string that gives the direction of the text. Options: `"sideways-lr"`, `"sideways-rl"`,
         `"vertical-lr"`. See note for information on text layout.
     align
-        The alignment to apply. Must be one of `"left"`, `"center"`, `"right", or "none"`. If text
+        The alignment to apply. Must be one of `"left"`, `"center"`, `"right"`, or `"none"`. If text
         is laid out vertically, this affects alignment along the vertical axis.
     padding
         The vertical padding to apply to the column labels.
@@ -275,7 +275,8 @@ def cols_label_rotate(
     )
     ```
 
-    Other styles you provide won't override the column label rotation directives.
+    Other styles you provide won't override the column label rotation directives. Here we set the
+    text to the right.
 
     ```{python}
     (
@@ -290,10 +291,7 @@ def cols_label_rotate(
     ```{python}
     (
         GT(exibble_sm, rowname_col="row", groupname_col="group")
-        .cols_label(
-        {
-            "fctr": "A longer description of the values in the column below"
-        })
+        .cols_label({"fctr": "A longer description of the values in the column below"})
         .cols_label_rotate(columns=["num", "fctr"], dir="sideways-lr")
         .tab_style(
             style=[style.text(weight="bold"), style.css(rule="height: 200px;")],

--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ._locations import resolve_cols_c
+from ._locations import LocColumnLabels, resolve_cols_c
+from ._styles import CellStyleCss
 from ._tbl_data import SelectExpr
 from ._text import BaseText
 from ._utils import _assert_list_is_subset
@@ -224,9 +225,52 @@ def cols_align(self: GTSelf, align: str = "left", columns: SelectExpr = None) ->
 def cols_label_rotate(self: GTSelf, columns: SelectExpr = None, dir: str = "vertical-lr") -> GTSelf:
     """
     Rotate the column label
+
+    Parameters
+    ----------
+    dir
+        A string that gives the direction of the text. Options: `"vertical-rl"`, `"vertical-lr"`,
+        `"sideways-rl"`, `"sideways-lr"`. See note for information on text layout.
+    columns
+        The columns to target. Can either be a single column name or a series of column names
+        provided in a list. If `None`, the alignment is applied to all columns.
+
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+
+    Examples
+    --------
+    ### `"vertical-rl"`
+
+    For ltr scripts, content flows vertically from top to bottom, and the next vertical line is
+    positioned to the left of the previous line. For rtl scripts, content flows vertically from
+    bottom to top, and the next vertical line is positioned to the right of the previous line.
+
+    ### `"vertical-lr"`
+
+    For ltr scripts, content flows vertically from top to bottom, and the next vertical line is
+    positioned to the right of the previous line. For rtl scripts, content flows vertically from
+    bottom to top, and the next vertical line is positioned to the left of the previous line.
+
+    ### `"sideways-rl"`
+
+    For ltr scripts, content flows vertically from top to bottom. For rtl scripts, content flows
+    vertically from bottom to top. All the glyphs, even those in vertical scripts, are set sideways
+    toward the right.
+
+    ### `"sideways-lr"`
+
+    For ltr scripts, content flows vertically from bottom to top. For rtl scripts, content flows
+    vertically from top to bottom. All the glyphs, even those in vertical scripts, are set sideways
+    toward the left.
+
+    Note
+    --------
+
     """
-    from ._locations import LocColumnLabels
-    from ._styles import CellStyleCss
 
     res = self.tab_style(
         style=CellStyleCss(f"writing-mode: {dir}; vertical-align: middle; transform: scale(-1);"),

--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ._locations import resolve_cols_c
-from ._utils import _assert_list_is_subset
 from ._tbl_data import SelectExpr
 from ._text import BaseText
+from ._utils import _assert_list_is_subset
 
 if TYPE_CHECKING:
     from ._types import GTSelf
@@ -219,3 +219,17 @@ def cols_align(self: GTSelf, align: str = "left", columns: SelectExpr = None) ->
 
     # Set the alignment for each column
     return self._replace(_boxhead=self._boxhead._set_column_aligns(sel_cols, align=align))
+
+
+def cols_label_rotate(self: GTSelf, columns: SelectExpr = None, dir: str = "vertical-lr") -> GTSelf:
+    """
+    Rotate the column label
+    """
+    from ._locations import LocColumnLabels
+    from ._styles import CellStyleCss
+
+    res = self.tab_style(
+        style=CellStyleCss(f"writing-mode: {dir}; vertical-align: middle; transform: scale(-1);"),
+        locations=LocColumnLabels(columns=columns),
+    )
+    return res

--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -222,18 +222,26 @@ def cols_align(self: GTSelf, align: str = "left", columns: SelectExpr = None) ->
     return self._replace(_boxhead=self._boxhead._set_column_aligns(sel_cols, align=align))
 
 
-def cols_label_rotate(self: GTSelf, columns: SelectExpr = None, dir: str = "vertical-lr") -> GTSelf:
+def cols_label_rotate(
+    self: GTSelf, columns: SelectExpr = None, dir: str = "sideways-lr", align: str = "none"
+) -> GTSelf:
     """
     Rotate the column label
+
+    The `cols_label_rotate()` method sets the orientation of the column label text to make it flow
+    vertically. The `dir` argument
 
     Parameters
     ----------
     dir
-        A string that gives the direction of the text. Options: `"vertical-rl"`, `"vertical-lr"`,
-        `"sideways-rl"`, `"sideways-lr"`. See note for information on text layout.
+        A string that gives the direction of the text. Options: `"sideways-lr"`, `"sideways-rl"`,
+        `"vertical-lr"`, `"vertical-rl"`. See note for information on text layout.
     columns
         The columns to target. Can either be a single column name or a series of column names
         provided in a list. If `None`, the alignment is applied to all columns.
+    align
+        The alignment to apply. Must be one of `"left"`, `"center"`, or `"right"`. If text is laid
+        out vertically, this affects alignment along the vertical axis.
 
     Returns
     -------
@@ -243,37 +251,61 @@ def cols_label_rotate(self: GTSelf, columns: SelectExpr = None, dir: str = "vert
 
     Examples
     --------
-    ### `"vertical-rl"`
 
-    For ltr scripts, content flows vertically from top to bottom, and the next vertical line is
-    positioned to the left of the previous line. For rtl scripts, content flows vertically from
-    bottom to top, and the next vertical line is positioned to the right of the previous line.
 
-    ### `"vertical-lr"`
+    ```{python}
+    from great_tables import GT, style, loc, exibble
 
-    For ltr scripts, content flows vertically from top to bottom, and the next vertical line is
-    positioned to the right of the previous line. For rtl scripts, content flows vertically from
-    bottom to top, and the next vertical line is positioned to the left of the previous line.
+    exibble_sm = exibble[["num", "fctr", "row", "group"]]
 
-    ### `"sideways-rl"`
+    (
+        GT(exibble_sm, rowname_col="row", groupname_col="group")
+        .cols_label_rotate(columns=["num", "fctr"])
+    )
+    ```
 
-    For ltr scripts, content flows vertically from top to bottom. For rtl scripts, content flows
-    vertically from bottom to top. All the glyphs, even those in vertical scripts, are set sideways
-    toward the right.
+    Other styles you provide won't override the column label rotation directives.
 
-    ### `"sideways-lr"`
+    ```{python}
+    (
+        GT(exibble_sm, rowname_col="row", groupname_col="group")
+        .cols_label_rotate(columns=["num", "fctr"], dir="vertical-lr")
+        .tab_style(style=style.text(weight="bold"), locations=loc.column_labels(["fctr"]))
+    )
+    ```
+
+    Note
+    --------
+    The dir parameter uses the following keywords to alter the direction of the column label text.
+
+    ##### `"sideways-lr"`
 
     For ltr scripts, content flows vertically from bottom to top. For rtl scripts, content flows
     vertically from top to bottom. All the glyphs, even those in vertical scripts, are set sideways
     toward the left.
 
-    Note
-    --------
+    ##### `"sideways-rl"`
+
+    For ltr scripts, content flows vertically from top to bottom. For rtl scripts, content flows
+    vertically from bottom to top. All the glyphs, even those in vertical scripts, are set sideways
+    toward the right.
+
+    ##### `"vertical-rl"`
+
+    For ltr scripts, content flows vertically from top to bottom, and the next vertical line is
+    positioned to the left of the previous line. For rtl scripts, content flows vertically from
+    bottom to top, and the next vertical line is positioned to the right of the previous line.
+
+    ##### `"vertical-lr"`
+
+    For ltr scripts, content flows vertically from top to bottom, and the next vertical line is
+    positioned to the right of the previous line. For rtl scripts, content flows vertically from
+    bottom to top, and the next vertical line is positioned to the left of the previous line.
 
     """
 
     res = self.tab_style(
-        style=CellStyleCss(f"writing-mode: {dir}; vertical-align: middle; transform: scale(-1);"),
+        style=CellStyleCss(f"writing-mode: {dir}; vertical-align: middle; text-align: {align};"),
         locations=LocColumnLabels(columns=columns),
     )
     return res

--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -262,7 +262,7 @@ def cols_label_rotate(
 
     Examples
     --------
-
+    The example below rotates column labels such that the text is set to the left.
 
     ```{python}
     from great_tables import GT, style, loc, exibble
@@ -282,6 +282,23 @@ def cols_label_rotate(
         GT(exibble_sm, rowname_col="row", groupname_col="group")
         .cols_label_rotate(columns=["num", "fctr"], dir="vertical-lr")
         .tab_style(style=style.text(weight="bold"), locations=loc.column_labels(["fctr"]))
+    )
+    ```
+
+    Labels that are restricted by the height of the stub head will wrap horizontally.
+
+    ```{python}
+    (
+        GT(exibble_sm, rowname_col="row", groupname_col="group")
+        .cols_label(
+        {
+            "fctr": "A longer description of the values in the column below"
+        })
+        .cols_label_rotate(columns=["num", "fctr"], dir="sideways-lr")
+        .tab_style(
+            style=[style.text(weight="bold"), style.css(rule="height: 200px;")],
+            locations=loc.column_labels(["fctr"])
+        )
     )
     ```
 

--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -223,8 +223,18 @@ def cols_align(self: GTSelf, align: str = "left", columns: SelectExpr = None) ->
 
 
 def cols_label_rotate(
-    self: GTSelf, columns: SelectExpr = None, dir: str = "sideways-lr", align: str = "none"
+    self: GTSelf,
+    columns: SelectExpr = None,
+    dir: str = "sideways-lr",
+    align: str = "none",
+    padding: int = 8,
 ) -> GTSelf:
+    # Todo arabic/hebrew check rotations
+    # Todo overflowed text across different dir
+    # Todo padding (8px)
+    # Example with format_tf
+    # Todo different browsers
+
     """
     Rotate the column label
 
@@ -242,6 +252,8 @@ def cols_label_rotate(
     align
         The alignment to apply. Must be one of `"left"`, `"center"`, or `"right"`. If text is laid
         out vertically, this affects alignment along the vertical axis.
+    padding
+        The vertical padding to apply to the column labels.
 
     Returns
     -------
@@ -281,31 +293,43 @@ def cols_label_rotate(
     ##### `"sideways-lr"`
 
     For ltr scripts, content flows vertically from bottom to top. For rtl scripts, content flows
-    vertically from top to bottom. All the glyphs, even those in vertical scripts, are set sideways
-    toward the left.
+    vertically from top to bottom. Characters are set sideways toward the left. Overflow lines are
+    appended to the right.
 
     ##### `"sideways-rl"`
 
     For ltr scripts, content flows vertically from top to bottom. For rtl scripts, content flows
-    vertically from bottom to top. All the glyphs, even those in vertical scripts, are set sideways
-    toward the right.
-
-    ##### `"vertical-rl"`
-
-    For ltr scripts, content flows vertically from top to bottom, and the next vertical line is
-    positioned to the left of the previous line. For rtl scripts, content flows vertically from
-    bottom to top, and the next vertical line is positioned to the right of the previous line.
+    vertically from bottom to top. Characters are set sideways toward the right. Overflow lines are
+    appended to the left.
 
     ##### `"vertical-lr"`
 
-    For ltr scripts, content flows vertically from top to bottom, and the next vertical line is
-    positioned to the right of the previous line. For rtl scripts, content flows vertically from
-    bottom to top, and the next vertical line is positioned to the left of the previous line.
+    Identical to sideways-rl, but overflow lines are appended to the right.
 
     """
+    # Throw if `align` is not one of the four allowed values
+    if align not in ["none", "left", "center", "right"]:
+        raise ValueError("Align must be one of 'left', 'center', or 'right'.")
+
+    # Throw if `dir` is not one of the three allowed values
+    if dir not in ["sideways-lr", "sideways-rl", "vertical-lr"]:
+        raise ValueError("Dir must be one of 'sideways-lr', 'sideways-rl', or 'vertical-lr'.")
+
+    # Todo ask if this is good practice, I feel like it is useful
+    # Todo consider using "default" instead of "none"
+
+    # If user doesn't set an align value then align to the bottom, which is left in the case of
+    # "sideways-lr" and right in all other cases
+    if align == "none":
+        if dir == "sideways-lr":
+            align = "left"
+        else:
+            align = "right"
 
     res = self.tab_style(
-        style=CellStyleCss(f"writing-mode: {dir}; vertical-align: middle; text-align: {align};"),
+        style=CellStyleCss(
+            f"writing-mode: {dir}; vertical-align: middle; text-align: {align}; padding: {padding}px 0px;"
+        ),
         locations=LocColumnLabels(columns=columns),
     )
     return res

--- a/great_tables/_boxhead.py
+++ b/great_tables/_boxhead.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from ._locations import LocColumnLabels, resolve_cols_c
 from ._styles import CellStyleCss
@@ -225,13 +225,10 @@ def cols_align(self: GTSelf, align: str = "left", columns: SelectExpr = None) ->
 def cols_label_rotate(
     self: GTSelf,
     columns: SelectExpr = None,
-    dir: str = "sideways-lr",
-    align: str = "none",
+    dir: Literal["sideways-lr", "sideways-rl", "vertical-lr"] = "sideways-lr",
+    align: Literal["left", "center", "right"] | None = None,
     padding: int = 8,
 ) -> GTSelf:
-    # Example with format_tf
-    # Todo different browsers
-
     """
     Rotate the column label for one or more columns.
 
@@ -322,19 +319,16 @@ def cols_label_rotate(
 
     """
     # Throw if `align` is not one of the four allowed values
-    if align not in ["none", "left", "center", "right"]:
-        raise ValueError("Align must be one of 'none', 'left', 'center', or 'right'.")
+    if align not in [None, "left", "center", "right"]:
+        raise ValueError("Align must be one of `None`, 'left', 'center', or 'right'.")
 
     # Throw if `dir` is not one of the three allowed values
     if dir not in ["sideways-lr", "sideways-rl", "vertical-lr"]:
         raise ValueError("Dir must be one of 'sideways-lr', 'sideways-rl', or 'vertical-lr'.")
 
-    # Todo ask if this is good practice, I feel like it is useful
-    # Todo consider using "default" instead of "none"
-
     # If user doesn't set an align value then align to the bottom, which is left in the case of
     # "sideways-lr" and right in all other cases
-    if align == "none":
+    if not align:
         if dir == "sideways-lr":
             align = "left"
         else:

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -6,7 +6,7 @@ from typing_extensions import Self
 
 # Main gt imports ----
 from ._body import body_reassemble
-from ._boxhead import cols_align, cols_label
+from ._boxhead import cols_align, cols_label, cols_label_rotate
 from ._data_color import data_color
 from ._export import as_latex, as_raw_html, save, show, write_raw_html
 from ._formats import (
@@ -260,6 +260,7 @@ class GT(
     cols_move_to_end = cols_move_to_end
     cols_hide = cols_hide
     cols_unhide = cols_unhide
+    cols_label_rotate = cols_label_rotate
 
     tab_header = tab_header
     tab_source_note = tab_source_note

--- a/tests/__snapshots__/test_boxhead.ambr
+++ b/tests/__snapshots__/test_boxhead.ambr
@@ -1,80 +1,10 @@
 # serializer version: 1
 # name: test_cols_label_rotate
   '''
-  <div id="test" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
-  <style>
-  #test table {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-          }
-  
-  #test thead, tbody, tfoot, tr, td, th { border-style: none; }
-   tr { background-color: transparent; }
-  #test p { margin: 0; padding: 0; }
-   #test .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
-   #test .gt_caption { padding-top: 4px; padding-bottom: 4px; }
-   #test .gt_title { color: #333333; font-size: 125%; font-weight: initial; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
-   #test .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 3px; padding-bottom: 5px; padding-left: 5px; padding-right: 5px; border-top-color: #FFFFFF; border-top-width: 0; }
-   #test .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
-   #test .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
-   #test .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
-   #test .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: bottom; padding-top: 5px; padding-bottom: 5px; padding-left: 5px; padding-right: 5px; overflow-x: hidden; }
-   #test .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
-   #test .gt_column_spanner_outer:first-child { padding-left: 0; }
-   #test .gt_column_spanner_outer:last-child { padding-right: 0; }
-   #test .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: bottom; padding-top: 5px; padding-bottom: 5px; overflow-x: hidden; display: inline-block; width: 100%; }
-   #test .gt_spanner_row { border-bottom-style: hidden; }
-   #test .gt_group_heading { padding-top: 8px; padding-bottom: 8px; padding-left: 5px; padding-right: 5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; text-align: left; }
-   #test .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: middle; }
-   #test .gt_from_md> :first-child { margin-top: 0; }
-   #test .gt_from_md> :last-child { margin-bottom: 0; }
-   #test .gt_row { padding-top: 8px; padding-bottom: 8px; padding-left: 5px; padding-right: 5px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
-   #test .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; }
-   #test .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
-   #test .gt_row_group_first td { border-top-width: 2px; }
-   #test .gt_row_group_first th { border-top-width: 2px; }
-   #test .gt_striped { background-color: rgba(128,128,128,0.05); }
-   #test .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
-   #test .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
-   #test .gt_sourcenote { font-size: 90%; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
-   #test .gt_left { text-align: left; }
-   #test .gt_center { text-align: center; }
-   #test .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
-   #test .gt_font_normal { font-weight: normal; }
-   #test .gt_font_bold { font-weight: bold; }
-   #test .gt_font_italic { font-style: italic; }
-   #test .gt_super { font-size: 65%; }
-   #test .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
-   #test .gt_asterisk { font-size: 100%; vertical-align: 0; }
-   
-  </style>
-  <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
-  <thead>
-  
   <tr class="gt_col_headings">
-    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" style="writing-mode: sideways-lr; vertical-align: middle; text-align: none;" scope="col" id="test-x">x</th>
-    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" style="writing-mode: sideways-lr; vertical-align: middle; text-align: none;" scope="col" id="test-y">y</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" style="writing-mode: sideways-lr; vertical-align: middle; text-align: left; padding: 8px 0px;" scope="col" id="test-x">x</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" style="writing-mode: sideways-lr; vertical-align: middle; text-align: left; padding: 8px 0px;" scope="col" id="test-y">y</th>
     <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="test-z">z</th>
   </tr>
-  </thead>
-  <tbody class="gt_table_body">
-    <tr>
-      <td class="gt_row gt_right">1.234</td>
-      <td class="gt_row gt_right">3.456</td>
-      <td class="gt_row gt_right">5.678</td>
-    </tr>
-    <tr>
-      <td class="gt_row gt_right">2.345</td>
-      <td class="gt_row gt_right">4.567</td>
-      <td class="gt_row gt_right">6.789</td>
-    </tr>
-  </tbody>
-  
-  
-  </table>
-  
-  </div>
-          
   '''
 # ---

--- a/tests/__snapshots__/test_boxhead.ambr
+++ b/tests/__snapshots__/test_boxhead.ambr
@@ -1,0 +1,80 @@
+# serializer version: 1
+# name: test_cols_label_rotate
+  '''
+  <div id="test" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+  <style>
+  #test table {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+          }
+  
+  #test thead, tbody, tfoot, tr, td, th { border-style: none; }
+   tr { background-color: transparent; }
+  #test p { margin: 0; padding: 0; }
+   #test .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
+   #test .gt_caption { padding-top: 4px; padding-bottom: 4px; }
+   #test .gt_title { color: #333333; font-size: 125%; font-weight: initial; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
+   #test .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 3px; padding-bottom: 5px; padding-left: 5px; padding-right: 5px; border-top-color: #FFFFFF; border-top-width: 0; }
+   #test .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+   #test .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+   #test .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+   #test .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: bottom; padding-top: 5px; padding-bottom: 5px; padding-left: 5px; padding-right: 5px; overflow-x: hidden; }
+   #test .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
+   #test .gt_column_spanner_outer:first-child { padding-left: 0; }
+   #test .gt_column_spanner_outer:last-child { padding-right: 0; }
+   #test .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: bottom; padding-top: 5px; padding-bottom: 5px; overflow-x: hidden; display: inline-block; width: 100%; }
+   #test .gt_spanner_row { border-bottom-style: hidden; }
+   #test .gt_group_heading { padding-top: 8px; padding-bottom: 8px; padding-left: 5px; padding-right: 5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; text-align: left; }
+   #test .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: middle; }
+   #test .gt_from_md> :first-child { margin-top: 0; }
+   #test .gt_from_md> :last-child { margin-bottom: 0; }
+   #test .gt_row { padding-top: 8px; padding-bottom: 8px; padding-left: 5px; padding-right: 5px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
+   #test .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; }
+   #test .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
+   #test .gt_row_group_first td { border-top-width: 2px; }
+   #test .gt_row_group_first th { border-top-width: 2px; }
+   #test .gt_striped { background-color: rgba(128,128,128,0.05); }
+   #test .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+   #test .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
+   #test .gt_sourcenote { font-size: 90%; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
+   #test .gt_left { text-align: left; }
+   #test .gt_center { text-align: center; }
+   #test .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
+   #test .gt_font_normal { font-weight: normal; }
+   #test .gt_font_bold { font-weight: bold; }
+   #test .gt_font_italic { font-style: italic; }
+   #test .gt_super { font-size: 65%; }
+   #test .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
+   #test .gt_asterisk { font-size: 100%; vertical-align: 0; }
+   
+  </style>
+  <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
+  <thead>
+  
+  <tr class="gt_col_headings">
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" style="writing-mode: sideways-lr; vertical-align: middle; text-align: none;" scope="col" id="test-x">x</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" style="writing-mode: sideways-lr; vertical-align: middle; text-align: none;" scope="col" id="test-y">y</th>
+    <th class="gt_col_heading gt_columns_bottom_border gt_right" rowspan="1" colspan="1" scope="col" id="test-z">z</th>
+  </tr>
+  </thead>
+  <tbody class="gt_table_body">
+    <tr>
+      <td class="gt_row gt_right">1.234</td>
+      <td class="gt_row gt_right">3.456</td>
+      <td class="gt_row gt_right">5.678</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.345</td>
+      <td class="gt_row gt_right">4.567</td>
+      <td class="gt_row gt_right">6.789</td>
+    </tr>
+  </tbody>
+  
+  
+  </table>
+  
+  </div>
+          
+  '''
+# ---

--- a/tests/test_boxhead.py
+++ b/tests/test_boxhead.py
@@ -2,6 +2,7 @@ import pandas as pd
 from great_tables import GT
 from great_tables.gt import _get_column_labels
 from great_tables._helpers import UnitStr
+from tests.test_utils_render_html import assert_rendered_columns
 
 
 def test_cols_label():
@@ -35,7 +36,7 @@ def test_cols_label_units_text():
 def test_cols_label_rotate(snapshot: str):
     df = pd.DataFrame({"x": [1.234, 2.345], "y": [3.456, 4.567], "z": [5.678, 6.789]})
     gt_tbl = GT(df, id="test").cols_label_rotate(columns=["x", "y"])
-    assert snapshot == gt_tbl.as_raw_html()
+    assert_rendered_columns(snapshot, gt_tbl)
 
 
 def test_final_columns_stub_move_to_begining():

--- a/tests/test_boxhead.py
+++ b/tests/test_boxhead.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 from great_tables import GT
 from great_tables.gt import _get_column_labels
 from great_tables._helpers import UnitStr
@@ -37,6 +38,31 @@ def test_cols_label_rotate(snapshot: str):
     df = pd.DataFrame({"x": [1.234, 2.345], "y": [3.456, 4.567], "z": [5.678, 6.789]})
     gt_tbl = GT(df, id="test").cols_label_rotate(columns=["x", "y"])
     assert_rendered_columns(snapshot, gt_tbl)
+
+
+def test_cols_label_rotate_align_fails():
+    with pytest.raises(ValueError) as exc_info:
+        df = pd.DataFrame({"x": [], "y": []})
+        GT(df).cols_label_rotate(align="invalid")  # noqa
+
+    assert "Align must be one of" in exc_info.value.args[0]
+
+
+def test_cols_label_rotate_dir_fails():
+    with pytest.raises(ValueError) as exc_info:
+        df = pd.DataFrame({"x": [], "y": []})
+        GT(df).cols_label_rotate(dir="invalid")  # noqa
+
+    assert "Dir must be one of" in exc_info.value.args[0]
+
+
+def test_cols_label_rotate_align_default():
+    df = pd.DataFrame({"x": [], "y": []})
+    gt1 = GT(df).cols_label_rotate(columns=["x"], dir="sideways-rl")
+    gt2 = GT(df).cols_label_rotate(columns=["y"], dir="sideways-lr")
+
+    assert "text-align: right;" in gt1._styles[0].styles[0].rule
+    assert "text-align: left;" in gt2._styles[0].styles[0].rule
 
 
 def test_final_columns_stub_move_to_begining():

--- a/tests/test_boxhead.py
+++ b/tests/test_boxhead.py
@@ -32,6 +32,12 @@ def test_cols_label_units_text():
     assert x[2] == "Zee"
 
 
+def test_cols_label_rotate(snapshot: str):
+    df = pd.DataFrame({"x": [1.234, 2.345], "y": [3.456, 4.567], "z": [5.678, 6.789]})
+    gt_tbl = GT(df, id="test").cols_label_rotate(columns=["x", "y"])
+    assert snapshot == gt_tbl.as_raw_html()
+
+
 def test_final_columns_stub_move_to_begining():
     df = pd.DataFrame({"w": [1], "x": [1], "y": [2], "z": [3]})
     gt = GT(df, rowname_col="y")


### PR DESCRIPTION
# Summary

Adding the cols_label_rotate method, which allows for rotating the column headers 90 degrees.

```python
from great_tables import GT, style, loc, exibble

exibble_sm = exibble[["num", "fctr", "row", "group"]]

(
    GT(exibble_sm, rowname_col="row", groupname_col="group")
    .cols_label_rotate(columns=["num", "fctr"])
    .tab_style(
        style=style.text(weight="bold"),
        locations=loc.column_labels(["fctr"])
    )
    .tab_style(
        style=style.text(size="22px"),
        locations=loc.body(columns=["fctr"], rows=[4, 5, 6, 7]),
    )
)
```

<img width="264" alt="image" src="https://github.com/user-attachments/assets/5e40be6e-c5f3-4648-bfe4-e4e04ba492a2" />


Fixes: #620
