### PR TITLE
fix: striping indexing issue

### DIFF
--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -471,11 +471,12 @@ def create_body_component_h(data: GTData) -> str:
 
     ordered_index: list[tuple[int, GroupRowInfo]] = data._stub.group_indices_map()
 
-    for i, group_info in ordered_index:
+    for j, (i, group_info) in enumerate(ordered_index):
         # For table striping we want to add a striping CSS class to the even-numbered
         # rows in the rendered table; to target these rows, determine if `i` in the current
         # row render is an odd number
-        odd_i_row = i % 2 == 1
+
+        odd_j_row = j % 2 == 1
 
         body_cells: list[str] = []
 
@@ -530,7 +531,7 @@ def create_body_component_h(data: GTData) -> str:
 
                 _rowname_styles = [x for x in styles_row_label if x.rownum == i]
 
-                if table_stub_striped and odd_i_row:
+                if table_stub_striped and odd_j_row:
                     classes.append("gt_striped")
 
             else:
@@ -540,7 +541,7 @@ def create_body_component_h(data: GTData) -> str:
 
                 _rowname_styles = []
 
-                if table_body_striped and odd_i_row:
+                if table_body_striped and odd_j_row:
                     classes.append("gt_striped")
 
             # Ensure that `classes` becomes a space-separated string


### PR DESCRIPTION
# Summary

The body generation needs a mapping of the rows to their location in the table because I believe `ordered_index` refers to a mapping before `groupname_col="[row_name]"` is applied.

As noted in the [issue](#700 ), the outcome for a table with groups in the body can be seen here:

```{python}
from great_tables import GT
from great_tables.data import reactions
import polars as pl

reactions_mini = (
    pl.from_pandas(reactions)
    .filter(
        (pl.col("cmpd_type") == "haloalkane (multiple)")
        | (pl.col("cmpd_type") == "haloalkane (separated)")
    )
    .select(["cmpd_name", "cmpd_smiles", "cmpd_type"])
)

gt = GT(reactions_mini, groupname_col="cmpd_type", rowname_col="cmpd_name").opt_row_striping()
```

![image](https://github.com/user-attachments/assets/b67931a9-68c6-4727-bcdd-911ecf941059)

Fixes #700 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.
