### PR TITLE
docs: add the `fmt_tf()` method to the reference API

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -134,6 +134,7 @@ quartodoc:
         - GT.fmt_roman
         - GT.fmt_date
         - GT.fmt_time
+        - GT.fmt_tf
         - GT.fmt_datetime
         - GT.fmt_markdown
         - GT.fmt_units


### PR DESCRIPTION
I'd missed it during work on https://github.com/posit-dev/great-tables/pull/665 so this PR follows up on that and simply adds the `fmt_tf()` method to the site's API Reference.