### PR TITLE
Allow list format in `_make_one_col_table`

### DIFF
--- a/great_tables/_formats_vals.py
+++ b/great_tables/_formats_vals.py
@@ -45,7 +45,7 @@ def _make_one_col_table(vals: X) -> GT:
     with contextlib.suppress(ImportError, ModuleNotFoundError):
         import polars as pl
 
-        vals: pl.Series = pl.Series(vals)
+        vals: pl.Series = pl.Series(values=vals, strict=False)
 
     df = to_frame(vals, name="x")
 

--- a/great_tables/_formats_vals.py
+++ b/great_tables/_formats_vals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -38,21 +39,17 @@ def _make_one_col_table(vals: X) -> GT:
         # anticipating a tuple may be too defensive
         vals = list(vals)
 
-    # If list, try converting it to polars
-    try:
+    # A bare list will always(!) be converted to a pandas Series.
+    # In the case that pandas isn't available, we try converting
+    # it to polars Series.
+    with contextlib.suppress(ImportError, ModuleNotFoundError):
         import polars as pl
-    except (ImportError, ModuleNotFoundError):
-        pass  # better hope pandas is installed
-    else:
+
         vals: pl.Series = pl.Series(vals)
 
-    # TODO: remove pandas. if vals is not a SeriesLike, then we currently
-    # convert them to a pandas Series for backwards compatibility.
     df = to_frame(vals, name="x")
 
-    # Convert the list to a Pandas DataFrame and then to a GTData object
-    gt_obj = GT(df, auto_align=False)
-    return gt_obj
+    return GT(df, auto_align=False)
 
 
 def val_fmt_number(

--- a/great_tables/_formats_vals.py
+++ b/great_tables/_formats_vals.py
@@ -38,6 +38,14 @@ def _make_one_col_table(vals: X) -> GT:
         # anticipating a tuple may be too defensive
         vals = list(vals)
 
+    # If list, try converting it to polars
+    try:
+        import polars as pl
+    except (ImportError, ModuleNotFoundError):
+        pass  # better hope pandas is installed
+    else:
+        vals: pl.Series = pl.Series(vals)
+
     # TODO: remove pandas. if vals is not a SeriesLike, then we currently
     # convert them to a pandas Series for backwards compatibility.
     df = to_frame(vals, name="x")

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -773,10 +773,7 @@ class GroupRows(_Sequence[GroupRowInfo]):
     def reorder(self, group_ids: list[str | MISSING_GROUP]) -> Self:
         # TODO: validate all group_ids are in data
         non_missing = [g for g in group_ids if not isinstance(g, MISSING_GROUP)]
-        try:
-            crnt_order = {grp.group_id: ii for ii, grp in enumerate(self)}
-        except IndexError:
-            crnt_order = {grp.group_id: ii for ii, grp in enumerate(self._d)}
+        crnt_order = {grp.group_id: ii for ii, grp in enumerate(self)}
 
         set_gids = set(group_ids)
         missing_groups = [grp.group_id for grp in self if grp.group_id not in set_gids]

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -773,7 +773,10 @@ class GroupRows(_Sequence[GroupRowInfo]):
     def reorder(self, group_ids: list[str | MISSING_GROUP]) -> Self:
         # TODO: validate all group_ids are in data
         non_missing = [g for g in group_ids if not isinstance(g, MISSING_GROUP)]
-        crnt_order = {grp.group_id: ii for ii, grp in enumerate(self)}
+        try:
+            crnt_order = {grp.group_id: ii for ii, grp in enumerate(self)}
+        except IndexError:
+            crnt_order = {grp.group_id: ii for ii, grp in enumerate(self._d)}
 
         set_gids = set(group_ids)
         missing_groups = [grp.group_id for grp in self if grp.group_id not in set_gids]

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -25,3 +25,22 @@ def test_no_pandas_vals_funcs_polars():
     import polars as pl
 
     assert vals.fmt_percent(pl.Series([0.11, 0.22]), decimals=0) == ["11%", "22%"]
+
+
+def test_make_on_col_table_from_list_no_pandas() -> None:
+    from great_tables._formats_vals import _make_one_col_table
+    import polars as pl
+    # TODO: Should paramaterize this to collections in general
+
+    with pytest.raises(ModuleNotFoundError):
+        import pandas  # sanity check to make sure it's not available
+
+    l: list[str] = ["a", "b", "c"]
+    list_table_html: str = _make_one_col_table(l).as_raw_html()
+    assert isinstance(list_table_html, str)
+
+    ser: pl.Series = pl.Series(l)
+    ser_table_html: str = _make_one_col_table(ser).as_raw_html()
+    assert isinstance(ser_table_html, str)
+
+    # TODO: Need a way to check the equality of the two HTML tables


### PR DESCRIPTION
This is another effort to tackle https://github.com/posit-dev/pointblank/issues/132. In various parts of the library, a list is passed to the one column table maker, so if possible I intercept it and convert it to polars before getting passed to format_values.

I'm curious to see if the tests run, I had to monkeypatch it on the fly for development.
