### PR TITLE
Add underline to active link in top nav

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -132,6 +132,13 @@ p,h1,h2,h3,#toc-title,#toc-function-reference,.nav-link,.table {
 	}
 }
 
+.nav-link.active {
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-decoration-color: rgba(222, 238, 250, 0.75);
+    text-underline-offset: 4px;
+}
+
 #navbarCollapse > ul.navbar-nav.navbar-nav-scroll.ms-auto > li > a {
     background-color: white;
     border-radius: 3px;


### PR DESCRIPTION
This PR is focused on making navigation through the docs site better by highlighting the current section the reader is in within the top navigation.

The proposed fix adds an underline for the current/active section:

<img width="738" alt="image" src="https://github.com/user-attachments/assets/715cd936-0d72-4bb7-8b05-402ef66bc3a0" />

And it works well with the orange background box that appears when hovering over the topnav items:

<img width="707" alt="image" src="https://github.com/user-attachments/assets/5d818cfc-fdee-42ec-bd0c-e43dce94c7a2" />

@machow lmk if this addresses the recent issue well. We can always tweak the appearance of the underline or even go with a different way to highlight the active section. 

Fixes: https://github.com/posit-dev/great-tables/issues/703