### PR TITLE
docs: introduce use of `show()` method in a callout

### DIFF
--- a/docs/get-started/index.qmd
+++ b/docs/get-started/index.qmd
@@ -41,11 +41,14 @@ The `islands` data is a simple **Pandas** DataFrame with 2 columns and that'll s
 gt_tbl = GT(islands_mini)
 
 # Show the output table
-# If working in the console, use gt_tbl.show()
 gt_tbl
 ```
 
 That doesn't look too bad! Sure, it's basic but we really didn't really ask for much. We did receive a proper table with column labels and the data. Oftentimes however, you'll want a bit more: a **Table header**, a **Stub**, and sometimes *source notes* in the **Table Footer** component.
+
+::: {.callout-note}
+Typically we use Great Tables in an notebook environment or within a Quarto document. Tables won't print to the console, but using the `~~GT.show()` method on a table object while in the console will open the HTML table in your default browser.
+:::
 
 ## **Polars** DataFrame support
 


### PR DESCRIPTION
This PR addresses a point of confusion when using GT outside of a notebook environment (e.g., console use). Previously there was a comment in the code cell that pointed toward the `show()` method. To address this better, I think it's worthwhile having a short sentence (with interlink to docs) about `show()` just below the example in a more prominent callout.

Fixes: https://github.com/posit-dev/great-tables/issues/619