### PR TITLE
perf: Avoid using polars map_elements

### DIFF
--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -516,7 +516,7 @@ def _(df: PdDataFrame):
 def _(df: PlDataFrame):
     import polars as pl
 
-    return df.clear().cast(pl.Utf8).clear(len(df))
+    return df.clear(len(df)).cast(pl.Utf8)
 
 
 @create_empty_frame.register
@@ -569,12 +569,19 @@ def _(df: PlDataFrame):
     import polars.selectors as cs
 
     list_cols = [
-        name for name, dtype in zip(df.columns, df.dtypes) if issubclass(dtype.base_type(), pl.List)
+        name for name, dtype in df.collect_schema().items() if issubclass(dtype.base_type(), pl.List)
     ]
 
     return df.with_columns(
-        cs.by_name(list_cols).map_elements(lambda x: str(x.to_list()), return_dtype=pl.String),
-        cs.all().exclude(list_cols).cast(pl.Utf8),
+        *[
+            pl.concat_str(
+                pl.lit("["),
+                pl.col(c).cast(pl.List(pl.String())).list.join(", "),
+                pl.lit("]")
+            ).alias(c)
+            for c in list_cols
+        ],
+        cs.all().exclude(list_cols).cast(pl.String()),
     )
 
 

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -569,15 +569,15 @@ def _(df: PlDataFrame):
     import polars.selectors as cs
 
     list_cols = [
-        name for name, dtype in df.collect_schema().items() if issubclass(dtype.base_type(), pl.List)
+        name
+        for name, dtype in df.collect_schema().items()
+        if issubclass(dtype.base_type(), pl.List)
     ]
 
     return df.with_columns(
         *[
             pl.concat_str(
-                pl.lit("["),
-                pl.col(c).cast(pl.List(pl.String())).list.join(", "),
-                pl.lit("]")
+                pl.lit("["), pl.col(c).cast(pl.List(pl.String())).list.join(", "), pl.lit("]")
             ).alias(c)
             for c in list_cols
         ],


### PR DESCRIPTION
# Summary

Avoid using `polars.Expr.map_elements` in `cast_frame_to_string` for performance reasons.

# Related GitHub Issues and PRs

NA

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ ] I have added **pytest** unit tests for any new functionality.


## Additional info

I made a simple script to reproduce the speedup:

<details> <summary> full script </summary>

```py
import random
import time

import polars as pl
import polars.selectors as cs

def new_impl(frame: pl.DataFrame) -> pl.DataFrame:
    list_cols = [
        name for name, dtype in frame.collect_schema().items() if issubclass(dtype.base_type(), pl.List)
    ]

    return frame.with_columns(
        *[
            pl.concat_str(
                pl.lit("["),
                pl.col(c).cast(pl.List(pl.String())).list.join(", "),
                pl.lit("]")
            ).alias(c)
            for c in list_cols
        ],
        cs.all().exclude(list_cols).cast(pl.String()),
    )

def old_impl(frame: pl.DataFrame) -> pl.DataFrame:
    list_cols = [
        name for name, dtype in zip(frame.columns, frame.dtypes) if issubclass(dtype.base_type(), pl.List)
    ]

    return frame.with_columns(
        cs.by_name(list_cols).map_elements(lambda x: str(x.to_list()), return_dtype=pl.String),
        cs.all().exclude(list_cols).cast(pl.Utf8),
    )

SIZES = (10, 100, 1_000, 10_000, 100_000)

results: list[dict[str, float]] = []

for SIZE in SIZES:

    data = {
        "l1": [[random.randint(1, 10) for _ in range(random.randint(1, 10))] for _ in range(SIZE)],
        "l2": [[random.randint(1, 10) for _ in range(random.randint(1, 10))] for _ in range(SIZE)],
        "x": pl.int_range(SIZE, eager=True),
        "y": [random.random() for _ in range(SIZE)]
    }
    df = pl.DataFrame(data)

    start_new = time.perf_counter()
    _ = [new_impl(df) for _ in range(100)]
    end_new = time.perf_counter()

    start_old = time.perf_counter()
    _ = [old_impl(df) for _ in range(100)]
    end_old = time.perf_counter()

    results.append({"size": SIZE, "new": end_new-start_new, "old": end_old - start_old})

print(pl.DataFrame(results))
```

</details>

which in my local results in:

```terminal
shape: (5, 3)
┌────────┬──────────┬───────────┐
│ size   ┆ new      ┆ old       │
│ ---    ┆ ---      ┆ ---       │
│ i64    ┆ f64      ┆ f64       │
╞════════╪══════════╪═══════════╡
│ 10     ┆ 0.017877 ┆ 0.030849  │
│ 100    ┆ 0.018732 ┆ 0.043844  │
│ 1000   ┆ 0.034522 ┆ 0.186577  │
│ 10000  ┆ 0.195836 ┆ 1.602947  │
│ 100000 ┆ 1.607751 ┆ 15.813912 │
└────────┴──────────┴───────────┘
```

*forgot to mention that "new" and "old" columns represent the time taken to run the implementation.

Even with dataframe of size 10, the speedup is significant (in relative terms) and it gets larger and larger as the size increases.
