### PR TITLE
fix: Align pyarrow float64 type to the right to match pandas and polars behavior

### DIFF
--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -407,6 +407,7 @@ class Boxhead(_Sequence[ColInfo]):
                 _str_detect(col_class, "int")
                 or _str_detect(col_class, "uint")
                 or _str_detect(col_class, "float")
+                or _str_detect(col_class, "double")
             ):
                 align.append("right")
             elif _str_detect(col_class, "date"):

--- a/tests/__snapshots__/test_tbl_data.ambr
+++ b/tests/__snapshots__/test_tbl_data.ambr
@@ -5,17 +5,17 @@
     <tr>
       <td class="gt_row gt_right">$1.00</td>
       <td class="gt_row gt_left">a</td>
-      <td class="gt_row gt_center">4</td>
+      <td class="gt_row gt_right">4</td>
     </tr>
     <tr>
       <td class="gt_row gt_right">$2.00</td>
       <td class="gt_row gt_left">b</td>
-      <td class="gt_row gt_center">5</td>
+      <td class="gt_row gt_right">5</td>
     </tr>
     <tr>
       <td class="gt_row gt_right">$3.00</td>
       <td class="gt_row gt_left">c</td>
-      <td class="gt_row gt_center">6</td>
+      <td class="gt_row gt_right">6</td>
     </tr>
   </tbody>
   '''


### PR DESCRIPTION
# Summary

As per title, this PR aligns the behavior of pyarrow float64 dtype to pandas and polars.

# Related GitHub Issues and PRs

- Closes #732

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.


## Additional info

```py
import pyarrow as pa

schema = pa.schema([
    pa.field("a", pa.float64()),
    pa.field("b", pa.float32()),
])

tbl = pa.table({"a": [1,2,], "b": [3,4]}, schema=schema)

str(tbl["a"].type)
# 'double'

str(tbl["b"].type)
# 'float'
```