### PR TITLE
fix: Always access column names via `get_column_names` instead of `.columns`

### DIFF
--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -6,7 +6,7 @@ import numpy as np
 from typing_extensions import TypeAlias
 
 from great_tables._locations import RowSelectExpr, resolve_cols_c, resolve_rows_i
-from great_tables._tbl_data import DataFrameLike, SelectExpr, is_na
+from great_tables._tbl_data import DataFrameLike, SelectExpr, get_column_names, is_na
 from great_tables.loc import body
 from great_tables.style import fill, text
 
@@ -216,7 +216,7 @@ def data_color(
     columns_resolved: list[str]
 
     if columns is None:
-        columns_resolved = data_table.columns
+        columns_resolved = get_column_names(data_table)
     else:
         columns_resolved = resolve_cols_c(data=self, expr=columns)
 

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -19,7 +19,7 @@ from ._gt_data import (
     StyleInfo,
 )
 from ._styles import CellStyle
-from ._tbl_data import PlDataFrame, PlExpr, eval_select, eval_transform
+from ._tbl_data import PlDataFrame, PlExpr, eval_select, eval_transform, get_column_names
 
 if TYPE_CHECKING:
     from ._gt_data import TblData
@@ -715,7 +715,7 @@ def resolve_cols_i(
 
                 return [
                     (col, ii)
-                    for ii, col in enumerate(data._tbl_data.columns)
+                    for ii, col in enumerate(get_column_names(data._tbl_data))
                     if col not in cols_excl
                 ]
 

--- a/tests/test_substitutions.py
+++ b/tests/test_substitutions.py
@@ -59,6 +59,12 @@ def test_sub_missing_meth(df):
     assert_series_equals(new_gt._body.body["col1"], ["--", "--", None])
 
 
+def test_sub_missing_meth_implicit_columns(df):
+    # Drive by: https://github.com/posit-dev/great-tables/issues/667
+    new_gt = GT(df).sub_missing(missing_text="--")._render_formats("html")
+    assert_series_equals(new_gt._body.body["col1"], ["--", "--", None])
+
+
 @pytest.mark.parametrize("el", [0, 0.0])
 def test_sub_zero_el(el):
     assert SubZero("--").to_html(el) == "--"


### PR DESCRIPTION
# Summary

Replaces `.columns` with `get_column_names` to return column names also for pyarrow (currently the column values are returned).

## Disclaimer

For pyarrow backed tbl_data, `data_color` the code would end up breaking a few lines down the line when performing the follow operation:

```py
column_vals = data_table[col][row_pos].to_list()
```

In fact, slicing with a list on a chunked array raises 

> *** TypeError: 'list' object cannot be interpreted as an integer

I wanted this PR to be atomic enough to solve _one_ issue. I can follow up on this other one

# Related GitHub Issues and PRs

- Closes #667 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.
