### PR TITLE
refactor: Narwhalify `data_color` function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = ["tables"]
 license.file = "LICENSE"
 authors = [
     { name = "Richard Iannone", email = "rich@posit.co" },
-    { name = "Michael Chow", email = "michael.chow@posit.co" }
+    { name = "Michael Chow", email = "michael.chow@posit.co" },
 ]
 dynamic = ["version"]
 classifiers = [
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Text Processing :: Markup :: HTML",
-    "Topic :: Scientific/Engineering :: Visualization"
+    "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
     "commonmark>=0.9.1",
@@ -45,27 +45,17 @@ dependencies = [
     "typing_extensions>=3.10.0.0",
     "numpy>=1.22.4",
     "Babel>=2.13.1",
-    "importlib-resources"
+    "importlib-resources",
+    "narwhals>=2.0.0",
 ]
 requires-python = ">=3.9"
 
 [project.optional-dependencies]
-all = [
-    "great_tables[extra]",
-    "great_tables[dev]",
-]
+all = ["great_tables[extra]", "great_tables[dev]"]
 
-extra = [
-    "css-inline>=0.14.1",
-    "selenium>=4.18.1",
-    "Pillow>=10.2.0",
-]
+extra = ["css-inline>=0.14.1", "selenium>=4.18.1", "Pillow>=10.2.0"]
 
-dev = [
-    "great_tables[dev-no-pandas]",
-    "pandas",
-    "plotnine",
-]
+dev = ["great_tables[dev-no-pandas]", "pandas", "plotnine"]
 
 dev-no-pandas = [
     "ruff==0.8.0",
@@ -80,7 +70,7 @@ dev-no-pandas = [
     "pytest-cov",
     "shiny",
     "svg.py",
-    "syrupy"
+    "syrupy",
 ]
 
 [project.urls]
@@ -91,9 +81,7 @@ documentation = "https://posit-dev.github.io/great-tables/"
 minversion = "6.0"
 addopts = "-ra -q --cov=great_tables -m 'not no_pandas'"
 asyncio_mode = "strict"
-testpaths = [
-    "tests"
-]
+testpaths = ["tests"]
 
 markers = [
     "extra: marks tests that require extra dependencies to run",
@@ -108,15 +96,13 @@ line-length = 100
 exclude = ["docs", ".venv", "tests/*"]
 
 ignore = [
-    "E402",    # module level import not at top of file
-    "E501",    # line too long (maximum 100 characters)
-    "F811",    # redefinition of unused name
-    "E203",    # whitespace before ':'
-    "F841",    # local variable 'name' is assigned to but never used
-    "E702",    # multiple statements on one line (semicolon)
+    "E402", # module level import not at top of file
+    "E501", # line too long (maximum 100 characters)
+    "F811", # redefinition of unused name
+    "E203", # whitespace before ':'
+    "F841", # local variable 'name' is assigned to but never used
+    "E702", # multiple statements on one line (semicolon)
 ]
 
 [tool.coverage.report]
-exclude_also = [
-    "if TYPE_CHECKING:"
-]
+exclude_also = ["if TYPE_CHECKING:"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,69 @@
+from importlib.util import find_spec
+
+from typing import Any, Sequence
+import pytest
+from narwhals.typing import IntoSeries
+from narwhals.utils import parse_version
+
+from tests.utils import SeriesConstructor
+
+
+def pandas_series_constructor(obj: Sequence[Any]) -> IntoSeries:
+    import pandas as pd
+
+    return pd.Series(obj)  # type: ignore[no-any-return]
+
+
+def pandas_nullable_series_constructor(obj: Sequence[Any]) -> IntoSeries:
+    import pandas as pd
+
+    return pd.Series(obj).convert_dtypes(dtype_backend="numpy_nullable")  # type: ignore[no-any-return]
+
+
+def pandas_pyarrow_series_constructor(obj: Sequence[Any]) -> IntoSeries:
+    import pandas as pd
+
+    return pd.Series(obj).convert_dtypes(dtype_backend="pyarrow")  # type: ignore[no-any-return]
+
+
+def polars_series_constructor(obj: Sequence[Any]) -> IntoSeries:
+    import polars as pl
+
+    return pl.Series(obj)
+
+
+def pyarrow_array_constructor(obj: Sequence[Any]) -> IntoSeries:
+    import pyarrow as pa
+
+    return pa.chunked_array([obj])  # type: ignore[no-any-return]
+
+
+series_constructors: list[SeriesConstructor] = []
+
+is_pyarrow_installed = find_spec("pyarrow") is not None
+
+if find_spec("pandas"):
+    import pandas as pd
+
+    series_constructors.append(pandas_series_constructor)
+
+    pandas_ge_v2 = parse_version(pd.__version__) >= parse_version("2.0.0")
+
+    if pandas_ge_v2:
+        series_constructors.append(pandas_nullable_series_constructor)
+
+    if pandas_ge_v2 and is_pyarrow_installed:
+        # pandas 2.0+ supports pyarrow dtype backend
+        # https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#new-dtype-backends
+        series_constructors.append(pandas_pyarrow_series_constructor)
+
+if find_spec("polars"):
+    series_constructors.append(polars_series_constructor)
+
+if is_pyarrow_installed:
+    series_constructors.append(pyarrow_array_constructor)
+
+
+@pytest.fixture(params=series_constructors)
+def series_constructor(request: pytest.FixtureRequest):
+    return request.param  # type: ignore[no-any-return]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 from importlib.util import find_spec
 
 from typing import Any, Sequence
+
 import pytest
+
 from narwhals.typing import IntoSeries
 from narwhals.utils import parse_version
 

--- a/tests/data_color/test_data_color_utils.py
+++ b/tests/data_color/test_data_color_utils.py
@@ -2,7 +2,6 @@ import math
 
 import narwhals.stable.v2 as nw
 import numpy as np
-import pandas as pd
 import pytest
 from great_tables._data_color.base import (
     _add_alpha,
@@ -463,11 +462,11 @@ def test_expand_short_hex_valid_short_hex():
         ([2, 3, 4], [0.25, 0.5, 0.75]),  # Test case 1: Rescale values within the domain range
         (
             [0, 6],
-            [np.nan, np.nan],
+            [float("nan"), float("nan")],
         ),  # Test case 2: Rescale values outside the domain range
         (
-            [2.0, np.nan, 4.0],
-            [0.25, np.nan, 0.75],
+            [2.0, float("nan"), 4.0],
+            [0.25, float("nan"), 0.75],
         ),  # Test case 3: Rescale values with NA values
     ],
 )
@@ -485,8 +484,8 @@ def test_rescale_numeric(
     "vals",
     [
         (1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
-        (1.0, 2, 3, 4, 5, 6, 7, 8, 9, 10, np.nan),
-        (1.0, 2, 3, 4, 5, 6, 7, 8, 9, 10, np.nan, np.nan),
+        (1.0, 2, 3, 4, 5, 6, 7, 8, 9, 10, float("nan")),
+        (1.0, 2, 3, 4, 5, 6, 7, 8, 9, 10, float("nan"), float("nan")),
     ],
 )
 def test_get_domain_numeric(series_constructor: SeriesConstructor, vals: list[float]) -> None:

--- a/tests/data_color/test_data_color_utils.py
+++ b/tests/data_color/test_data_color_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 from contextlib import nullcontext
 from typing import Any

--- a/tests/data_color/test_data_color_utils.py
+++ b/tests/data_color/test_data_color_utils.py
@@ -1,4 +1,6 @@
 import math
+from contextlib import nullcontext
+from typing import Any
 
 import narwhals.stable.v2 as nw
 import numpy as np
@@ -23,306 +25,212 @@ from great_tables._data_color.base import (
     _srgb,
 )
 from great_tables._data_color.palettes import GradientPalette
-from great_tables._tbl_data import is_na, Agnostic
 
 from tests.utils import SeriesConstructor, assert_series_equal
 
 
-def test_ideal_fgnd_color_dark_contrast():
-    bgnd_color = "#FFFFFF"  # White background color
-    fgnd_color = _ideal_fgnd_color(bgnd_color)
-    assert fgnd_color == "#000000"  # Expected dark foreground color
+@pytest.mark.parametrize(
+    ("bgnd_color", "fgnd_color"),
+    [
+        ("#FFFFFF", "#000000"),  # White background color -> Expected dark foreground color
+        ("#000000", "#FFFFFF"),  # Black background color -> Expected light foreground color
+    ],
+)
+def test_ideal_fgnd_color_contrast(bgnd_color: str, fgnd_color: str) -> None:
+    assert _ideal_fgnd_color(bgnd_color) == fgnd_color
 
 
-def test_ideal_fgnd_color_light_contrast():
-    bgnd_color = "#000000"  # Black background color
-    fgnd_color = _ideal_fgnd_color(bgnd_color)
-    assert fgnd_color == "#FFFFFF"  # Expected light foreground color
+@pytest.mark.parametrize(
+    ("bgnd_color", "light_color", "dark_color", "fgnd_color"),
+    [
+        (
+            "#FF0000",  # Red background color
+            "#00FF00",  # Green light color
+            "#0000FF",  # Blue dark color
+            "#00FF00",  # Expected custom light foreground color
+        ),
+        (
+            "#FF0000FF",  # Red background color with alpha
+            "#00FF00",  # Green light color
+            "#0000FF",  # Blue dark color
+            "#00FF00",  # Expected custom light foreground color
+        ),
+        (
+            "#FF0000",  # Red background color
+            "#00FF00",  # Green light color
+            "#0000FF",  # Blue dark color
+            "#00FF00",  # Expected custom light foreground color
+        ),
+        (
+            "#FF0000FF",  # Red background color with alpha
+            "#00FF00",  # Green light color
+            "#0000FF",  # Blue dark color
+            "#00FF00",  # Expected custom light foreground color
+        ),
+    ],
+)
+def test_ideal_fgnd_color_custom_contrast(
+    bgnd_color: str, fgnd_color: str, light_color: str, dark_color: str
+) -> None:
+    assert _ideal_fgnd_color(bgnd_color, light=light_color, dark=dark_color) == fgnd_color
 
 
-def test_ideal_fgnd_color_custom_contrast():
-    bgnd_color = "#FF0000"  # Red background color
-    light_color = "#00FF00"  # Green light color
-    dark_color = "#0000FF"  # Blue dark color
-    fgnd_color = _ideal_fgnd_color(bgnd_color, light=light_color, dark=dark_color)
-    assert fgnd_color == "#00FF00"  # Expected custom light foreground color
+@pytest.mark.parametrize(
+    ("color_1", "color_2", "contrast_ratio"),
+    [
+        ("#FFFFFF", "#000000", 21.0),  # Colors: (White, Black) -> high contrast ratio
+        ("#FF0000", "#00FF00", 2.9139375476009137),  # colors: (Red, Green) -> low contrast ratio
+        (
+            "#FF0000FF",
+            "#00FF00",
+            2.9139375476009137,
+        ),  # colors: (Red with alpha, Green) -> Contrast ratio unchanged with alpha
+        (
+            "#FF0000",
+            "#FF0000",
+            1.0,
+        ),  # colors: (Red, Red) -> Contrast ratio always 1.0 for same color
+        (
+            "#FF0000FF",
+            "#FF0000FF",
+            1.0,
+        ),  # colors: (Red with alpha, Red with alpha) -> Contrast ratio unchanged with alpha
+    ],
+)
+def test_get_wcag_contrast_ratio(color_1: str, color_2: str, contrast_ratio: float) -> None:
+    assert _get_wcag_contrast_ratio(color_1, color_2) == contrast_ratio
 
 
-def test_ideal_fgnd_color_custom_contrast_with_alpha():
-    bgnd_color = "#FF0000FF"  # Red background color with alpha
-    light_color = "#00FF00"  # Green light color
-    dark_color = "#0000FF"  # Blue dark color
-    fgnd_color = _ideal_fgnd_color(bgnd_color, light=light_color, dark=dark_color)
-    assert fgnd_color == "#00FF00"  # Expected custom light foreground color
+@pytest.mark.parametrize(
+    ("hex_color", "rgb"),
+    [
+        ("#FF0000", (255, 0, 0)),  # Red color
+        ("#00FF00", (0, 255, 0)),  # Green color
+        ("#0000FF", (0, 0, 255)),  # Blue color
+        ("#FFFFFF", (255, 255, 255)),  # White color
+        ("#000000", (0, 0, 0)),  # Black color
+        ("#FF0000FF", (255, 0, 0)),  # Red color with alpha
+        ("#00FF00FF", (0, 255, 0)),  # Green color with alpha
+        ("#0000FFFF", (0, 0, 255)),  # Blue color with alpha
+        ("#FFFFFFFF", (255, 255, 255)),  # White color with alpha
+        ("#000000FF", (0, 0, 0)),  # Black color with alpha
+    ],
+)
+def test_hex_to_rgb(hex_color: str, rgb: tuple[int, int, int]) -> None:
+    assert _hex_to_rgb(hex_color) == rgb
 
 
-def test_ideal_fgnd_color_custom_contrast_with_custom_colors():
-    bgnd_color = "#FF0000"  # Red background color
-    light_color = "#00FF00"  # Green light color
-    dark_color = "#0000FF"  # Blue dark color
-    fgnd_color = _ideal_fgnd_color(bgnd_color, light=light_color, dark=dark_color)
-    assert fgnd_color == "#00FF00"  # Expected custom light foreground color
+@pytest.mark.parametrize(
+    ("rgb", "luminance"),
+    [
+        ((255, 255, 255), 1.0),  # White color
+        ((0, 0, 0), 0.0),  # Black color
+        ((255, 0, 0), 0.2126),  # Red color
+        ((0, 255, 0), 0.7152),  # Green color
+        ((0, 0, 255), 0.0722),  # Blue color
+    ],
+)
+def test_relative_luminance(rgb: tuple[int, int, int], luminance: float) -> None:
+    assert _relative_luminance(rgb) == luminance
 
 
-def test_ideal_fgnd_color_custom_contrast_with_custom_colors_and_alpha():
-    bgnd_color = "#FF0000FF"  # Red background color with alpha
-    light_color = "#00FF00"  # Green light color
-    dark_color = "#0000FF"  # Blue dark color
-    fgnd_color = _ideal_fgnd_color(bgnd_color, light=light_color, dark=dark_color)
-    assert fgnd_color == "#00FF00"  # Expected custom light foreground color
+@pytest.mark.parametrize(
+    ("x", "srgb"),
+    [
+        (0, 0.0),
+        (255, 1.0),
+        (128, 0.21586050011389926),
+        (100, 0.12743768043564743),
+        (200, 0.5775804404296506),
+    ],
+)
+def test_srgb(x: int, srgb: float) -> None:
+    assert _srgb(x) == srgb
 
 
-def test_get_wcag_contrast_ratio():
-    color_1 = "#FFFFFF"  # White color
-    color_2 = "#000000"  # Black color
-    contrast_ratio = _get_wcag_contrast_ratio(color_1, color_2)
-    assert contrast_ratio == 21.0  # Expected high contrast ratio
+@pytest.mark.parametrize(
+    ("colors", "alpha", "result"),
+    [
+        (["#FF0000", "#00FF00", "#0000FF"], None, ["#FF0000", "#00FF00", "#0000FF"]),
+        (["red", "green", "blue"], None, ["#FF0000", "#008000", "#0000FF"]),
+        (["#FF0000", "green", "#0000FF"], None, ["#FF0000", "#008000", "#0000FF"]),
+        (["#FF0000", "#00FF00", "#0000FF"], 0.5, ["#FF00007F", "#00FF007F", "#0000FF7F"]),
+        (["red", "green", "blue"], 0.5, ["#FF00007F", "#0080007F", "#0000FF7F"]),
+        (["#FF0000", "green", "#0000FF"], 0.5, ["#FF00007F", "#0080007F", "#0000FF7F"]),
+    ],
+)
+def test_html_color_hex_colors(colors: list[str], alpha: float | None, result: list[str]) -> None:
+    assert _html_color(colors, alpha=alpha) == result
 
 
-def test_get_wcag_contrast_ratio_custom_colors():
-    color_1 = "#FF0000"  # Red color
-    color_2 = "#00FF00"  # Green color
-    contrast_ratio = _get_wcag_contrast_ratio(color_1, color_2)
-    assert contrast_ratio == 2.9139375476009137  # Expected low contrast ratio
-
-
-def test_get_wcag_contrast_ratio_custom_colors_with_alpha():
-    color_1 = "#FF0000FF"  # Red color with alpha
-    color_2 = "#00FF00"  # Green color
-    contrast_ratio = _get_wcag_contrast_ratio(color_1, color_2)
-    assert contrast_ratio == 2.9139375476009137  # Contrast ratio unchanged with alpha
-
-
-def test_get_wcag_contrast_ratio_same_color():
-    color_1 = "#FF0000"  # Red color
-    color_2 = "#FF0000"  # Red color
-    contrast_ratio = _get_wcag_contrast_ratio(color_1, color_2)
-    assert contrast_ratio == 1.0  # Contrast ratio always 1.0 for same color
-
-
-def test_get_wcag_contrast_ratio_same_color_with_alpha():
-    color_1 = "#FF0000FF"  # Red color with alpha
-    color_2 = "#FF0000FF"  # Red color with alpha
-    contrast_ratio = _get_wcag_contrast_ratio(color_1, color_2)
-    assert contrast_ratio == 1.0  # Contrast ratio unchanged with alpha
-
-
-def test_hex_to_rgb():
-    hex_color = "#FF0000"  # Red color
-    rgb = _hex_to_rgb(hex_color)
-    assert rgb == (255, 0, 0)
-
-    hex_color = "#00FF00"  # Green color
-    rgb = _hex_to_rgb(hex_color)
-    assert rgb == (0, 255, 0)
-
-    hex_color = "#0000FF"  # Blue color
-    rgb = _hex_to_rgb(hex_color)
-    assert rgb == (0, 0, 255)
-
-    hex_color = "#FFFFFF"  # White color
-    rgb = _hex_to_rgb(hex_color)
-    assert rgb == (255, 255, 255)
-
-    hex_color = "#000000"  # Black color
-    rgb = _hex_to_rgb(hex_color)
-    assert rgb == (0, 0, 0)
-
-    hex_color = "#FF0000FF"  # Red color with alpha
-    rgb = _hex_to_rgb(hex_color)
-    assert rgb == (255, 0, 0)
-
-    hex_color = "#00FF00FF"  # Green color with alpha
-    rgb = _hex_to_rgb(hex_color)
-    assert rgb == (0, 255, 0)
-
-    hex_color = "#0000FFFF"  # Blue color with alpha
-    rgb = _hex_to_rgb(hex_color)
-    assert rgb == (0, 0, 255)
-
-    hex_color = "#FFFFFFFF"  # White color with alpha
-    rgb = _hex_to_rgb(hex_color)
-    assert rgb == (255, 255, 255)
-
-    hex_color = "#000000FF"  # Black color with alpha
-    rgb = _hex_to_rgb(hex_color)
-    assert rgb == (0, 0, 0)
-
-
-def test_relative_luminance():
-    rgb = (255, 255, 255)  # White color
-    luminance = _relative_luminance(rgb)
-    assert luminance == 1.0
-
-    rgb = (0, 0, 0)  # Black color
-    luminance = _relative_luminance(rgb)
-    assert luminance == 0.0
-
-    rgb = (255, 0, 0)  # Red color
-    luminance = _relative_luminance(rgb)
-    assert luminance == 0.2126
-
-    rgb = (0, 255, 0)  # Green color
-    luminance = _relative_luminance(rgb)
-    assert luminance == 0.7152
-
-    rgb = (0, 0, 255)  # Blue color
-    luminance = _relative_luminance(rgb)
-    assert luminance == 0.0722
-
-
-def test_srgb():
-    x = 0
-    result = _srgb(x)
-    assert result == 0.0
-
-    x = 255
-    result = _srgb(x)
-    assert result == 1.0
-
-    x = 128
-    result = _srgb(x)
-    assert result == 0.21586050011389926
-
-    x = 100
-    result = _srgb(x)
-    assert result == 0.12743768043564743
-
-    x = 200
-    result = _srgb(x)
-    assert result == 0.5775804404296506
-
-
-def test_html_color_hex_colors():
+@pytest.mark.parametrize(
+    ("alpha", "context"),
+    [
+        (0.5, nullcontext()),
+        (
+            1.5,
+            pytest.raises(
+                ValueError,
+                match=r"Invalid alpha value provided \(1.5\). Please ensure that alpha is a value between 0 and 1.",
+            ),
+        ),
+    ],
+)
+def test_add_alpha_float_alpha(alpha: float, context: Any) -> None:
     colors = ["#FF0000", "#00FF00", "#0000FF"]
-    result = _html_color(colors)
-    assert result == ["#FF0000", "#00FF00", "#0000FF"]
+
+    with context:
+        result = _add_alpha(colors, alpha)
+        assert result == ["#FF00007F", "#00FF007F", "#0000FF7F"]
 
 
-def test_html_color_named_colors():
-    colors = ["red", "green", "blue"]
-    result = _html_color(colors)
-    assert result == ["#FF0000", "#008000", "#0000FF"]
+@pytest.mark.parametrize(
+    ("colors", "result"),
+    [
+        (["#FF0000FF", "#00FF00FF", "#0000FFFF"], ["#FF0000", "#00FF00", "#0000FF"]),
+        (["#FF000080", "#00FF0080", "#0000FF80"], ["#FF0000", "#00FF00", "#0000FF"]),
+        (["#FF0000", "#00FF00", "#0000FF"], ["#FF0000", "#00FF00", "#0000FF"]),
+    ],
+)
+def test_remove_alpha(colors: list[str], result: list[str]) -> None:
+    assert _remove_alpha(colors) == result
 
 
-def test_html_color_mixed_colors():
-    colors = ["#FF0000", "green", "#0000FF"]
-    result = _html_color(colors)
-    assert result == ["#FF0000", "#008000", "#0000FF"]
+@pytest.mark.parametrize(
+    ("x", "hex"),
+    [
+        (0.0, "00"),  # Test case 1: x = 0.0
+        (1.0, "FF"),  # Test case 2: x = 1.0
+        (0.5, "7F"),  # Test case 3: x = 0.5
+        (0.25, "3F"),  # Test case 4: x = 0.25
+        (0.75, "BF"),  # Test case 5: x = 0.75
+        (0.125, "1F"),  # Test case 6: x = 0.125
+    ],
+)
+def test_float_to_hex(x: float, hex: str) -> None:
+    assert _float_to_hex(x) == hex
 
 
-def test_html_color_hex_colors_with_alpha():
-    colors = ["#FF0000", "#00FF00", "#0000FF"]
-    alpha = 0.5
-    result = _html_color(colors, alpha)
-    assert result == ["#FF00007F", "#00FF007F", "#0000FF7F"]
+@pytest.mark.parametrize(
+    ("colors", "result"),
+    [
+        # Test case 1: All colors are already in hexadecimal format
+        (["#FF0000", "#00FF00", "#0000FF"], ["#FF0000", "#00FF00", "#0000FF"]),
+        # Test case 2: Some colors are in color name format
+        (["red", "green", "blue"], ["#FF0000", "#008000", "#0000FF"]),
+        # Test case 3: All colors are in color name format
+        (["red", "green", "blue"], ["#FF0000", "#008000", "#0000FF"]),
+        # Test case 4: Empty list of colors []
+        ([], []),
+        # Test case 5: Colors with mixed formats
+        (["#FF0000", "green", "#0000FF"], ["#FF0000", "#008000", "#0000FF"]),
+    ],
+)
+def test_color_name_to_hex(colors: list[str], result: list[str]) -> None:
+    assert _color_name_to_hex(colors) == result
 
 
-def test_html_color_named_colors_with_alpha():
-    colors = ["red", "green", "blue"]
-    alpha = 0.5
-    result = _html_color(colors, alpha)
-    assert result == ["#FF00007F", "#0080007F", "#0000FF7F"]
-
-
-def test_html_color_mixed_colors_with_alpha():
-    colors = ["#FF0000", "green", "#0000FF"]
-    alpha = 0.5
-    result = _html_color(colors, alpha)
-    assert result == ["#FF00007F", "#0080007F", "#0000FF7F"]
-
-
-def test_add_alpha_float_alpha():
-    colors = ["#FF0000", "#00FF00", "#0000FF"]
-    alpha = 0.5
-    result = _add_alpha(colors, alpha)
-    assert result == ["#FF00007F", "#00FF007F", "#0000FF7F"]
-
-
-def test_add_alpha_invalid_alpha():
-    colors = ["#FF0000", "#00FF00", "#0000FF"]
-    alpha = 1.5
-    try:
-        _add_alpha(colors, alpha)
-    except ValueError as e:
-        assert (
-            str(e)
-            == "Invalid alpha value provided (1.5). Please ensure that alpha is a value between 0 and 1."
-        )
-
-
-def test_remove_alpha():
-    colors = ["#FF0000FF", "#00FF00FF", "#0000FFFF"]
-    result = _remove_alpha(colors)
-    assert result == ["#FF0000", "#00FF00", "#0000FF"]
-
-    colors = ["#FF000080", "#00FF0080", "#0000FF80"]
-    result = _remove_alpha(colors)
-    assert result == ["#FF0000", "#00FF00", "#0000FF"]
-
-    colors = ["#FF0000", "#00FF00", "#0000FF"]
-    result = _remove_alpha(colors)
-    assert result == ["#FF0000", "#00FF00", "#0000FF"]
-
-
-def test_float_to_hex():
-    # Test case 1: x = 0.0
-    x = 0.0
-    result = _float_to_hex(x)
-    assert result == "00"
-
-    # Test case 2: x = 1.0
-    x = 1.0
-    result = _float_to_hex(x)
-    assert result == "FF"
-
-    # Test case 3: x = 0.5
-    x = 0.5
-    result = _float_to_hex(x)
-    assert result == "7F"
-
-    # Test case 4: x = 0.25
-    x = 0.25
-    result = _float_to_hex(x)
-    assert result == "3F"
-
-    # Test case 5: x = 0.75
-    x = 0.75
-    result = _float_to_hex(x)
-    assert result == "BF"
-
-    # Test case 6: x = 0.125
-    x = 0.125
-    result = _float_to_hex(x)
-    assert result == "1F"
-
-
-def test_color_name_to_hex():
-    # Test case 1: All colors are already in hexadecimal format
-    colors = ["#FF0000", "#00FF00", "#0000FF"]
-    result = _color_name_to_hex(colors)
-    assert result == ["#FF0000", "#00FF00", "#0000FF"]
-
-    # Test case 2: Some colors are in color name format
-    colors = ["red", "green", "blue"]
-    result = _color_name_to_hex(colors)
-    assert result == ["#FF0000", "#008000", "#0000FF"]
-
-    # Test case 3: All colors are in color name format
-    colors = ["red", "green", "blue"]
-    result = _color_name_to_hex(colors)
-    assert result == ["#FF0000", "#008000", "#0000FF"]
-
-    # Test case 4: Empty list of colors
-    colors = []
-    result = _color_name_to_hex(colors)
-    assert result == []
-
-    # Test case 5: Colors with mixed formats
-    colors = ["#FF0000", "green", "#0000FF"]
-    result = _color_name_to_hex(colors)
-    assert result == ["#FF0000", "#008000", "#0000FF"]
-
+def test_color_name_to_hex_invalid() -> None:
     # Test case 6: Colors with invalid names
     colors = ["#FF0000", "green", "invalid"]
     with pytest.raises(ValueError) as e:
@@ -331,143 +239,89 @@ def test_color_name_to_hex():
     assert "Invalid color name provided (invalid)" in e.value.args[0]
 
 
-def test_is_short_hex_valid_short_hex():
-    color = "#F00"
-    result = _is_short_hex(color)
-    assert result is True
-
-    color = "#0F0"
-    result = _is_short_hex(color)
-    assert result is True
-
-    color = "#00F"
-    result = _is_short_hex(color)
-    assert result is True
-
-    color = "#123"
-    result = _is_short_hex(color)
-    assert result is True
-
-
-def test_is_short_hex_valid_long_hex():
-    color = "#FF0000"
-    result = _is_short_hex(color)
-    assert result is False
-
-    color = "#00FF00"
-    result = _is_short_hex(color)
-    assert result is False
-
-    color = "#0000FF"
-    result = _is_short_hex(color)
-    assert result is False
-
-    color = "#123456"
-    result = _is_short_hex(color)
-    assert result is False
+@pytest.mark.parametrize(
+    ("color", "is_short_hex"),
+    [
+        ("#F00", True),
+        ("#0F0", True),
+        ("#00F", True),
+        ("#123", True),
+        ("#FF0000", False),
+        ("#00FF00", False),
+        ("#0000FF", False),
+        ("#123456", False),
+    ],
+)
+def test_is_short_hex(color: str, is_short_hex: bool) -> None:
+    assert _is_short_hex(color) is is_short_hex
 
 
-def test_is_hex_col_valid_hex_colors():
-    colors = ["#FF0000", "#00FF00", "#0000FF"]
-    result = _is_hex_col(colors)
-    assert result == [True, True, True]
-
-    colors = ["#123456", "#ABCDEF", "#abcdef"]
-    result = _is_hex_col(colors)
-    assert result == [True, True, True]
-
-    colors = ["#F00", "#0F0", "#00F"]
-    result = _is_hex_col(colors)
-    assert result == [False, False, False]
-
-    colors = ["#FF0000FF", "#00FF00FF", "#0000FFFF"]
-    result = _is_hex_col(colors)
-    assert result == [True, True, True]
-
-
-def test_is_hex_col_invalid_hex_colors():
-    colors = ["#FF000", "#00FF00F", "#0000FFG"]
-    result = _is_hex_col(colors)
-    assert result == [False, False, False]
-
-    colors = ["#12345", "#ABCDEF1", "#abcdefg"]
-    result = _is_hex_col(colors)
-    assert result == [False, False, False]
-
-    colors = ["#F0", "#0F00", "#00FG"]
-    result = _is_hex_col(colors)
-    assert result == [False, False, False]
-
-    colors = ["#FF0000F", "#00FF00F", "#0000FFG"]
-    result = _is_hex_col(colors)
-    assert result == [False, False, False]
+@pytest.mark.parametrize(
+    ("colors", "is_valid"),
+    [
+        (["#FF0000", "#00FF00", "#0000FF"], [True, True, True]),
+        (["#123456", "#ABCDEF", "#abcdef"], [True, True, True]),
+        (["#F00", "#0F0", "#00F"], [False, False, False]),
+        (["#FF0000FF", "#00FF00FF", "#0000FFFF"], [True, True, True]),
+        (["#FF000", "#00FF00F", "#0000FFG"], [False, False, False]),
+        (["#12345", "#ABCDEF1", "#abcdefg"], [False, False, False]),
+        (["#F0", "#0F00", "#00FG"], [False, False, False]),
+        (["#FF0000F", "#00FF00F", "#0000FFG"], [False, False, False]),
+    ],
+)
+def test_is_hex_col_valid_hex_colors(colors: list[str], is_valid: list[bool]) -> None:
+    assert _is_hex_col(colors) == is_valid
 
 
-def test_is_standard_hex_col():
-    colors = ["#FF0000", "#00FF00", "#0000FF"]
-    result = _is_standard_hex_col(colors)
-    assert result == [True, True, True]
-
-    colors = ["#F00", "#0F0", "#00F"]
-    result = _is_standard_hex_col(colors)
-    assert result == [False, False, False]
-
-    colors = ["#123456", "#ABCDEF", "#abcdef"]
-    result = _is_standard_hex_col(colors)
-    assert result == [True, True, True]
-
-    colors = ["#123", "#abc", "#ABC"]
-    result = _is_standard_hex_col(colors)
-    assert result == [False, False, False]
-
-    colors = [
-        "#FF0000",
-        "#00FF00",
-        "#0000FF",
-        "#F00",
-        "#0F0",
-        "#00F",
-        "#123456",
-        "#ABCDEF",
-        "#abcdef",
-        "#123",
-        "#abc",
-        "#ABC",
-    ]
-    result = _is_standard_hex_col(colors)
-    assert result == [True, True, True, False, False, False, True, True, True, False, False, False]
+@pytest.mark.parametrize(
+    ("colors", "result"),
+    [
+        (["#FF0000", "#00FF00", "#0000FF"], [True, True, True]),
+        (["#F00", "#0F0", "#00F"], [False, False, False]),
+        (["#123456", "#ABCDEF", "#abcdef"], [True, True, True]),
+        (["#123", "#abc", "#ABC"], [False, False, False]),
+        (
+            [
+                "#FF0000",
+                "#00FF00",
+                "#0000FF",
+                "#F00",
+                "#0F0",
+                "#00F",
+                "#123456",
+                "#ABCDEF",
+                "#abcdef",
+                "#123",
+                "#abc",
+                "#ABC",
+            ],
+            [True, True, True, False, False, False, True, True, True, False, False, False],
+        ),
+    ],
+)
+def test_is_standard_hex_col(colors: list[str], result: list[bool]) -> None:
+    assert _is_standard_hex_col(colors) == result
 
 
-def test_expand_short_hex_valid_short_hex():
-    hex_color = "#F00"
-    expanded = _expand_short_hex(hex_color)
-    assert expanded == "#FF0000"
-
-    hex_color = "#0F0"
-    expanded = _expand_short_hex(hex_color)
-    assert expanded == "#00FF00"
-
-    hex_color = "#00F"
-    expanded = _expand_short_hex(hex_color)
-    assert expanded == "#0000FF"
-
-    hex_color = "#123"
-    expanded = _expand_short_hex(hex_color)
-    assert expanded == "#112233"
+@pytest.mark.parametrize(
+    ("hex_color", "expanded"),
+    [
+        ("#F00", "#FF0000"),
+        ("#0F0", "#00FF00"),
+        ("#00F", "#0000FF"),
+        ("#123", "#112233"),
+    ],
+)
+def test_expand_short_hex_valid_short_hex(hex_color: str, expanded: str) -> None:
+    assert _expand_short_hex(hex_color) == expanded
 
 
 @pytest.mark.parametrize(
     ("vals", "expected_vals"),
     [
-        ([2, 3, 4], [0.25, 0.5, 0.75]),  # Test case 1: Rescale values within the domain range
-        (
-            [0, 6],
-            [float("nan"), float("nan")],
-        ),  # Test case 2: Rescale values outside the domain range
-        (
-            [2.0, float("nan"), 4.0],
-            [0.25, float("nan"), 0.75],
-        ),  # Test case 3: Rescale values with NA values
+        ([2, 3, 4], [0.25, 0.5, 0.75]),  # Rescale values within the domain range
+        ([0, 6], [float("nan"), float("nan")]),  # Rescale values outside the domain range
+        ([2.0, float("nan"), 4.0], [0.25, float("nan"), 0.75]),  # Rescale values with NA values
     ],
 )
 def test_rescale_numeric(
@@ -497,13 +351,10 @@ def test_get_domain_numeric(series_constructor: SeriesConstructor, vals: list[fl
 @pytest.mark.parametrize(
     ("vals", "expected_vals"),
     [
-        ([], []),  # Test case 1: Empty Series
-        (["A", "B", "A", "C", "B"], ["A", "B", "C"]),  # Test case 2: Series with factor values
-        (
-            ["A", "B", None, "C"],
-            ["A", "B", "C"],
-        ),  # Test case 3: Series with factor & nan values
-        (["A", "B", "B", "C"], ["A", "B", "C"]),  # Test case 4: Series with duplicate values
+        ([], []),  # Empty Series
+        (["A", "B", "A", "C", "B"], ["A", "B", "C"]),  # Series with factor values
+        (["A", "B", None, "C"], ["A", "B", "C"]),  # Series with factor & nan values
+        (["A", "B", "B", "C"], ["A", "B", "C"]),  #  Series with duplicate values
     ],
 )
 def test_get_domain_factor(
@@ -522,24 +373,28 @@ def test_gradient_n_pal():
 
 
 @pytest.mark.parametrize(
-    "src,dst", [(0.001, "#ff0000"), (0.004, "#fe0001"), (0.999, "#0000ff"), (0.996, "#0100fe")]
+    ("src", "dst"), [(0.001, "#ff0000"), (0.004, "#fe0001"), (0.999, "#0000ff"), (0.996, "#0100fe")]
 )
-def test_gradient_n_pal_rounds(src, dst):
+def test_gradient_n_pal_rounds(src: float, dst: str) -> None:
     palette = GradientPalette(["red", "blue"])
 
     res = palette([src])
     assert res == [dst]
 
 
-def test_gradient_n_pal_inf():
+@pytest.mark.parametrize(
+    ("src", "dst"),
+    [
+        ([-math.inf, 0, math.nan, 1, math.inf], [None, "#ff0000", None, "#0000ff", None]),
+        # same but with numpy
+        ([-np.inf, 0, np.nan, 1, np.inf], [None, "#ff0000", None, "#0000ff", None]),
+    ],
+)
+def test_gradient_n_pal_inf(src: list[float], dst: list[str]) -> None:
     palette = GradientPalette(["red", "blue"])
 
-    res = palette([-math.inf, 0, math.nan, 1, math.inf])
-    assert res == [None, "#ff0000", None, "#0000ff", None]
-
-    # same but with numpy
-    res = palette([-np.inf, 0, np.nan, 1, np.inf])
-    assert res == [None, "#ff0000", None, "#0000ff", None]
+    res = palette(src)
+    assert res == dst
 
 
 def test_gradient_n_pal_symmetric():
@@ -558,45 +413,45 @@ def test_gradient_n_pal_manual_values():
     assert res == ["#ff0000", "#0000ff", "#008080", "#00ff00"]
 
 
-def test_gradient_n_pal_guard_raises():
-    with pytest.raises(ValueError) as exc_info:
-        GradientPalette(["red"])
+@pytest.mark.parametrize(
+    ("colors", "values", "context"),
+    [
+        (["red"], None, pytest.raises(ValueError, match="only 1 provided")),
+        # values must start with 0
+        (["red", "blue"], [0.1, 1], pytest.raises(ValueError, match="start with 0")),
+        # values must end with 1
+        (["red", "blue"], [0, 0.1], pytest.raises(ValueError, match="end with 1")),
+        # len(color) != len(values)
+        (
+            ["red", "blue"],
+            [0, 1.1, 1],
+            pytest.raises(ValueError, match="Received 3 values and 2 colors"),
+        ),
+        (
+            [(255, 0, 0), (0, 255, 0)],
+            None,
+            pytest.raises(
+                NotImplementedError, match="Currently, rgb tuples can't be passed directly."
+            ),
+        ),
+    ],
+)
+def test_gradient_n_pal_guard_raises(
+    colors: list[str], values: list[float] | None, context: Any
+) -> None:
+    with context:
+        GradientPalette(colors=colors, values=values)
 
-    assert "only 1 provided" in exc_info.value.args[0]
 
-    # values must start with 0
-    with pytest.raises(ValueError) as exc_info:
-        GradientPalette(["red", "blue"], values=[0.1, 1])
-
-    assert "start with 0" in exc_info.value.args[0]
-
-    # values must end with 1
-    with pytest.raises(ValueError) as exc_info:
-        GradientPalette(["red", "blue"], values=[0, 0.1])
-
-    assert "end with 1" in exc_info.value.args[0]
-
-    # len(color) != len(values)
-    with pytest.raises(ValueError) as exc_info:
-        GradientPalette(["red", "blue"], values=[0, 1.1, 1])
-
-    assert "Received 3 values and 2 colors" in exc_info.value.args[0]
-
-    with pytest.raises(NotImplementedError) as exc_info:
-        GradientPalette([(255, 0, 0), (0, 255, 0)])
-
-    assert "Currently, rgb tuples can't be passed directly." in exc_info.value.args[0]
-
-
-def test_gradient_n_pal_out_of_bounds_raises():
+@pytest.mark.parametrize(
+    ("data", "msg"),
+    [
+        ([0, 1.1], "Value: 1.1"),
+        ([0, -0.1], "Value: -0.1"),
+    ],
+)
+def test_gradient_n_pal_out_of_bounds_raises(data: list[float], msg: str) -> None:
     palette = GradientPalette(["red", "blue"])
 
-    with pytest.raises(ValueError) as exc_info:
-        palette([0, 1.1])
-
-    assert "Value: 1.1" in exc_info.value.args[0]
-
-    with pytest.raises(ValueError) as exc_info:
-        palette([0, -0.1])
-
-    assert "Value: -0.1" in exc_info.value.args[0]
+    with pytest.raises(ValueError, match=msg):
+        palette(data)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import math
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Sequence
+
+import pandas as pd
+from narwhals.typing import IntoSeries, SeriesT
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+
+SeriesConstructor: TypeAlias = Callable[[Sequence[Any]], IntoSeries]
+
+
+def zip_strict(left: SeriesT, right: SeriesT) -> Iterator[Any]:
+    if len(left) != len(right):
+        msg = f"{len(left)=} != {len(right)=}\nLeft: {left}\nRight: {right}"  # pragma: no cover
+        raise AssertionError(msg)  # pragma: no cover
+    return zip(left, right)
+
+
+def assert_series_equal(left: SeriesT, right: SeriesT, *, check_name: bool = False) -> None:
+    if check_name:
+        left_name, right_name = left.name, right.name
+        assert (
+            left_name == right_name
+        ), f"Expected names to be equal, found '{left_name}' and '{right_name}'"
+
+    for i, (lhs, rhs) in enumerate(zip_strict(left, right)):
+        if isinstance(lhs, float) and not math.isnan(lhs):
+            are_equivalent_values = rhs is not None and math.isclose(
+                lhs, rhs, rel_tol=0, abs_tol=1e-6
+            )
+        elif isinstance(lhs, float) and math.isnan(lhs):
+            are_equivalent_values = rhs is None or math.isnan(rhs)
+        elif isinstance(rhs, float) and math.isnan(rhs):
+            are_equivalent_values = lhs is None or math.isnan(lhs)
+        elif lhs is None:
+            are_equivalent_values = rhs is None
+        elif isinstance(lhs, list) and isinstance(rhs, list):
+            are_equivalent_values = all(
+                left_side == right_side for left_side, right_side in zip(lhs, rhs)
+            )
+        elif pd.isna(lhs):
+            are_equivalent_values = pd.isna(rhs)
+        elif type(lhs) is date and type(rhs) is datetime:
+            are_equivalent_values = datetime(lhs.year, lhs.month, lhs.day) == rhs
+        else:
+            are_equivalent_values = lhs == rhs
+
+        assert (
+            are_equivalent_values
+        ), f"Mismatch at index {i}: {lhs} != {rhs}\nExpected: {right}\nGot: {left}"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,19 +15,15 @@ SeriesConstructor: TypeAlias = Callable[[Sequence[Any]], IntoSeries]
 
 
 def zip_strict(left: SeriesT, right: SeriesT) -> Iterator[Any]:
-    if len(left) != len(right):
-        msg = f"{len(left)=} != {len(right)=}\nLeft: {left}\nRight: {right}"  # pragma: no cover
-        raise AssertionError(msg)  # pragma: no cover
+    """Return zip(left, right) after checking that the length is the same."""
+    left_size, right_size = len(left), len(right)
+    assert left_size == right_size, f"{left_size=} != {len(right)=}\nLeft: {left}\nRight: {right}"
+
     return zip(left, right)
 
 
-def assert_series_equal(left: SeriesT, right: SeriesT, *, check_name: bool = False) -> None:
-    if check_name:
-        left_name, right_name = left.name, right.name
-        assert (
-            left_name == right_name
-        ), f"Expected names to be equal, found '{left_name}' and '{right_name}'"
-
+def assert_series_equal(left: SeriesT, right: SeriesT) -> None:
+    """Check left and right series have the same elements at each index."""
     for i, (lhs, rhs) in enumerate(zip_strict(left, right)):
         if isinstance(lhs, float) and not math.isnan(lhs):
             are_equivalent_values = rhs is not None and math.isclose(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,8 +4,8 @@ import math
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Sequence
 
-import pandas as pd
 from narwhals.typing import IntoSeries, SeriesT
+from narwhals.dependencies import get_pandas
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
@@ -39,7 +39,7 @@ def assert_series_equal(left: SeriesT, right: SeriesT) -> None:
             are_equivalent_values = all(
                 left_side == right_side for left_side, right_side in zip(lhs, rhs)
             )
-        elif pd.isna(lhs):
+        elif (pd := get_pandas()) is not None and pd.isna(lhs):
             are_equivalent_values = pd.isna(rhs)
         elif type(lhs) is date and type(rhs) is datetime:
             are_equivalent_values = datetime(lhs.year, lhs.month, lhs.day) == rhs


### PR DESCRIPTION
# Summary

Since I had it ready, I went ahead and narwhalified the `data_color` function. This means adding narwhals as a dependency.

In order to test functionalities I added a `series_constroctor` fixture that (depending on which libraries are installed) return constructors for pandas, pandas nullable, pandas pyarrow, polars and pyarrow series.

I also added a `assert_series_equal` in the test utils. This might need to change in the future, but this version in inspired by what we have in our test utils.

Finally, I added a commit (https://github.com/posit-dev/great-tables/pull/738/commits/ac1094cba2f557931dabe5648f691f0b6d6191db) in which I change all the tests in `test_data_color_utils.py` to use `@pytest.mark.parametrize`. I can revert it and re-scope it in another PR if it's something you would like to see! As you might have noticed already, I tend to lean in these kind of rabbit holes.


# Related GitHub Issues and PRs

Related #737 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.
