### PR TITLE
fix: Address slicing for pyarrow array in `data_color`

### DIFF
--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -6,7 +6,14 @@ import numpy as np
 from typing_extensions import TypeAlias
 
 from great_tables._locations import RowSelectExpr, resolve_cols_c, resolve_rows_i
-from great_tables._tbl_data import DataFrameLike, SelectExpr, get_column_names, is_na
+from great_tables._tbl_data import (
+    DataFrameLike,
+    SelectExpr,
+    get_at_row_positions,
+    get_column_names,
+    is_na,
+    to_list,
+)
 from great_tables.loc import body
 from great_tables.style import fill, text
 
@@ -228,7 +235,7 @@ def data_color(
     # For each column targeted, get the data values as a new list object
     for col in columns_resolved:
         # This line handles both pandas and polars dataframes
-        column_vals = data_table[col][row_pos].to_list()
+        column_vals = to_list(get_at_row_positions(data_table[col], indexes=row_pos))
 
         # Filter out NA values from `column_vals`
         filtered_column_vals = [x for x in column_vals if not is_na(data_table, x)]

--- a/tests/data_color/__snapshots__/test_data_color.ambr
+++ b/tests/data_color/__snapshots__/test_data_color.ambr
@@ -123,6 +123,32 @@
   </tbody>
   '''
 # ---
+# name: test_data_color_autocolor_text_false[pyarrow]
+  '''
+  <tbody class="gt_table_body">
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="background-color: #5c5200;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="background-color: #077c00;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="background-color: #0000FF;" class="gt_row gt_right">65100</td>
+    </tr>
+  </tbody>
+  '''
+# ---
 # name: test_data_color_colorbrewer_snap
   '''
   <tbody class="gt_table_body">
@@ -206,6 +232,32 @@
   </tbody>
   '''
 # ---
+# name: test_data_color_domain_na_color_reverse_snap[pyarrow]
+  '''
+  <tbody class="gt_table_body">
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #FFFFFF; background-color: #5c5200;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #FFFFFF; background-color: #077c00;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100</td>
+    </tr>
+  </tbody>
+  '''
+# ---
 # name: test_data_color_domain_na_color_snap[pandas]
   '''
   <tbody class="gt_table_body">
@@ -254,6 +306,32 @@
       <td class="gt_row gt_right">444.4</td>
       <td class="gt_row gt_left">durian</td>
       <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100.0</td>
+    </tr>
+  </tbody>
+  '''
+# ---
+# name: test_data_color_domain_na_color_snap[pyarrow]
+  '''
+  <tbody class="gt_table_body">
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #FFFFFF; background-color: #a32e00;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #000000; background-color: #f80400;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #FFFFFF; background-color: #0000FF;" class="gt_row gt_right">65100</td>
     </tr>
   </tbody>
   '''
@@ -310,6 +388,32 @@
   </tbody>
   '''
 # ---
+# name: test_data_color_overlapping_domain[pyarrow]
+  '''
+  <tbody class="gt_table_body">
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #FFFFFF; background-color: #673498;" class="gt_row gt_right">65100</td>
+    </tr>
+  </tbody>
+  '''
+# ---
 # name: test_data_color_palette_snap[pandas]
   '''
   <tbody class="gt_table_body">
@@ -358,6 +462,32 @@
       <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">444.4</td>
       <td class="gt_row gt_left">durian</td>
       <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">65100.0</td>
+    </tr>
+  </tbody>
+  '''
+# ---
+# name: test_data_color_palette_snap[pyarrow]
+  '''
+  <tbody class="gt_table_body">
+    <tr>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #fe0100;" class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #ec0a00;" class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #000000; background-color: #ff0000;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #FFFFFF; background-color: #008000;" class="gt_row gt_right">65100</td>
     </tr>
   </tbody>
   '''
@@ -495,6 +625,32 @@
   </tbody>
   '''
 # ---
+# name: test_data_color_simple_exibble_snap[pyarrow]
+  '''
+  <tbody class="gt_table_body">
+    <tr>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">0.1111</td>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_left">apricot</td>
+      <td style="color: #FFFFFF; background-color: #010001;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #070304;" class="gt_row gt_right">2.222</td>
+      <td style="color: #000000; background-color: #4cbd81;" class="gt_row gt_left">banana</td>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td style="color: #FFFFFF; background-color: #752b38;" class="gt_row gt_right">33.33</td>
+      <td style="color: #FFFFFF; background-color: #9653ca;" class="gt_row gt_left">coconut</td>
+      <td style="color: #FFFFFF; background-color: #000000;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">444.4</td>
+      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_left">durian</td>
+      <td style="color: #000000; background-color: #9e9e9e;" class="gt_row gt_right">65100</td>
+    </tr>
+  </tbody>
+  '''
+# ---
 # name: test_data_color_subset_domain[pandas]
   '''
   <tbody class="gt_table_body">
@@ -543,6 +699,32 @@
       <td class="gt_row gt_right">444.4</td>
       <td class="gt_row gt_left">durian</td>
       <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">65100.0</td>
+    </tr>
+  </tbody>
+  '''
+# ---
+# name: test_data_color_subset_domain[pyarrow]
+  '''
+  <tbody class="gt_table_body">
+    <tr>
+      <td class="gt_row gt_right">0.1111</td>
+      <td class="gt_row gt_left">apricot</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">49.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">2.222</td>
+      <td class="gt_row gt_left">banana</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">17.95</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">33.33</td>
+      <td class="gt_row gt_left">coconut</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">1.39</td>
+    </tr>
+    <tr>
+      <td class="gt_row gt_right">444.4</td>
+      <td class="gt_row gt_left">durian</td>
+      <td style="color: #000000; background-color: #FF0000;" class="gt_row gt_right">65100</td>
     </tr>
   </tbody>
   '''

--- a/tests/data_color/test_data_color.py
+++ b/tests/data_color/test_data_color.py
@@ -3,6 +3,7 @@ from typing import Type, TypeVar
 import numpy as np
 import pandas as pd
 import polars as pl
+import pyarrow as pa
 import pytest
 
 from great_tables import GT, style
@@ -16,6 +17,7 @@ T_CellStyle = TypeVar("T_CellStyle", bound=CellStyle)
 params_frames = [
     pytest.param(pd.DataFrame, id="pandas"),
     pytest.param(pl.DataFrame, id="polars"),
+    pytest.param(pa.table, id="pyarrow"),
 ]
 
 


### PR DESCRIPTION
# Summary

Follow up from the disclaimer section in https://github.com/posit-dev/great-tables/pull/736

<details> <summary> summary </summary>
> For pyarrow backed tbl_data, `data_color` the code would end up breaking a few lines down the line when performing the follow operation:

```py
column_vals = data_table[col][row_pos].to_list()
```

In fact, slicing with a list on a chunked array raises 

> *** TypeError: 'list' object cannot be interpreted as an integer

I wanted this PR to be atomic enough to solve _one_ issue. I can follow up on this other one

</details>

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.
