### PR TITLE
docs: Extending Great Tables

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -55,6 +55,7 @@ website:
         - section: Extra
           contents:
             - get-started/contributing.qmd
+            - get-started/extensions.qmd
 
 format:
   html:

--- a/docs/get-started/extensions.qmd
+++ b/docs/get-started/extensions.qmd
@@ -4,7 +4,7 @@ format: html
 ---
 
 <!-- Intro -->
-The **Great Tables** package boasts a diverse range of methods for your creation of beautiful tables. With no shortage of tools, styles, formats and themes, you can produce a very wide range of tables. If you haven't yet, head over to the [examples gallery](../examples/index.qmd) for a flavor of the variety that is possible.
+The **Great Tables** package boasts a diverse range of methods for creating beautiful tables. With no shortage of tools, styles, formats and themes, you can produce a very wide range of tables. If you haven't yet, head over to the [examples gallery](../examples/index.qmd) for a flavor of the variety that is possible.
 
 But what happens when there's something you want to add to your table, but it's not directly supported by **Great Tables**? Let's say you have a very specific use case for your great table, so it's not necessarily broad enough to [contribute to the package](contributing.qmd). Or maybe it *is* generalizable, but it's beyond the scope of what you want to do. There are plenty of reasons to want a specific feature for your table that doesn't warrant a pull request.
 
@@ -78,7 +78,7 @@ def espn_theme(gt: GT) -> GT:
     )
 ```
 
-This is where wrapper functions really shine. Maybe you want a very standardized look, or you want all of your tables to mimic your favorite one. Take advantage of `~~GT.tab_options()` for your own [premade themes](./table-theme-premade.qmd), with styles from any of the [table theme options](./table-theme-options.qmd) of your choosing.
+This is where composed functions really shine. Maybe you want a very standardized look, or you want all of your tables to mimic your favorite one. Take advantage of `~~GT.tab_options()` for your own [premade themes](./table-theme-premade.qmd), with styles from any of the [table theme options](./table-theme-options.qmd) of your choosing.
 
 ### Extensions
 
@@ -110,11 +110,11 @@ def double_table(gt1: GT, gt2: GT) -> str:
     return double_table_html
 ```
 
-Aagin, this is a **gt-extras** function which extends the customizing of tables, [`gt_two_column_layout()`](https://posit-dev.github.io/gt-extras/reference/gt_two_column_layout) does a little more heavy lifting than **Great Tables** itself supports. Notice this time it is new behavior we're adding.
+Again, this is a **gt-extras** function which extends the customizing of tables, [`gt_two_column_layout()`](https://posit-dev.github.io/gt-extras/reference/gt_two_column_layout) does a little more heavy lifting than **Great Tables** itself supports. Notice this time it is new behavior we're adding.
 
 ## Extension Plots
 
-Also known as sparklines, embedded plots in tables are a powerful tool. So much so that some plotting is already built in, called [nanoplots](nanoplots.qmd). But there are endless plot types you could want in your great tables, and for these `~~GT.fmt()` is your friend.
+Embedded plots in tables (also known as sparklines) are a powerful tool.. So much so that some plotting is already built in, called [nanoplots](nanoplots.qmd). But there are endless plot types you could want in your great tables, and for these `~~GT.fmt()` is your friend.
 
 The key to adding custom plots to your tables is using `~~GT.fmt()` with a function that converts your data values into visual representations. Your formatting function should take a value from your table and return an HTML string containing your plot—whether that's an SVG, a series of styled `<div>` elements, or even embedded images.
 
@@ -159,7 +159,7 @@ gt.fmt(fns=fmt_star_rating, columns="my_data_column")
 
 ## Beyond
 
-For some inspiration on ways to extend **Great Tables**, check out [**gt-extras**](posit-dev.github.io/gt-extras/) and its [source code](https://github.com/posit-dev/gt-extras).
+For some inspiration on ways to extend **Great Tables**, check out [**gt-extras**](https://posit-dev.github.io/gt-extras/) and its [source code](https://github.com/posit-dev/gt-extras).
 
 | Function |   Type   |
 |----------|----------|

--- a/docs/get-started/extensions.qmd
+++ b/docs/get-started/extensions.qmd
@@ -6,7 +6,7 @@ format: html
 <!-- Intro -->
 The **Great Tables** package boasts a diverse range of methods for creating beautiful tables. With no shortage of tools, styles, formats and themes, you can produce a very wide range of tables. If you haven't yet, head over to the [examples gallery](../examples/index.qmd) for a flavor of the variety that is possible.
 
-But what happens when there's something you want to add to your table, but it's not directly supported by **Great Tables**? Let's say you have a very specific use case for your great table, so it's not necessarily broad enough to [contribute to the package](contributing.qmd). Or maybe it *is* generalizable, but it's beyond the scope of what you want to do. There are plenty of reasons to want a specific feature for your table that doesn't warrant a pull request.
+But what happens when there's something you want to add to your table, and it's not directly supported by **Great Tables**? Let's say you have a very specific use case for your great table, so it's not necessarily broad enough to [contribute to the package](contributing.qmd). Or maybe it *is* generalizable, but it's beyond the scope of what you want to do. Not every feature fits neatly into a pull request.
 
 [**gt-extras**](https://posit-dev.github.io/gt-extras/) is a great case study in this, filling some table goals that aren't supported by **Great Tables** directly.
 
@@ -45,7 +45,7 @@ def highlight_cols(gt: GT, columns: SelectExpr) -> GT:
     )
 ```
 
-In fact, many of the functions in [**gt-extras**](https://posit-dev.github.io/gt-extras/) are wrappers. What you see above is very similar to the source code for the function [`gt_highlight_cols()`](https://posit-dev.github.io/gt-extras/reference/gt_highlight_cols), which is a wrapper function that doesn't add *new* functionality to **Great Tables**.
+In fact, many of the functions in [**gt-extras**](https://posit-dev.github.io/gt-extras/) are wrappers. What you see above is very similar to the source code for the function [`gt_highlight_cols()`](https://posit-dev.github.io/gt-extras/reference/gt_highlight_cols), which is a wrapper function that doesn't add *new* functionality to **Great Tables**, instead it makes a common action much easier.
 
 ### Composing Functions
 
@@ -82,7 +82,7 @@ This is where composed functions really shine. Maybe you want a very standardize
 
 ### Extensions
 
-Let's extend the post-processing by building an HTML string containing two side-by-side tables. This function takes two separate `~~GT` objects, renders them as HTML using `~~GT.as_raw_html()`, and then wraps them in custom HTML structure to create a side-by-side layout, which would not be possible with **Great Tables** methods alone.
+Let's extend the post-processing step by building an HTML string containing two side-by-side tables. This function takes two separate `~~GT` objects, renders them as HTML using `~~GT.as_raw_html()`, and then wraps them in custom HTML structure to create a side-by-side layout, which would not be possible with **Great Tables** methods alone.
 
 ```{python}
 # | eval: False
@@ -110,13 +110,13 @@ def double_table(gt1: GT, gt2: GT) -> str:
     return double_table_html
 ```
 
-Again, this is a **gt-extras** function which extends the customizing of tables, [`gt_two_column_layout()`](https://posit-dev.github.io/gt-extras/reference/gt_two_column_layout) does a little more heavy lifting than **Great Tables** itself supports. Notice this time it is new behavior we're adding.
+Again, this is a facet of the **gt-extras** function which extends the customizing of tables, [`gt_two_column_layout()`](https://posit-dev.github.io/gt-extras/reference/gt_two_column_layout) does a little more heavy lifting than **Great Tables** itself supports. Notice this time it is new behavior we're adding.
 
 ## Extension Plots
 
-Embedded plots in tables (also known as sparklines) are a powerful tool.. So much so that some plotting is already built in, called [nanoplots](nanoplots.qmd). But there are endless plot types you could want in your great tables, and for these `~~GT.fmt()` is your friend.
+Embedded plots in tables (also known as sparklines) are a powerful tool. So much so that some plotting is already built in, called [nanoplots](nanoplots.qmd). But there are endless plot types you could want in your great tables, and for these `~~GT.fmt()` is your friend.
 
-The key to adding custom plots to your tables is using `~~GT.fmt()` with a function that converts your data values into visual representations. Your formatting function should take a value from your table and return an HTML string containing your plot—whether that's an SVG, a series of styled `<div>` elements, or even embedded images.
+The key to adding custom plots to your tables is using `~~GT.fmt()` with a function that converts your data values into visual representations. Your formatting function should take a value from your table and return an HTML string containing your plot – whether that's an SVG, a series of styled `<div>` elements, or even embedded images.
 
 Here's the basic pattern for a plot extension:
 
@@ -139,8 +139,8 @@ Check out this [blog post](../blog/plots-in-tables/index.qmd)  for a deeper dive
 
 They say a picture is worth a thousand words. So maybe you want to take `~~GT.fmt_icon()` and run with it, but with your own custom icon sets or specialized styling needs. For example:
 
-- **Create domain-specific icon mappings**: Automatically map data values to meaningful icons (like status indicators, ratings, or categories)
-- **Apply custom styling**: Add animations, colors, or hover effects to your icons
+- *Create domain-specific icon mappings:* Automatically map data values to meaningful icons (like status indicators, ratings, or categories)
+- *Apply custom styling:* Add animations, colors, or hover effects to your icons
 
 Here's an example of how you might create a custom icon extension that maps numerical ratings to star icons:
 

--- a/docs/get-started/extensions.qmd
+++ b/docs/get-started/extensions.qmd
@@ -6,7 +6,7 @@ format: html
 <!-- Intro -->
 The **Great Tables** package boasts a diverse range of methods for creating beautiful tables. With no shortage of tools, styles, formats and themes, you can produce a very wide range of tables. If you haven't yet, head over to the [examples gallery](../examples/index.qmd) for a flavor of the variety that is possible.
 
-But what happens when there's something you want to add to your table, and it's not directly supported by **Great Tables**? Let's say you have a very specific use case for your great table, so it's not necessarily broad enough to [contribute to the package](contributing.qmd). Or maybe it *is* generalizable, but it's beyond the scope of what you want to do. Not every feature fits neatly into a pull request.
+But what happens when there's something you want to add to your table, and it's not directly supported by **Great Tables**? Let's say you have a very specific use case for your great table, so it's not necessarily broad enough to [contribute to the package](contributing.qmd). Or maybe it *is* generalizable, but implementing it is beyond the scope of your current project. Not every feature fits neatly into a pull request.
 
 [**gt-extras**](https://posit-dev.github.io/gt-extras/) is a great case study in this, filling some table goals that aren't supported by **Great Tables** directly.
 
@@ -60,7 +60,7 @@ def some_theme(gt: GT) -> GT:
     )
 ```
 
-This is where composing really shine. Maybe you want a very standardized look, or you want all of your tables to mimic your favorite one. Take advantage of `~~GT.tab_options()` for your own [premade themes](./table-theme-premade.qmd), with styles from any of the [table theme options](./table-theme-options.qmd) of your choosing.
+This is where composing really shines. Maybe you want a very standardized look, or you want all of your tables to mimic your favorite one. Take advantage of `~~GT.tab_options()` for your own [premade themes](./table-theme-premade.qmd), with styles from any of the [table theme options](./table-theme-options.qmd) of your choosing.
 
 ### Extending
 
@@ -75,7 +75,7 @@ def double_table(gt1: GT, gt2: GT) -> str:
     return f"""<div>{table_1_html}</div><div>{table_2_html}</div>"""
 ```
 
-Again, this is a sneak peek of the **gt-extras** function, [`gt_two_column_layout()`](https://posit-dev.github.io/gt-extras/reference/gt_two_column_layout), which does a little more heavy lifting than **Great Tables** itself supports. Notice this time it is new behavior we're adding.
+Again, this is a sneak peek of the **gt-extras** function, [`gt_two_column_layout()`](https://posit-dev.github.io/gt-extras/reference/gt_two_column_layout), which does a little more heavy lifting than **Great Tables** itself supports. This time, we're adding new behavior.
 
 ## Extending with Plots
 
@@ -83,7 +83,7 @@ Embedded plots in tables (also known as sparklines) are a powerful tool. So much
 
 The key to adding custom plots to your tables is using `~~GT.fmt()` with a function that converts your data values into visual representations. Your formatting function should take a value from your table and return an HTML string containing your plot – whether that's an SVG, a series of styled `<div>` elements, or even embedded images.
 
-Here's the basic pattern for a plot extension:
+Here's a basic pattern for a plot extension:
 
 ```{python}
 # | eval: False
@@ -102,7 +102,7 @@ Check out this [blog post](../blog/plots-in-tables/index.qmd)  for a deeper dive
 
 ## Extending with Icons
 
-They say a picture is worth a thousand words. So maybe you want to take `~~GT.fmt_icon()` and run with it, but with your own custom icon sets or specialized styling needs. For example:
+They say a picture is worth a thousand words. Maybe you want to take `~~GT.fmt_icon()` and run with it, but with your own custom icon sets or specialized styling needs. For example:
 
 - *Create domain-specific icon mappings:* Automatically map data values to meaningful icons (like status indicators, ratings, or categories)
 - *Apply custom styling:* Add animations, colors, or hover effects to your icons
@@ -122,7 +122,7 @@ gt.fmt(fns=fmt_star_rating, columns="my_data_column")
 
 ## Beyond
 
-For some inspiration on ways to extend **Great Tables**, check out [**gt-extras**](https://posit-dev.github.io/gt-extras/) and its [source code](https://github.com/posit-dev/gt-extras).
+For inspiration on ways to extend **Great Tables**, check out [**gt-extras**](https://posit-dev.github.io/gt-extras/) and its [source code](https://github.com/posit-dev/gt-extras).
 
 | Function |   Type   |
 |----------|----------|

--- a/docs/get-started/extensions.qmd
+++ b/docs/get-started/extensions.qmd
@@ -1,0 +1,161 @@
+---
+title: Extending Great Tables
+format: html
+---
+
+<!-- Intro -->
+The **Great Tables** package boasts a diverse range of methods for your creation of beautiful tables. With no shortage of tools, styles, formats and themes, you can produce a very wide range of tables. If you haven't yet, head over to the [examples gallery](../examples/index.qmd) for a flavor of the variety that is possible.
+
+But what happens when there's something you want to add to your table, but it's not directly supported by **Great Tables**? Let's say you have a very specific use case for your great table, so it's not necessarily broad enough to [contribute to the package](contributing.qmd). Or maybe it *is* generalizable, but it's beyond the scope of what you want to do. There are plenty of reasons to want a specific feature for your table that doesn't warrant a pull request.
+
+[**gt-extras**](https://posit-dev.github.io/gt-extras/) is a great case study in this, filling some table goals that aren't supported by **Great Tables** directly.
+
+## Writing an Extension Function
+
+When extending **Great Tables**, you have two main approaches: *wrappers* and *extensions*. Understanding the distinction between these approaches will help you choose the right strategy for your use case.
+
+- **Wrappers** simplify existing functionality by bundling common parameter combinations into convenient functions. They don't add new capabilities, but make complex styling or formatting tasks more accessible.
+- **Extensions**, on the other hand, add new functionality by combining multiple methods in creative ways, processing data outside the package, or generating custom content (like HTML or images) that gets integrated into your table.
+
+Both approaches are valuable contributions to the **Great Tables** ecosystem, and the choice between them depends on whether you're making it easier to access existing tooling or creating entirely new capabilities.
+
+### gt-extras
+
+Some of the functions in [**gt-extras**](https://posit-dev.github.io/gt-extras/) are wrappers. Take [`gt_highlight_cols()`](https://posit-dev.github.io/gt-extras/reference/gt_highlight_cols), which is a wrapper function that doesn't add *new* functionality to **Great Tables**. If you look at the underlying code, you'll see it makes a call to `~~GT.tab_style()`, while setting specific `locations=` and `style=` parameters. Something as lightweight as this might be useful for someone who knows what effect they want, but doesn't want to investigate the entire space of options for styling.
+
+<!-- Show code here maybe? -->
+
+```{python}
+# | eval: False
+# | code-fold: true
+# | code-summary: "Show the code"
+# Select locations based on the parameters in scope at this point of the function
+locations: list[Loc] = [loc.body(columns=columns)]
+if include_column_labels:
+    locations.append(loc.column_labels(columns=columns))
+
+# Select styles according to fill, font_weight, and font_color parameters
+styles: list[CellStyle] = [
+    style.fill(color=fill),
+    style.borders(color=fill),
+    style.text(weight=font_weight, color=font_color),
+]
+
+# Make the wrapped tab_style call
+gt = gt.tab_style(
+    style=styles,
+    locations=locations,
+)
+```
+
+
+**gt-extras** also extends the customizing of tables, beyond making existing methods even more convenient to use. For example [`gt_two_column_layout()`](https://posit-dev.github.io/gt-extras/reference/gt_two_column_layout) does a little more heavy lifting, building an HTML string containing two side-by-side tables. This function takes two separate `~~GT` objects, renders them as HTML using `~~GT.as_raw_html()`, and then wraps them in custom HTML structure to create a unified side-by-side layout, which would not be possible with **Great Tables** methods alone.
+
+```{python}
+# | eval: False
+# | code-fold: true
+# | code-summary: "Show the code"
+# In one of the branched of `gt_two_column_layout`, a header isn't set
+header_html = ""
+table_1_html = gt1.as_raw_html()
+table_2_html = gt2.as_raw_html()
+
+# Great Tables is extended via supplemental html
+double_table_html = f"""
+    <div style="display: flex; justify-content: center; width: 100%;">
+        <div id="mycombinedtable" style="display: inline-block; width: auto;">
+            {header_html}
+            <div style="overflow: auto; white-space: nowrap;">
+                <div style="display: inline-block; margin-right: 1em;">
+                    {table_1_html}
+                </div>
+                <div style="display: inline-block;">
+                    {table_2_html}
+                </div>
+            </div>
+        </div>
+    </div>
+    """
+```
+
+
+## Great Tables Extension Possibilities
+
+What might you want to put into an extension to **Great Tables**? Here are some of the most common and impactful areas where extensions can add significant value to your tables.
+
+### Plots
+
+Also known as sparklines, embedded plots in tables are a powerful tool. So much so that some plotting is already built in, called [nanoplots](nanoplots.qmd). But there are endless plot types you could want in your great tables, and for these `~~GT.fmt()` is your friend.
+
+The key to adding custom plots to your tables is using `~~GT.fmt()` with a function that converts your data values into visual representations. Your formatting function should take a value from your table and return an HTML string containing your plot—whether that's an SVG, a series of styled `<div>` elements, or even embedded images.
+
+Here's the basic pattern for a plot extension:
+
+```{python}
+# | eval: False
+def create_my_plot(value):
+    # Transform the data value into a visual representation
+    # This could use any plotting library or even pure HTML/CSS
+    plot_html = f"<svg>...</svg>"  # Your plot generation logic here
+    return plot_html
+
+
+# Apply to your table
+gt.fmt(fns=create_my_plot, columns="my_data_column")
+```
+
+Check out this [blog post](../blog/plots-in-tables/index.qmd)  for a deeper dive into different approaches for creating plots in tables.
+
+### Themes
+
+This is where wrapper functions really shine. Maybe you want a very standardized look, or you want all of your tables to mimic your favorite one. Take advantage of `~~GT.tab_options()` for your own [premade themes](./table-theme-premade.qmd), with styles from any of the [table theme options](./table-theme-options.qmd) of your choosing.
+
+Here's how **gt-extras** implemented the [ESPN](https://posit-dev.github.io/gt-extras/reference/gt_theme_espn) theme:
+
+```{python}
+# | eval: False
+gt_theme_espn = (
+    gt.opt_all_caps()
+    .opt_table_font(font=google_font("Lato"), weight=400)
+    .opt_row_striping()
+    .tab_style(style=style.text(weight="bold"), locations=loc.column_header())
+    .tab_options(
+        row_striping_background_color="#fafafa",
+        table_body_hlines_color="#f6f7f7",
+        source_notes_font_size="12px",
+        table_font_size="16px",
+        heading_align="left",
+        heading_title_font_size="24px",
+        table_border_top_color="white",
+        table_border_top_width="3px",
+        data_row_padding="7px",
+    )
+)
+```
+
+### Icons
+
+They say a picture is worth a thousand words. So maybe you want to take `~~GT.fmt_icon()` and run with it, but with your own custom icon sets or specialized styling needs. For example:
+
+- **Create domain-specific icon mappings**: Automatically map data values to meaningful icons (like status indicators, ratings, or categories)
+- **Apply custom styling**: Add animations, colors, or hover effects to your icons
+
+Here's an example of how you might create a custom icon extension that maps numerical ratings to star icons:
+
+```{python}
+# | eval: False
+def fmt_star_rating(value, max_stars=5):
+    filled_stars = int(value)
+    empty_stars = max_stars - filled_stars
+
+    star_html = "★" * filled_stars + "☆" * empty_stars
+    return f'<span style="color: gold; font-size: 18px;">{star_html}</span>'
+
+
+# Apply to your table, again `fmt()` comes in handy!
+gt.fmt(fns=fmt_star_rating, columns="rating")
+```
+
+### Beyond
+
+Go where your heart desires, you aren't constrained by what is provided by this package, in fact, this package is just the beginning of your tabling life!

--- a/docs/get-started/extensions.qmd
+++ b/docs/get-started/extensions.qmd
@@ -8,7 +8,7 @@ The **Great Tables** package boasts a diverse range of methods for creating beau
 
 But what happens when there's something you want to add to your table, and it's not directly supported by **Great Tables**? Let's say you have a very specific use case for your great table, so it's not necessarily broad enough to [contribute to the package](contributing.qmd). Or maybe it *is* generalizable, but implementing it is beyond the scope of your current project. Not every feature fits neatly into a pull request.
 
-[**gt-extras**](https://posit-dev.github.io/gt-extras/) is a great case study in this, filling some table goals that aren't supported by **Great Tables** directly.
+[**gt-extras**](https://posit-dev.github.io/gt-extras/) is a great case study in this, filling your table desires that aren't supported by **Great Tables** directly.
 
 ## Writing an Add-on Function
 

--- a/docs/get-started/extensions.qmd
+++ b/docs/get-started/extensions.qmd
@@ -32,15 +32,9 @@ def highlight_cols(gt: GT, columns: SelectExpr) -> GT:
         loc.column_labels(columns=columns),
     ]
 
-    styles = [
-        style.fill(color="lightblue"),
-        style.borders(color="lightblue"),
-        style.text(weight="bold", color="black"),
-    ]
-
     # Make the wrapped tab_style call
     return gt.tab_style(
-        style=styles,
+        style=style.fill(color="lightblue"),
         locations=locations,
     )
 ```
@@ -55,26 +49,14 @@ Here's how **gt-extras** implemented the [ESPN](https://posit-dev.github.io/gt-e
 
 ```{python}
 # | eval: False
-def espn_theme(gt: GT) -> GT:
+def some_theme(gt: GT) -> GT:
     return (
         gt.opt_all_caps()
-        .opt_table_font(font=google_font("Lato"), weight=400)
+        .opt_table_font(
+            font=google_font("Lato"),
+            weight=400,
+        )
         .opt_row_striping()
-        .tab_style(
-            style=style.text(weight="bold"),
-            locations=loc.column_header(),
-        )
-        .tab_options(
-            row_striping_background_color="#fafafa",
-            table_body_hlines_color="#f6f7f7",
-            source_notes_font_size="12px",
-            table_font_size="16px",
-            heading_align="left",
-            heading_title_font_size="24px",
-            table_border_top_color="white",
-            table_border_top_width="3px",
-            data_row_padding="7px",
-        )
     )
 ```
 
@@ -87,27 +69,10 @@ Let's extend the post-processing step by building an HTML string containing two 
 ```{python}
 # | eval: False
 def double_table(gt1: GT, gt2: GT) -> str:
-    header_html = "Combined Table"
     table_1_html = gt1.as_raw_html()
     table_2_html = gt2.as_raw_html()
 
-    # Great Tables is extended via supplemental html
-    double_table_html = f"""
-        <div style="display: flex; justify-content: center; width: 100%;">
-            <div id="mycombinedtable" style="display: inline-block; width: auto;">
-                {header_html}
-                <div style="overflow: auto; white-space: nowrap;">
-                    <div style="display: inline-block; margin-right: 1em;">
-                        {table_1_html}
-                    </div>
-                    <div style="display: inline-block;">
-                        {table_2_html}
-                    </div>
-                </div>
-            </div>
-        </div>
-        """
-    return double_table_html
+    return f"""<div>{table_1_html}</div><div>{table_2_html}</div>"""
 ```
 
 Again, this is a facet of the **gt-extras** function which extends the customizing of tables, [`gt_two_column_layout()`](https://posit-dev.github.io/gt-extras/reference/gt_two_column_layout) does a little more heavy lifting than **Great Tables** itself supports. Notice this time it is new behavior we're adding.

--- a/docs/get-started/extensions.qmd
+++ b/docs/get-started/extensions.qmd
@@ -12,78 +12,107 @@ But what happens when there's something you want to add to your table, but it's 
 
 ## Writing an Extension Function
 
-When extending **Great Tables**, you have two main approaches: *wrappers* and *extensions*. Understanding the distinction between these approaches will help you choose the right strategy for your use case.
+When extending **Great Tables**, you have three main approaches: *wrappers*, *extensions*, and what we might call *composing functions*.
 
 - **Wrappers** simplify existing functionality by bundling common parameter combinations into convenient functions. They don't add new capabilities, but make complex styling or formatting tasks more accessible.
+- **Composing functions** combine multiple methods into a single function, allowing you to build more complex table logic or reusable patterns.
 - **Extensions**, on the other hand, add new functionality by combining multiple methods in creative ways, processing data outside the package, or generating custom content (like HTML or images) that gets integrated into your table.
 
-Both approaches are valuable contributions to the **Great Tables** ecosystem, and the choice between them depends on whether you're making it easier to access existing tooling or creating entirely new capabilities.
+All approaches are valuable contributions to the **Great Tables** ecosystem, and the choice between them depends on whether you're making it easier to access existing tooling or creating entirely new capabilities.
 
-### gt-extras
+### Wrappers
 
-Some of the functions in [**gt-extras**](https://posit-dev.github.io/gt-extras/) are wrappers. Take [`gt_highlight_cols()`](https://posit-dev.github.io/gt-extras/reference/gt_highlight_cols), which is a wrapper function that doesn't add *new* functionality to **Great Tables**. If you look at the underlying code, you'll see it makes a call to `~~GT.tab_style()`, while setting specific `locations=` and `style=` parameters. Something as lightweight as this might be useful for someone who knows what effect they want, but doesn't want to investigate the entire space of options for styling.
-
-<!-- Show code here maybe? -->
+Let's wrap `~~GT.tab_style()` to perform a specific action supported by the general function. `~~GT.tab_style()` takes `locations=` and `style=` parameters, so let's assign those. Something this lightweight might be useful for someone who knows what effect they want, but doesn't want to investigate the entire space of options for styling.
 
 ```{python}
 # | eval: False
-# | code-fold: true
-# | code-summary: "Show the code"
-# Select locations based on the parameters in scope at this point of the function
-locations: list[Loc] = [loc.body(columns=columns)]
-if include_column_labels:
-    locations.append(loc.column_labels(columns=columns))
+def highlight_cols(gt: GT, columns: SelectExpr) -> GT:
+    locations = [
+        loc.body(columns=columns),
+        loc.column_labels(columns=columns),
+    ]
 
-# Select styles according to fill, font_weight, and font_color parameters
-styles: list[CellStyle] = [
-    style.fill(color=fill),
-    style.borders(color=fill),
-    style.text(weight=font_weight, color=font_color),
-]
+    styles = [
+        style.fill(color="lightblue"),
+        style.borders(color="lightblue"),
+        style.text(weight="bold", color="black"),
+    ]
 
-# Make the wrapped tab_style call
-gt = gt.tab_style(
-    style=styles,
-    locations=locations,
-)
+    # Make the wrapped tab_style call
+    return gt.tab_style(
+        style=styles,
+        locations=locations,
+    )
 ```
 
+In fact, many of the functions in [**gt-extras**](https://posit-dev.github.io/gt-extras/) are wrappers. What you see above is very similar to the source code for the function [`gt_highlight_cols()`](https://posit-dev.github.io/gt-extras/reference/gt_highlight_cols), which is a wrapper function that doesn't add *new* functionality to **Great Tables**.
 
-**gt-extras** also extends the customizing of tables, beyond making existing methods even more convenient to use. For example [`gt_two_column_layout()`](https://posit-dev.github.io/gt-extras/reference/gt_two_column_layout) does a little more heavy lifting, building an HTML string containing two side-by-side tables. This function takes two separate `~~GT` objects, renders them as HTML using `~~GT.as_raw_html()`, and then wraps them in custom HTML structure to create a unified side-by-side layout, which would not be possible with **Great Tables** methods alone.
+### Composing Functions
+
+A little more complex than wrapping, we can also compose functions to perform several steps, such as applying multiple styles, formatting, or themes all at once.
+
+Here's how **gt-extras** implemented the [ESPN](https://posit-dev.github.io/gt-extras/reference/gt_theme_espn) theme:
 
 ```{python}
 # | eval: False
-# | code-fold: true
-# | code-summary: "Show the code"
-# In one of the branched of `gt_two_column_layout`, a header isn't set
-header_html = ""
-table_1_html = gt1.as_raw_html()
-table_2_html = gt2.as_raw_html()
+def espn_theme(gt: GT) -> GT:
+    return (
+        gt.opt_all_caps()
+        .opt_table_font(font=google_font("Lato"), weight=400)
+        .opt_row_striping()
+        .tab_style(
+            style=style.text(weight="bold"),
+            locations=loc.column_header(),
+        )
+        .tab_options(
+            row_striping_background_color="#fafafa",
+            table_body_hlines_color="#f6f7f7",
+            source_notes_font_size="12px",
+            table_font_size="16px",
+            heading_align="left",
+            heading_title_font_size="24px",
+            table_border_top_color="white",
+            table_border_top_width="3px",
+            data_row_padding="7px",
+        )
+    )
+```
 
-# Great Tables is extended via supplemental html
-double_table_html = f"""
-    <div style="display: flex; justify-content: center; width: 100%;">
-        <div id="mycombinedtable" style="display: inline-block; width: auto;">
-            {header_html}
-            <div style="overflow: auto; white-space: nowrap;">
-                <div style="display: inline-block; margin-right: 1em;">
-                    {table_1_html}
-                </div>
-                <div style="display: inline-block;">
-                    {table_2_html}
+This is where wrapper functions really shine. Maybe you want a very standardized look, or you want all of your tables to mimic your favorite one. Take advantage of `~~GT.tab_options()` for your own [premade themes](./table-theme-premade.qmd), with styles from any of the [table theme options](./table-theme-options.qmd) of your choosing.
+
+### Extensions
+
+Let's extend the post-processing by building an HTML string containing two side-by-side tables. This function takes two separate `~~GT` objects, renders them as HTML using `~~GT.as_raw_html()`, and then wraps them in custom HTML structure to create a side-by-side layout, which would not be possible with **Great Tables** methods alone.
+
+```{python}
+# | eval: False
+def double_table(gt1: GT, gt2: GT) -> str:
+    header_html = "Combined Table"
+    table_1_html = gt1.as_raw_html()
+    table_2_html = gt2.as_raw_html()
+
+    # Great Tables is extended via supplemental html
+    double_table_html = f"""
+        <div style="display: flex; justify-content: center; width: 100%;">
+            <div id="mycombinedtable" style="display: inline-block; width: auto;">
+                {header_html}
+                <div style="overflow: auto; white-space: nowrap;">
+                    <div style="display: inline-block; margin-right: 1em;">
+                        {table_1_html}
+                    </div>
+                    <div style="display: inline-block;">
+                        {table_2_html}
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
-    """
+        """
+    return double_table_html
 ```
 
+Aagin, this is a **gt-extras** function which extends the customizing of tables, [`gt_two_column_layout()`](https://posit-dev.github.io/gt-extras/reference/gt_two_column_layout) does a little more heavy lifting than **Great Tables** itself supports. Notice this time it is new behavior we're adding.
 
-## Great Tables Extension Possibilities
-
-What might you want to put into an extension to **Great Tables**? Here are some of the most common and impactful areas where extensions can add significant value to your tables.
-
-### Plots
+## Extension Plots
 
 Also known as sparklines, embedded plots in tables are a powerful tool. So much so that some plotting is already built in, called [nanoplots](nanoplots.qmd). But there are endless plot types you could want in your great tables, and for these `~~GT.fmt()` is your friend.
 
@@ -106,34 +135,7 @@ gt.fmt(fns=create_my_plot, columns="my_data_column")
 
 Check out this [blog post](../blog/plots-in-tables/index.qmd)  for a deeper dive into different approaches for creating plots in tables.
 
-### Themes
-
-This is where wrapper functions really shine. Maybe you want a very standardized look, or you want all of your tables to mimic your favorite one. Take advantage of `~~GT.tab_options()` for your own [premade themes](./table-theme-premade.qmd), with styles from any of the [table theme options](./table-theme-options.qmd) of your choosing.
-
-Here's how **gt-extras** implemented the [ESPN](https://posit-dev.github.io/gt-extras/reference/gt_theme_espn) theme:
-
-```{python}
-# | eval: False
-gt_theme_espn = (
-    gt.opt_all_caps()
-    .opt_table_font(font=google_font("Lato"), weight=400)
-    .opt_row_striping()
-    .tab_style(style=style.text(weight="bold"), locations=loc.column_header())
-    .tab_options(
-        row_striping_background_color="#fafafa",
-        table_body_hlines_color="#f6f7f7",
-        source_notes_font_size="12px",
-        table_font_size="16px",
-        heading_align="left",
-        heading_title_font_size="24px",
-        table_border_top_color="white",
-        table_border_top_width="3px",
-        data_row_padding="7px",
-    )
-)
-```
-
-### Icons
+## Extension Icons
 
 They say a picture is worth a thousand words. So maybe you want to take `~~GT.fmt_icon()` and run with it, but with your own custom icon sets or specialized styling needs. For example:
 
@@ -155,6 +157,14 @@ def fmt_star_rating(filled_stars: int, max_stars=5):
 gt.fmt(fns=fmt_star_rating, columns="my_data_column")
 ```
 
-### Beyond
+## Beyond
 
-Go where your heart desires, you aren't constrained by what is provided by this package, in fact, this package is just the beginning of your tabling life!
+For some inspiration on ways to extend **Great Tables**, check out [**gt-extras**](posit-dev.github.io/gt-extras/) and its [source code](https://github.com/posit-dev/gt-extras).
+
+| Function |   Type   |
+|----------|----------|
+| [gt_plt_bar](https://posit-dev.github.io/gt-extras/reference/gt_plt_bar) | Extension |
+| [gt_color_box](https://posit-dev.github.io/gt-extras/reference/gt_color_box) | Extension |
+| [gt_data_color_by_group](https://posit-dev.github.io/gt-extras/reference/gt_data_color_by_group) | Wrapper |
+| [gt_add_divider](https://posit-dev.github.io/gt-extras/reference/gt_add_divider) | Wrapper |
+| [gt_theme_538](https://posit-dev.github.io/gt-extras/reference/gt_theme_538) | Composite |

--- a/docs/get-started/extensions.qmd
+++ b/docs/get-started/extensions.qmd
@@ -64,7 +64,19 @@ This is where composing really shines. Maybe you want a very standardized look, 
 
 ### Extending
 
-Let's extend the post-processing step by building an HTML string containing two side-by-side tables. This function takes two separate `~~GT` objects, renders them as HTML using `~~GT.as_raw_html()`, and then joins them in custom HTML structure, which would not be possible with **Great Tables** methods alone.
+Perhaps the most complex, this involves new behavior not supported by **Great Tables** methods alone. Formatting values is a common way to do this:
+
+```{python}
+# | eval: false
+def fmt_threshold(gt, columns, threshold: float):
+    """Format values to 0 if they are under threshold.""""
+    def _truncate(val: float)
+        return "0" if val < threshold else str(val)
+
+    return gt.fmt(_truncate, columns)
+```
+
+Alternatively, we can extend the post-processing step by building an HTML string containing two side-by-side tables. This function takes two separate `~~GT` objects, renders them as HTML using `~~GT.as_raw_html()`, and then joins them in custom HTML structure, which would not be possible with **Great Tables** methods alone.
 
 ```{python}
 # | eval: False

--- a/docs/get-started/extensions.qmd
+++ b/docs/get-started/extensions.qmd
@@ -10,17 +10,17 @@ But what happens when there's something you want to add to your table, and it's 
 
 [**gt-extras**](https://posit-dev.github.io/gt-extras/) is a great case study in this, filling some table goals that aren't supported by **Great Tables** directly.
 
-## Writing an Extension Function
+## Writing an Add-on Function
 
-When extending **Great Tables**, you have three main approaches: *wrappers*, *extensions*, and what we might call *composing functions*.
+When adding to **Great Tables**, you have three main approaches: *wrapping*, *extending*, and what we might call *composing*.
 
-- **Wrappers** simplify existing functionality by bundling common parameter combinations into convenient functions. They don't add new capabilities, but make complex styling or formatting tasks more accessible.
-- **Composing functions** combine multiple methods into a single function, allowing you to build more complex table logic or reusable patterns.
-- **Extensions**, on the other hand, add new functionality by combining multiple methods in creative ways, processing data outside the package, or generating custom content (like HTML or images) that gets integrated into your table.
+- **Wrapping** is when you simplify existing functionality by bundling common parameter combinations. It doesn't add new capabilities, instead makes specific or complex styling tasks more accessible.
+- **Composing** multiple methods into a single function, allowing you to build more complex table logic or reusable patterns.
+- **Extending**, on the other hand, adds new functionality by adding behavior beyond built-in methods. This could include processing data outside the package, or generating custom content (like HTML or images), that gets integrated into your table.
 
 All approaches are valuable contributions to the **Great Tables** ecosystem, and the choice between them depends on whether you're making it easier to access existing tooling or creating entirely new capabilities.
 
-### Wrappers
+### Wrapping
 
 Let's wrap `~~GT.tab_style()` to perform a specific action supported by the general function. `~~GT.tab_style()` takes `locations=` and `style=` parameters, so let's assign those. Something this lightweight might be useful for someone who knows what effect they want, but doesn't want to investigate the entire space of options for styling.
 
@@ -39,13 +39,13 @@ def highlight_cols(gt: GT, columns: SelectExpr) -> GT:
     )
 ```
 
-In fact, many of the functions in [**gt-extras**](https://posit-dev.github.io/gt-extras/) are wrappers. What you see above is very similar to the source code for the function [`gt_highlight_cols()`](https://posit-dev.github.io/gt-extras/reference/gt_highlight_cols), which is a wrapper function that doesn't add *new* functionality to **Great Tables**, instead it makes a common action much easier.
+In fact, many of the functions in [**gt-extras**](https://posit-dev.github.io/gt-extras/) are wrappers. What you see above is pulled from the source code for the function [`gt_highlight_cols()`](https://posit-dev.github.io/gt-extras/reference/gt_highlight_cols), which is a wrapper function that doesn't add *new* functionality to **Great Tables**, instead it makes a common action much easier.
 
-### Composing Functions
+### Composing
 
-A little more complex than wrapping, we can also compose functions to perform several steps, such as applying multiple styles, formatting, or themes all at once.
+A little more complex than wrapping, we can also compose methods to perform several steps, such as applying multiple styles, formatting, or themes all at once.
 
-Here's how **gt-extras** implemented the [ESPN](https://posit-dev.github.io/gt-extras/reference/gt_theme_espn) theme:
+Here's a flavor of the composed methods that **gt-extras** used in the [ESPN theme](https://posit-dev.github.io/gt-extras/reference/gt_theme_espn):
 
 ```{python}
 # | eval: False
@@ -60,11 +60,11 @@ def some_theme(gt: GT) -> GT:
     )
 ```
 
-This is where composed functions really shine. Maybe you want a very standardized look, or you want all of your tables to mimic your favorite one. Take advantage of `~~GT.tab_options()` for your own [premade themes](./table-theme-premade.qmd), with styles from any of the [table theme options](./table-theme-options.qmd) of your choosing.
+This is where composing really shine. Maybe you want a very standardized look, or you want all of your tables to mimic your favorite one. Take advantage of `~~GT.tab_options()` for your own [premade themes](./table-theme-premade.qmd), with styles from any of the [table theme options](./table-theme-options.qmd) of your choosing.
 
-### Extensions
+### Extending
 
-Let's extend the post-processing step by building an HTML string containing two side-by-side tables. This function takes two separate `~~GT` objects, renders them as HTML using `~~GT.as_raw_html()`, and then wraps them in custom HTML structure to create a side-by-side layout, which would not be possible with **Great Tables** methods alone.
+Let's extend the post-processing step by building an HTML string containing two side-by-side tables. This function takes two separate `~~GT` objects, renders them as HTML using `~~GT.as_raw_html()`, and then joins them in custom HTML structure, which would not be possible with **Great Tables** methods alone.
 
 ```{python}
 # | eval: False
@@ -75,9 +75,9 @@ def double_table(gt1: GT, gt2: GT) -> str:
     return f"""<div>{table_1_html}</div><div>{table_2_html}</div>"""
 ```
 
-Again, this is a facet of the **gt-extras** function which extends the customizing of tables, [`gt_two_column_layout()`](https://posit-dev.github.io/gt-extras/reference/gt_two_column_layout) does a little more heavy lifting than **Great Tables** itself supports. Notice this time it is new behavior we're adding.
+Again, this is a sneak peek of the **gt-extras** function, [`gt_two_column_layout()`](https://posit-dev.github.io/gt-extras/reference/gt_two_column_layout), which does a little more heavy lifting than **Great Tables** itself supports. Notice this time it is new behavior we're adding.
 
-## Extension Plots
+## Extending with Plots
 
 Embedded plots in tables (also known as sparklines) are a powerful tool. So much so that some plotting is already built in, called [nanoplots](nanoplots.qmd). But there are endless plot types you could want in your great tables, and for these `~~GT.fmt()` is your friend.
 
@@ -100,7 +100,7 @@ gt.fmt(fns=create_my_plot, columns="my_data_column")
 
 Check out this [blog post](../blog/plots-in-tables/index.qmd)  for a deeper dive into different approaches for creating plots in tables.
 
-## Extension Icons
+## Extending with Icons
 
 They say a picture is worth a thousand words. So maybe you want to take `~~GT.fmt_icon()` and run with it, but with your own custom icon sets or specialized styling needs. For example:
 
@@ -111,10 +111,8 @@ Here's an example of how you might create a custom icon extension that maps nume
 
 ```{python}
 # | eval: False
-def fmt_star_rating(filled_stars: int, max_stars=5):
-    empty_stars = max_stars - filled_stars
-
-    star_html = "★" * filled_stars + "☆" * empty_stars
+def fmt_star_rating(filled_stars: int):
+    star_html = "★" * filled_stars
     return f'<span style="color: gold; font-size: 18px;">{star_html}</span>'
 
 
@@ -128,8 +126,8 @@ For some inspiration on ways to extend **Great Tables**, check out [**gt-extras*
 
 | Function |   Type   |
 |----------|----------|
-| [gt_plt_bar](https://posit-dev.github.io/gt-extras/reference/gt_plt_bar) | Extension |
-| [gt_color_box](https://posit-dev.github.io/gt-extras/reference/gt_color_box) | Extension |
-| [gt_data_color_by_group](https://posit-dev.github.io/gt-extras/reference/gt_data_color_by_group) | Wrapper |
-| [gt_add_divider](https://posit-dev.github.io/gt-extras/reference/gt_add_divider) | Wrapper |
-| [gt_theme_538](https://posit-dev.github.io/gt-extras/reference/gt_theme_538) | Composite |
+| [gt_plt_bar](https://posit-dev.github.io/gt-extras/reference/gt_plt_bar) | Extend |
+| [gt_color_box](https://posit-dev.github.io/gt-extras/reference/gt_color_box) | Extend |
+| [gt_data_color_by_group](https://posit-dev.github.io/gt-extras/reference/gt_data_color_by_group) | Wrap |
+| [gt_add_divider](https://posit-dev.github.io/gt-extras/reference/gt_add_divider) | Wrap |
+| [gt_theme_538](https://posit-dev.github.io/gt-extras/reference/gt_theme_538) | Compose |

--- a/docs/get-started/extensions.qmd
+++ b/docs/get-started/extensions.qmd
@@ -144,8 +144,7 @@ Here's an example of how you might create a custom icon extension that maps nume
 
 ```{python}
 # | eval: False
-def fmt_star_rating(value, max_stars=5):
-    filled_stars = int(value)
+def fmt_star_rating(filled_stars: int, max_stars=5):
     empty_stars = max_stars - filled_stars
 
     star_html = "★" * filled_stars + "☆" * empty_stars
@@ -153,7 +152,7 @@ def fmt_star_rating(value, max_stars=5):
 
 
 # Apply to your table, again `fmt()` comes in handy!
-gt.fmt(fns=fmt_star_rating, columns="rating")
+gt.fmt(fns=fmt_star_rating, columns="my_data_column")
 ```
 
 ### Beyond


### PR DESCRIPTION
This adds a get-started subpage which is a guide page on extensions, with gt-extras as an reference point.

The goal is to help people make their own personal "gt-extras" packages.