### PR TITLE
Fix: Row striping font color contrast with background

### DIFF
--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -1181,9 +1181,7 @@ class Options:
     )
     source_notes_multiline: OptionsInfo = OptionsInfo(False, "source_notes", "boolean", True)
     source_notes_sep: OptionsInfo = OptionsInfo(False, "source_notes", "value", " ")
-    row_striping_background_color: OptionsInfo = OptionsInfo(
-        True, "row", "value", "rgba(128,128,128,0.05)"
-    )
+    row_striping_background_color: OptionsInfo = OptionsInfo(True, "row", "value", None)
     row_striping_include_stub: OptionsInfo = OptionsInfo(False, "row", "boolean", False)
     row_striping_include_table_body: OptionsInfo = OptionsInfo(False, "row", "boolean", False)
     container_width: OptionsInfo = OptionsInfo(False, "container", "px", "auto")

--- a/great_tables/_scss.py
+++ b/great_tables/_scss.py
@@ -22,6 +22,7 @@ DEFAULTS_TABLE_BACKGROUND = (
     "grand_summary_row_background_color",
     "footnotes_background_color",
     "source_notes_background_color",
+    "row_striping_background_color",
 )
 
 FONT_COLOR_VARS = (
@@ -36,6 +37,7 @@ FONT_COLOR_VARS = (
     "grand_summary_row_background_color",
     "footnotes_background_color",
     "source_notes_background_color",
+    "row_striping_background_color",
 )
 
 

--- a/great_tables/_scss.py
+++ b/great_tables/_scss.py
@@ -29,7 +29,6 @@ FONT_COLOR_VARS = (
     "table_background_color",
     "heading_background_color",
     "column_labels_background_color",
-    "column_labels_background_color",
     "row_group_background_color",
     "stub_background_color",
     "stub_row_group_background_color",

--- a/great_tables/css/gt_styles_default.scss
+++ b/great_tables/css/gt_styles_default.scss
@@ -264,6 +264,7 @@ p {
 }
 
 .gt_striped {
+  color: $font_color_row_striping_background_color;
   background-color: $row_striping_background_color;
 }
 

--- a/tests/__snapshots__/test_export.ambr
+++ b/tests/__snapshots__/test_export.ambr
@@ -34,7 +34,7 @@
    #test_table .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
    #test_table .gt_row_group_first td { border-top-width: 2px; }
    #test_table .gt_row_group_first th { border-top-width: 2px; }
-   #test_table .gt_striped { background-color: rgba(128,128,128,0.05); }
+   #test_table .gt_striped { color: #333333; background-color: #FFFFFF; }
    #test_table .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
    #test_table .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
    #test_table .gt_sourcenote { font-size: 90%; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }

--- a/tests/__snapshots__/test_options.ambr
+++ b/tests/__snapshots__/test_options.ambr
@@ -1011,6 +1011,7 @@
   }
   
   #abc .gt_striped {
+    color: #333333;
     background-color: #F4F4F4;
   }
   
@@ -1362,6 +1363,7 @@
   }
   
   #abc .gt_striped {
+    color: #333333;
     background-color: #F4F4F4;
   }
   
@@ -1821,7 +1823,8 @@
   }
   
   #abc .gt_striped {
-    background-color: rgba(128,128,128,0.05);
+    color: #000000;
+    background-color: red;
   }
   
   #abc .gt_table_body {
@@ -2172,7 +2175,8 @@
   }
   
   #abc .gt_striped {
-    background-color: rgba(128,128,128,0.05);
+    color: #333333;
+    background-color: #FFFFFF;
   }
   
   #abc .gt_table_body {

--- a/tests/__snapshots__/test_repr.ambr
+++ b/tests/__snapshots__/test_repr.ambr
@@ -34,7 +34,7 @@
    #test .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
    #test .gt_row_group_first td { border-top-width: 2px; }
    #test .gt_row_group_first th { border-top-width: 2px; }
-   #test .gt_striped { background-color: rgba(128,128,128,0.05); }
+   #test .gt_striped { color: #333333; background-color: #FFFFFF; }
    #test .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
    #test .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
    #test .gt_sourcenote { font-size: 90%; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
@@ -110,7 +110,7 @@
    #test .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
    #test .gt_row_group_first td { border-top-width: 2px; }
    #test .gt_row_group_first th { border-top-width: 2px; }
-   #test .gt_striped { background-color: rgba(128,128,128,0.05); }
+   #test .gt_striped { color: #333333; background-color: #FFFFFF; }
    #test .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
    #test .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
    #test .gt_sourcenote { font-size: 90%; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
@@ -192,7 +192,7 @@
    #test .gt_stub_row_group { color: #333333 !important; background-color: #FFFFFF !important; font-size: 100% !important; font-weight: initial !important; text-transform: inherit !important; border-right-style: solid !important; border-right-width: 2px !important; border-right-color: #D3D3D3 !important; padding-left: 5px !important; padding-right: 5px !important; vertical-align: top !important; }
    #test .gt_row_group_first td { border-top-width: 2px !important; }
    #test .gt_row_group_first th { border-top-width: 2px !important; }
-   #test .gt_striped { background-color: rgba(128,128,128,0.05) !important; }
+   #test .gt_striped { color: #333333 !important; background-color: #FFFFFF !important; }
    #test .gt_table_body { border-top-style: solid !important; border-top-width: 2px !important; border-top-color: #D3D3D3 !important; border-bottom-style: solid !important; border-bottom-width: 2px !important; border-bottom-color: #D3D3D3 !important; }
    #test .gt_sourcenotes { color: #333333 !important; background-color: #FFFFFF !important; border-bottom-style: none !important; border-bottom-width: 2px !important; border-bottom-color: #D3D3D3 !important; border-left-style: none !important; border-left-width: 2px !important; border-left-color: #D3D3D3 !important; border-right-style: none !important; border-right-width: 2px !important; border-right-color: #D3D3D3 !important; }
    #test .gt_sourcenote { font-size: 90% !important; padding-top: 4px !important; padding-bottom: 4px !important; padding-left: 5px !important; padding-right: 5px !important; text-align: left !important; }
@@ -271,7 +271,7 @@
    #test .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
    #test .gt_row_group_first td { border-top-width: 2px; }
    #test .gt_row_group_first th { border-top-width: 2px; }
-   #test .gt_striped { background-color: rgba(128,128,128,0.05); }
+   #test .gt_striped { color: #333333; background-color: #FFFFFF; }
    #test .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
    #test .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
    #test .gt_sourcenote { font-size: 90%; padding-top: 4px; padding-bottom: 4px; padding-left: 5px; padding-right: 5px; text-align: left; }
@@ -347,7 +347,7 @@
    #test .gt_stub_row_group { color: #333333 !important; background-color: #FFFFFF !important; font-size: 100% !important; font-weight: initial !important; text-transform: inherit !important; border-right-style: solid !important; border-right-width: 2px !important; border-right-color: #D3D3D3 !important; padding-left: 5px !important; padding-right: 5px !important; vertical-align: top !important; }
    #test .gt_row_group_first td { border-top-width: 2px !important; }
    #test .gt_row_group_first th { border-top-width: 2px !important; }
-   #test .gt_striped { background-color: rgba(128,128,128,0.05) !important; }
+   #test .gt_striped { color: #333333 !important; background-color: #FFFFFF !important; }
    #test .gt_table_body { border-top-style: solid !important; border-top-width: 2px !important; border-top-color: #D3D3D3 !important; border-bottom-style: solid !important; border-bottom-width: 2px !important; border-bottom-color: #D3D3D3 !important; }
    #test .gt_sourcenotes { color: #333333 !important; background-color: #FFFFFF !important; border-bottom-style: none !important; border-bottom-width: 2px !important; border-bottom-color: #D3D3D3 !important; border-left-style: none !important; border-left-width: 2px !important; border-left-color: #D3D3D3 !important; border-right-style: none !important; border-right-width: 2px !important; border-right-color: #D3D3D3 !important; }
    #test .gt_sourcenote { font-size: 90% !important; padding-top: 4px !important; padding-bottom: 4px !important; padding-left: 5px !important; padding-right: 5px !important; text-align: left !important; }

--- a/tests/__snapshots__/test_scss.ambr
+++ b/tests/__snapshots__/test_scss.ambr
@@ -273,7 +273,8 @@
   }
   
   #abc .gt_striped {
-    background-color: rgba(128,128,128,0.05);
+    color: #333333;
+    background-color: #FFFFFF;
   }
   
   #abc .gt_table_body {


### PR DESCRIPTION
# Summary

See related issue. The color of the text of gt-striped rows does not get contrasted with the striping color.
 
# Related GitHub Issues and PRs

- Ref: Closes #744

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ ] I have added **pytest** unit tests for any new functionality.
