### PR TITLE
Fix: `_ideal_fgnd_color()` takes alpha into account

### DIFF
--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -509,21 +509,6 @@ def _add_alpha(colors: list[str], alpha: int | float) -> list[str]:
     return colors
 
 
-def _remove_alpha(colors: list[str]) -> list[str]:
-    # Loop through the colors and remove the alpha value from each one
-    for i in range(len(colors)):
-        color = colors[i]
-        # If the color value is already in the `#RRGGBB` format, then we need to add the
-        # alpha value to it before removing the alpha value
-        if _is_standard_hex_col([color])[0]:
-            color = color + "FF"
-
-        # Remove the alpha value from the color value
-        colors[i] = color[:-2]
-
-    return colors
-
-
 def _float_to_hex(x: float) -> str:
     """
     Convert a float to a hexadecimal value.

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -294,8 +294,8 @@ def data_color(
 
 
 def _ideal_fgnd_color(bgnd_color: str, light: str = "#FFFFFF", dark: str = "#000000") -> str:
-    # Remove alpha value from hexadecimal color value in `bgnd_color=`
-    bgnd_color = _remove_alpha(colors=[bgnd_color])[0]
+    # Compose alpha value from hexadecimal color value in `bgnd_color=`
+    bgnd_color = _alpha_composite_with_white(bgnd_color)
 
     contrast_dark = _get_wcag_contrast_ratio(color_1=dark, color_2=bgnd_color)
     contrast_light = _get_wcag_contrast_ratio(color_1=light, color_2=bgnd_color)
@@ -303,6 +303,48 @@ def _ideal_fgnd_color(bgnd_color: str, light: str = "#FFFFFF", dark: str = "#000
     fgnd_color = dark if abs(contrast_dark) > abs(contrast_light) else light
 
     return fgnd_color
+
+
+def _alpha_composite_with_white(color: str) -> str:
+    """
+    Alpha composite a color with white background
+
+    Parameters
+    ----------
+    color : str
+        Hexadecimal color value, either #RRGGBB or #RRGGBBAA format
+
+    Returns
+    -------
+    str
+        Composited color in #RRGGBB format
+    """
+
+    # If no alpha channel, return as-is
+    if len(color) != 9:
+        return color
+
+    # Extract RGB and alpha components
+    r = int(color[1:3], 16)
+    g = int(color[3:5], 16)
+    b = int(color[5:7], 16)
+    alpha = int(color[7:9], 16) / 255.0
+
+    # White background (255, 255, 255) with full opacity
+    white_r, white_g, white_b = 255, 255, 255
+
+    # Apply alpha compositing formula: cr = cf * af + cb * ab * (1 - af)
+    result_r = int(r * alpha + white_r * (1 - alpha))
+    result_g = int(g * alpha + white_g * (1 - alpha))
+    result_b = int(b * alpha + white_b * (1 - alpha))
+
+    # Clamp values to [0, 255] range
+    result_r = max(0, min(255, result_r))
+    result_g = max(0, min(255, result_g))
+    result_b = max(0, min(255, result_b))
+
+    # Convert back to hex format
+    return f"#{result_r:02X}{result_g:02X}{result_b:02X}"
 
 
 def _get_wcag_contrast_ratio(color_1: str, color_2: str) -> float:

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -344,6 +344,7 @@ def _alpha_composite_with_white(color: str) -> str:
     result_b = max(0, min(255, result_b))
 
     # Convert back to hex format
+    # TODO: After refactor, use rgb_to_hex (now in palettes.py)
     return f"#{result_r:02X}{result_g:02X}{result_b:02X}"
 
 

--- a/tests/data_color/test_data_color_utils.py
+++ b/tests/data_color/test_data_color_utils.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 from great_tables._data_color.base import (
     _add_alpha,
+    _alpha_composite_with_white,
     _color_name_to_hex,
     _expand_short_hex,
     _float_to_hex,
@@ -272,6 +273,34 @@ def test_remove_alpha():
     colors = ["#FF0000", "#00FF00", "#0000FF"]
     result = _remove_alpha(colors)
     assert result == ["#FF0000", "#00FF00", "#0000FF"]
+
+
+def test_alpha_composite_with_white():
+    colors = ["#FF000040", "#00FF0040", "#0000FF40"]  # 25% alpha
+    result = [_alpha_composite_with_white(color) for color in colors]
+    expected = ["#FFBFBF", "#BFFFBF", "#BFBFFF"]
+    assert result == expected
+
+    colors = ["#FF000080", "#00FF0080", "#0000FF80"]  # 50% alpha
+    result = [_alpha_composite_with_white(color) for color in colors]
+    expected = ["#FF7F7F", "#7FFF7F", "#7F7FFF"]
+    assert result == expected
+
+    colors = ["#FF0000FF", "#00FF00FF", "#0000FFFF"]  # 100% alpha
+    result = [_alpha_composite_with_white(color) for color in colors]
+    expected = ["#FF0000", "#00FF00", "#0000FF"]
+    assert result == expected
+
+    colors = ["#FF000000", "#00FF0000", "#0000FF00"]  # 0% alpha
+    result = [_alpha_composite_with_white(color) for color in colors]
+    expected = ["#FFFFFF", "#FFFFFF", "#FFFFFF"]
+    assert result == expected
+
+    # Test colors without alpha
+    colors = ["#FF0000", "#00FF00", "#0000FF"]
+    result = [_alpha_composite_with_white(color) for color in colors]
+    expected = ["#FF0000", "#00FF00", "#0000FF"]
+    assert result == expected
 
 
 def test_float_to_hex():

--- a/tests/data_color/test_data_color_utils.py
+++ b/tests/data_color/test_data_color_utils.py
@@ -19,7 +19,6 @@ from great_tables._data_color.base import (
     _is_short_hex,
     _is_standard_hex_col,
     _relative_luminance,
-    _remove_alpha,
     _rescale_numeric,
     _srgb,
 )
@@ -259,20 +258,6 @@ def test_add_alpha_invalid_alpha():
             str(e)
             == "Invalid alpha value provided (1.5). Please ensure that alpha is a value between 0 and 1."
         )
-
-
-def test_remove_alpha():
-    colors = ["#FF0000FF", "#00FF00FF", "#0000FFFF"]
-    result = _remove_alpha(colors)
-    assert result == ["#FF0000", "#00FF00", "#0000FF"]
-
-    colors = ["#FF000080", "#00FF0080", "#0000FF80"]
-    result = _remove_alpha(colors)
-    assert result == ["#FF0000", "#00FF00", "#0000FF"]
-
-    colors = ["#FF0000", "#00FF00", "#0000FF"]
-    result = _remove_alpha(colors)
-    assert result == ["#FF0000", "#00FF00", "#0000FF"]
 
 
 def test_alpha_composite_with_white():


### PR DESCRIPTION
# Summary

See related issue. This PR relies on the fact that background that are not fully opaque are always blended against a white background. I think the way tables set final cell and other background colors is consistent with this fact, but I am open to being corrected and looking for a workaround if that isn't the case.

The PR effectively replaces `_remove_alpha()` with `_alpha_composite_with_white()`.

# Related GitHub Issues and PRs

- Ref: Closes #746 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.
