### PR TITLE
Remove numpy from dependencies

### DIFF
--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -605,16 +605,7 @@ def _rescale_numeric(
         # values outside domain set to missing
         min_val, max_val = None, None
 
-    return [
-        min_val
-        if x is not None and x < 0
-        else max_val
-        if x is not None and x > 1
-        else x
-        if x is not None
-        else None
-        for x in scaled
-    ]
+    return [None if x is None else min_val if x < 0 else max_val if x > 1 else x for x in scaled]
 
 
 def _rescale_factor(

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -594,9 +594,8 @@ def _rescale_numeric(
         return [0.0 if not is_na(df, x) else x for x in vals]
 
     # Rescale the values in `vals` to the range [0, 1], pass through NA values
-    filled: list[float | None] = [None if is_na(df, x) else x for x in vals]
     scaled: list[float | None] = [
-        None if x is None else (x - domain_min) / domain_range for x in filled
+        None if is_na(df, x) else (x - domain_min) / domain_range for x in vals
     ]
 
     if truncate:

--- a/great_tables/_data_color/base.py
+++ b/great_tables/_data_color/base.py
@@ -598,12 +598,7 @@ def _rescale_numeric(
         None if is_na(df, x) else (x - domain_min) / domain_range for x in vals
     ]
 
-    if truncate:
-        # values outside domain set to 0 or 1
-        min_val, max_val = 0, 1
-    else:
-        # values outside domain set to missing
-        min_val, max_val = None, None
+    min_val, max_val = (0, 1) if truncate else (None, None)
 
     return [None if x is None else min_val if x < 0 else max_val if x > 1 else x for x in scaled]
 

--- a/great_tables/_data_color/palettes.py
+++ b/great_tables/_data_color/palettes.py
@@ -131,20 +131,26 @@ class GradientPalette:
         rgb = self.vals_to_rgb(data)
         return [rgb_to_hex(x) if x is not None else None for x in rgb]
 
-    def vals_to_rgb(self, data: list[float]) -> "list[RGBColor | None]":
+    def vals_to_rgb(self, data: list[float | None]) -> "list[RGBColor | None]":
         """Return data transformed to RGB values."""
 
         out: "list[RGBColor | None]" = []
         for ii, x in enumerate(data):
+            if x is None:
+                out.append(None)
+                continue
+
             if isinf(x) or isnan(x):
                 out.append(None)
-            elif x < 0 or x > 1:
+                continue
+
+            if x < 0 or x > 1:
                 raise ValueError(f"Element {ii} is outside the range [0, 1]. Value: {x}.")
-            else:
-                r = self._interpolate(x, self._r_coeffs)
-                g = self._interpolate(x, self._g_coeffs)
-                b = self._interpolate(x, self._b_coeffs)
-                out.append((round(r), round(g), round(b)))
+
+            r = self._interpolate(x, self._r_coeffs)
+            g = self._interpolate(x, self._g_coeffs)
+            b = self._interpolate(x, self._b_coeffs)
+            out.append((round(r), round(g), round(b)))
 
         return out
 

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     PlNull = pl.Null
 
     NpNan = np.nan
+    NpInteger = np.integer
 
     DataFrameLike = Union[PdDataFrame, PlDataFrame, PyArrowTable]
     SeriesLike = Union[PdSeries, PlSeries, PyArrowArray, PyArrowChunkedArray]
@@ -85,6 +86,9 @@ else:
 
     class NpNan(AbstractBackend):
         _backends = [("numpy", "nan")]
+
+    class NpInteger(AbstractBackend):
+        _backends = [("numpy", "integer")]
 
     # TODO: these types are imported throughout gt, so we need to either put
     # those imports under TYPE_CHECKING, or continue to make available dynamically here.

--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -933,7 +933,7 @@ def _generate_nanoplot(
         x_proportions = x_proportions_list["vals"]
 
     else:
-        x_proportions = np.linspace(0, 1, num_y_vals)
+        x_proportions = [i / (num_y_vals - 1) if num_y_vals > 1 else 0 for i in range(num_y_vals)]
 
     #
     # Create normalized (and inverted for SVG) data `x` and `y` values for the

--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import random
 from typing import Any, Callable
 
 import narwhals as nw
@@ -425,7 +426,7 @@ def _jitter_vals(x: list[int | float], amount: float) -> list[int | float]:
     Jitter a list of numeric values by a small amount.
     """
 
-    return [val + np.random.uniform(-amount, amount) for val in x]
+    return [val + random.uniform(-amount, amount) for val in x]
 
 
 def _normalize_to_dict(**kwargs: list[int | float]) -> dict[str, list[int | float]]:

--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+import narwhals as nw
 import numpy as np
 
 from ._tbl_data import Agnostic, is_na
@@ -56,7 +57,13 @@ def _is_integerlike(val_list: list[Any]) -> bool:
     if not val_list:
         return False
 
-    return all((isinstance(val, (int, np.integer)) or _is_na(val)) for val in val_list)
+    ## use narwhals to determine if it's numpy
+    try:
+        alt_int = nw.dependencies.get_numpy().integer
+    except AttributeError:  # if no numpy, `integer` won't exist on None
+        alt_int = int
+
+    return all((isinstance(val, (int, alt_int)) or _is_na(val)) for val in val_list)
 
 
 def _any_na_in_list(x: list[Any]) -> bool:

--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import random
 from typing import Any, Callable
 
-from ._tbl_data import Agnostic, is_na
+from ._tbl_data import Agnostic, NpInteger, is_na
 from ._utils import _flatten_list, _match_arg
 
 REFERENCE_LINE_KEYWORDS = ["mean", "median", "min", "max", "q1", "q3"]
@@ -55,15 +55,7 @@ def _is_integerlike(val_list: list[Any]) -> bool:
     if not val_list:
         return False
 
-    ## use narwhals to determine if it's numpy
-    try:
-        import numpy as np
-    except (ImportError, ModuleNotFoundError):
-        alt_int = int
-    else:
-        alt_int = np.integer
-
-    return all((isinstance(val, (int, alt_int)) or _is_na(val)) for val in val_list)
+    return all((isinstance(val, (int, NpInteger)) or _is_na(val)) for val in val_list)
 
 
 def _any_na_in_list(x: list[Any]) -> bool:

--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import random
 from typing import Any, Callable
 
-import narwhals as nw
-
 from ._tbl_data import Agnostic, is_na
 from ._utils import _flatten_list, _match_arg
 
@@ -59,9 +57,11 @@ def _is_integerlike(val_list: list[Any]) -> bool:
 
     ## use narwhals to determine if it's numpy
     try:
-        alt_int = nw.dependencies.get_numpy().integer
-    except AttributeError:  # if no numpy, `integer` won't exist on None
+        import numpy as np
+    except (ImportError, ModuleNotFoundError):
         alt_int = int
+    else:
+        alt_int = np.integer
 
     return all((isinstance(val, (int, alt_int)) or _is_na(val)) for val in val_list)
 

--- a/great_tables/_utils_nanoplots.py
+++ b/great_tables/_utils_nanoplots.py
@@ -4,7 +4,6 @@ import random
 from typing import Any, Callable
 
 import narwhals as nw
-import numpy as np
 
 from ._tbl_data import Agnostic, is_na
 from ._utils import _flatten_list, _match_arg
@@ -400,22 +399,21 @@ def _generate_ref_line_from_keyword(vals: list[int | float], keyword: str) -> in
     return ref_line
 
 
-def _normalize_vals(x: list[int] | list[float] | list[int | float]) -> list[int | float]:
+def _normalize_vals(x: list[int] | list[float] | list[int | float]) -> list[float | None]:
     """
     Normalize a list of numeric values to be between 0 and 1. Account for missing values.
     """
 
     x_missing = [i for i, val in enumerate(x) if _is_na(val)]
-    mean_x = np.mean([val for val in x if not _is_na(val)])
-    x = [mean_x if _is_na(val) else val for val in x]
-    x = np.array(x)
-    min_attr = np.min(x, axis=0)
-    max_attr = np.max(x, axis=0)
-    x = x - min_attr
-    x = x / (max_attr - min_attr)
-    x = x.tolist()
-    x = [np.nan if i in x_missing else val for i, val in enumerate(x)]
-    return x
+    mean_x: float = sum(val for val in x if not _is_na(val)) / sum(
+        1 for val in x if not _is_na(val)
+    )
+    x: list[float] = [mean_x if _is_na(val) else val for val in x]
+    min_attr: float = min(x)
+    max_attr: float = max(x)
+    xmin: list[float] = [val - min_attr for val in x]
+    xover_diff: list[float] = [x / (max_attr - min_attr) for x in xmin]
+    return [None if i in x_missing else val for i, val in enumerate(xover_diff)]
 
 
 # TODO: example nanoplot showing when jitter vals might be applied

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "htmltools>=0.4.1",
     "importlib-metadata",
     "typing_extensions>=3.10.0.0",
-    "numpy>=1.22.4",
     "Babel>=2.13.1",
     "importlib-resources"
 ]
@@ -65,6 +64,8 @@ dev = [
     "great_tables[dev-no-pandas]",
     "pandas",
     "plotnine",
+    "numpy>=1.22.4",
+
 ]
 
 dev-no-pandas = [

--- a/tests/test__utils_nanoplots.py
+++ b/tests/test__utils_nanoplots.py
@@ -183,12 +183,12 @@ def test_normalize_to_dict():
     assert _normalize_to_dict(a=3.5, b=-0.3) == {"a": [1.0], "b": [0.0]}
 
     # Test case 2: Normalization with missing values
-    assert _normalize_to_dict(a=3.5, b=np.nan, c=4.0) == {"a": [0.0], "b": [np.nan], "c": [1.0]}
+    assert _normalize_to_dict(a=3.5, b=np.nan, c=4.0) == {"a": [0.0], "b": [None], "c": [1.0]}
 
     # Test case 3: Normalization with negative values
     assert _normalize_to_dict(a=3.5, b=np.nan, c=4.0, werwdf=-5) == {
         "a": [0.9444444444444444],
-        "b": [np.nan],
+        "b": [None],
         "c": [1.0],
         "werwdf": [0.0],
     }


### PR DESCRIPTION
Hi maintainers, I'm seeing if numpy could be removed from the dependencies in order to make the library more agnostic. I know this was a a discussion some time back but wasn't prioritized.

Personally, I'd love to drop numpy from some production images at my work.

I don't believe this current pr has any issues, but it's tough to tell since you're obviously testing it with a full dependency graph available. For this reason I'm marking it as a draft until I'm more confident!

Would love feedback/criticism