### PR TITLE
Fix: `fmt()` methods applied to `groupname_col`

### DIFF
--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -478,7 +478,12 @@ def create_body_component_h(data: GTData) -> str:
 
             # Only create if this is the first row of data within the group
             if group_info is not prev_group_info:
-                group_label = group_info.defaulted_label()
+                # Fetch group label from _tbl_data
+                # since fmt functions have been applied at this point
+                rowgroup_var = data._boxhead._get_row_group_column()
+                cell_content: Any = _get_cell(tbl_data, i, rowgroup_var.var)
+                group_label: str = str(cell_content)
+
                 group_class = (
                     "gt_empty_group_heading" if group_label == "" else "gt_group_heading_row"
                 )

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -8,7 +8,7 @@ from htmltools import HTML, TagList, css, tags
 from . import _locations as loc
 from ._gt_data import GroupRowInfo, GTData, Styles
 from ._spanners import spanners_print_matrix
-from ._tbl_data import _get_cell, cast_frame_to_string, replace_null_frame
+from ._tbl_data import _get_cell, cast_frame_to_string, is_na, replace_null_frame
 from ._text import BaseText, _process_text, _process_text_id
 from ._utils import heading_has_subtitle, heading_has_title, seq_groups
 
@@ -478,11 +478,14 @@ def create_body_component_h(data: GTData) -> str:
 
             # Only create if this is the first row of data within the group
             if group_info is not prev_group_info:
-                # Fetch group label from _tbl_data
+                group_label = group_info.defaulted_label()
+
+                # If we have a group_label, fetch group label from _tbl_data
                 # since fmt functions have been applied at this point
-                rowgroup_var = data._boxhead._get_row_group_column()
-                cell_content: Any = _get_cell(tbl_data, i, rowgroup_var.var)
-                group_label: str = str(cell_content)
+                if not is_na(tbl_data, group_label):
+                    rowgroup_var = data._boxhead._get_row_group_column()
+                    cell_content: Any = _get_cell(tbl_data, i, rowgroup_var.var)
+                    group_label: str = str(cell_content)
 
                 group_class = (
                     "gt_empty_group_heading" if group_label == "" else "gt_group_heading_row"


### PR DESCRIPTION
# Summary

This PR ensures data for group labels in groupname_col are fetched from the formatted table values, rather than pure text. The example code in the linked issue now outputs:

<img width="498" height="779" alt="image" src="https://github.com/user-attachments/assets/264415b2-e832-44f6-a67e-084eced16888" />

One caveat is I don't know what the expected behavior should be with None/NA values in the groupname_col. This PR is specifically designed with the intention of not modifying the rendering of None/NA values.

# Related GitHub Issues and PRs

Closes #236 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ ] I have added **pytest** unit tests for any new functionality.
