### PR TITLE
fix: update Polars selector type annotation to use `Selector`

### DIFF
--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -20,13 +20,13 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
     # the class behind selectors
-    from polars.selectors import _selector_proxy_
+    from polars.selectors import Selector
 
     PdDataFrame = pd.DataFrame
     PlDataFrame = pl.DataFrame
     PyArrowTable = pa.Table
 
-    PlSelectExpr = _selector_proxy_
+    PlSelectExpr = Selector
     PlExpr = pl.Expr
 
     PdSeries = pd.Series


### PR DESCRIPTION
# Summary

This PR fixes a type annotation issue with Polars selectors.
Polars [introduced a new `Selector` class](https://github.com/pola-rs/polars/pull/23351). As a result, the current import of `_selector_proxy_` in `great-tables` fails when using at least version `1.32.0` of Polars.

Without this change, type-checking `great-tables` with recent Polars versions fails due to missing `_selector_proxy_`.

#### Changes

- Replaced `_selector_proxy_` with `Selector`
- Updated type alias: `PlSelectExpr = Selector`

#### Notes

- This is a type-checking only change; no runtime behavior is affected.
- Verified with latest Polars release where `Selector` is available.

# Related GitHub Issues and PRs

- https://github.com/pola-rs/polars/pull/23351

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- ~~[ ] I have added **pytest** unit tests for any new functionality.~~
