### PR TITLE
docs: add notice of 2025 Posit Table Contest in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!IMPORTANT]
+>
+> Consider submitting a beautiful table of your own making to the [**2025 Posit Table Contest**](https://github.com/rich-iannone/table-contest/discussions/2)! This is an annual celebration of beautiful display tables, aiming to highlight the creativity and technical prowess of our community. Entries will be judged and fabulous prizes will be doled out.
+>
+> The deadline is Friday, October 17, 2025 at midnight ([anywhere on earth](https://time.is/Anywhere_on_Earth)). Submit using the [2025 Table Contest submission form](https://github.com/rich-iannone/contest-submissions/discussions/new?category=2025-table-contest).
+
 <div align="center">
 
 <a href="https://posit-dev.github.io/great-tables/"><img src="https://posit-dev.github.io/great-tables/assets/GT_logo.svg" width="350px"/></a>


### PR DESCRIPTION
This PR adds a special notice to the top of the README. It lets readers know that the 2025 Posit Table Contest is underway and is accepting submissions.