### PR TITLE
docs: remove the 2025 Table Contest submission info callouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-> [!IMPORTANT]
->
-> Consider submitting a beautiful table of your own making to the [**2025 Posit Table Contest**](https://github.com/rich-iannone/table-contest/discussions/2)! This is an annual celebration of beautiful display tables, aiming to highlight the creativity and technical prowess of our community. Entries will be judged and fabulous prizes will be doled out.
->
-> The deadline is Friday, October 17, 2025 at midnight ([anywhere on earth](https://time.is/Anywhere_on_Earth)). Submit using the [2025 Table Contest submission form](https://github.com/rich-iannone/contest-submissions/discussions/new?category=2025-table-contest).
-
 <div align="center">
 
 <a href="https://posit-dev.github.io/great-tables/"><img src="https://posit-dev.github.io/great-tables/assets/GT_logo.svg" width="350px"/></a>

--- a/docs/articles/intro.qmd
+++ b/docs/articles/intro.qmd
@@ -6,14 +6,6 @@ sidebar: false
 html-table-processing: none
 ---
 
-::: {.callout-note}
-
-Consider submitting a beautiful table of your own making to the [**2025 Posit Table Contest**](https://github.com/rich-iannone/table-contest/discussions/2)! This is an annual celebration of beautiful display tables, aiming to highlight the creativity and technical prowess of our community. Entries will be judged and fabulous prizes will be doled out.
-
-The deadline is Friday, October 17, 2025 at midnight ([anywhere on earth](https://time.is/Anywhere_on_Earth)). Submit using the [2025 Table Contest submission form](https://github.com/rich-iannone/contest-submissions/discussions/new?category=2025-table-contest).
-
-:::
-
 <div style="text-align: center;">
 
 ![](/assets/GT_logo.svg){width=350}


### PR DESCRIPTION
Since the submission deadline of the 2025 contest has passed, these notices can be removed from the README and from the project website.