### PR TITLE
chore: refactor internals of `opt_all_caps()`

### DIFF
--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -972,8 +972,6 @@ def opt_all_caps(
     # Ensure that the `locations` value is a list of strings
     _utils._assert_str_list(locations)
 
-    # TODO: Ensure that all values within `locations` are valid
-
     # Define the style settings for each location when all_caps is enabled vs disabled
     # Each location has: (font_size, font_weight, text_transform)
     all_caps_styles = ("80%", "bolder", "uppercase")
@@ -983,32 +981,31 @@ def opt_all_caps(
         "row_group": ("100%", "initial", "inherit"),
     }
 
+    # Validate that all specified locations are valid
+    valid_locations = set(default_styles.keys())
+    invalid_locations = [loc for loc in locations if loc not in valid_locations]
+    if invalid_locations:
+        raise ValueError(
+            f"Invalid location(s): {invalid_locations}. "
+            f"Valid locations are: {sorted(valid_locations)}."
+        )
+
     res = self
 
-    if all_caps:
-        # Apply all caps styling only to specified locations
-        for loc in locations:
-            if loc in default_styles:
-                font_size, font_weight, text_transform = all_caps_styles
-                res = tab_options(
-                    res,
-                    **{
-                        f"{loc}_font_size": font_size,
-                        f"{loc}_font_weight": font_weight,
-                        f"{loc}_text_transform": text_transform,
-                    },
-                )
-    else:
-        # Reset all locations to their default values
-        for loc, (font_size, font_weight, text_transform) in default_styles.items():
-            res = tab_options(
-                res,
-                **{
-                    f"{loc}_font_size": font_size,
-                    f"{loc}_font_weight": font_weight,
-                    f"{loc}_text_transform": text_transform,
-                },
-            )
+    # Apply styling to specified locations
+    for loc in locations:
+        if all_caps:
+            font_size, font_weight, text_transform = all_caps_styles
+        else:
+            font_size, font_weight, text_transform = default_styles[loc]
+        res = tab_options(
+            res,
+            **{
+                f"{loc}_font_size": font_size,
+                f"{loc}_font_weight": font_weight,
+                f"{loc}_text_transform": text_transform,
+            },
+        )
 
     return res
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -550,3 +550,107 @@ def test_opt_horizontal_padding_raises(gt_tbl: GT, scale: float):
         gt_tbl.opt_horizontal_padding(scale=scale)
 
     assert "`scale` must be a value between `0` and `3`." in exc_info.value.args[0]
+
+
+# Tests for opt_all_caps()
+def test_opt_all_caps_default():
+    """Test opt_all_caps with default parameters (all_caps=True, all locations)."""
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    tbl = GT(df).opt_all_caps()
+
+    assert tbl._options.column_labels_font_size.value == "80%"
+    assert tbl._options.column_labels_font_weight.value == "bolder"
+    assert tbl._options.column_labels_text_transform.value == "uppercase"
+    assert tbl._options.stub_font_size.value == "80%"
+    assert tbl._options.stub_font_weight.value == "bolder"
+    assert tbl._options.stub_text_transform.value == "uppercase"
+    assert tbl._options.row_group_font_size.value == "80%"
+    assert tbl._options.row_group_font_weight.value == "bolder"
+    assert tbl._options.row_group_text_transform.value == "uppercase"
+
+
+def test_opt_all_caps_single_location():
+    """Test opt_all_caps with a single location as scalar string."""
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    tbl = GT(df).opt_all_caps(locations="stub")
+
+    # Stub should have all caps styling
+    assert tbl._options.stub_font_size.value == "80%"
+    assert tbl._options.stub_font_weight.value == "bolder"
+    assert tbl._options.stub_text_transform.value == "uppercase"
+    # Other locations should retain default values (not uppercase)
+    assert tbl._options.column_labels_text_transform.value == "inherit"
+    assert tbl._options.row_group_text_transform.value == "inherit"
+
+
+def test_opt_all_caps_multiple_locations():
+    """Test opt_all_caps with multiple locations as list."""
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    tbl = GT(df).opt_all_caps(locations=["column_labels", "row_group"])
+
+    # Specified locations should have all caps styling
+    assert tbl._options.column_labels_font_size.value == "80%"
+    assert tbl._options.column_labels_text_transform.value == "uppercase"
+    assert tbl._options.row_group_font_size.value == "80%"
+    assert tbl._options.row_group_text_transform.value == "uppercase"
+    # Stub should retain default values
+    assert tbl._options.stub_text_transform.value == "inherit"
+
+
+def test_opt_all_caps_false_resets_only_specified_locations():
+    """Test that all_caps=False only resets the specified locations."""
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    # First apply all caps to all locations
+    tbl = GT(df).opt_all_caps()
+
+    # Then reset only stub
+    tbl = tbl.opt_all_caps(locations="stub", all_caps=False)
+
+    # Stub should be reset to defaults
+    assert tbl._options.stub_font_size.value == "100%"
+    assert tbl._options.stub_font_weight.value == "initial"
+    assert tbl._options.stub_text_transform.value == "inherit"
+    # Other locations should still have all caps styling
+    assert tbl._options.column_labels_text_transform.value == "uppercase"
+    assert tbl._options.row_group_text_transform.value == "uppercase"
+
+
+def test_opt_all_caps_false_all_locations():
+    """Test that all_caps=False with all locations resets everything."""
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    # First apply all caps to all locations
+    tbl = GT(df).opt_all_caps()
+
+    # Then reset all locations
+    tbl = tbl.opt_all_caps(all_caps=False)
+
+    # All locations should be reset to defaults
+    assert tbl._options.column_labels_font_size.value == "100%"
+    assert tbl._options.column_labels_font_weight.value == "normal"
+    assert tbl._options.column_labels_text_transform.value == "inherit"
+    assert tbl._options.stub_font_size.value == "100%"
+    assert tbl._options.stub_font_weight.value == "initial"
+    assert tbl._options.stub_text_transform.value == "inherit"
+    assert tbl._options.row_group_font_size.value == "100%"
+    assert tbl._options.row_group_font_weight.value == "initial"
+    assert tbl._options.row_group_text_transform.value == "inherit"
+
+
+def test_opt_all_caps_invalid_location_raises():
+    """Test that invalid locations raise a ValueError."""
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    with pytest.raises(ValueError) as exc_info:
+        GT(df).opt_all_caps(locations="invalid_location")
+
+    assert "Invalid location(s)" in exc_info.value.args[0]
+    assert "invalid_location" in exc_info.value.args[0]
+
+
+def test_opt_all_caps_invalid_location_in_list_raises():
+    """Test that invalid locations in a list raise a ValueError."""
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    with pytest.raises(ValueError) as exc_info:
+        GT(df).opt_all_caps(locations=["column_labels", "bad_loc", "stub"])
+
+    assert "Invalid location(s)" in exc_info.value.args[0]
+    assert "bad_loc" in exc_info.value.args[0]


### PR DESCRIPTION
This PR simply refactors the `opt_all_caps()` method. The original code had many lines of repetitive `tab_options()` calls whereas the refactored version defines style settings in a data structure (along with iterating over locations instead of checking each one individually).