### PR TITLE
fix: prepend charset meta tag to HTML in save()

### DIFF
--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -449,7 +449,8 @@ def save(
         file = str(Path(file).with_suffix(".png"))
 
     # Get the HTML content from the displayed output
-    html_content = as_raw_html(self)
+    # Prepend utf-8 charset so the Chrome webdriver renders unicode correctly
+    html_content = "<meta charset='utf-8'>" + as_raw_html(self)
 
     wdriver = _get_web_driver(web_driver)
 


### PR DESCRIPTION
# Summary

Headless browsers (like Chrome) can misidentify the encoding of an HTML fragment and corrupt Unicode characters. 

Fix: Added a one-liner change as suggested by @rich-iannone, prepending raw html with  `<meta charset='utf-8'>` to make the webdriver recognize encoding and render characters correctly in the resulting image file.

# Related GitHub Issues and PRs

- Ref: #795 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.
       N/A - There was no test that would catch this beforehand and I wasn't sure testing 'when we prepend a string with another string, we should test that the prefix is there' warrants a new unit test. But if you think it does, let me know and I'll be happy to add it :)
