### PR TITLE
fix: update snapshots affected by updated `css_inline` library

### DIFF
--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -440,7 +440,7 @@ class GT(
 </style>
 {html_table}
 </div>
-        """
+"""
 
         if make_page:
             # Create an HTML page and place the table within it
@@ -453,7 +453,7 @@ class GT(
 {finalized_table}
 </body>
 </html>
-            """
+"""
         return finalized_table
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ all = [
 ]
 
 extra = [
-    "css-inline>=0.14.1",
+    "css-inline>=0.20.2,<0.21",
     "selenium>=4.18.1",
     "Pillow>=10.2.0",
 ]

--- a/tests/__snapshots__/test_export.ambr
+++ b/tests/__snapshots__/test_export.ambr
@@ -165,6 +165,7 @@
   </table>
   
   </div>
+  
   '''
 # ---
 # name: test_html_string_generated_inline_css_make_page

--- a/tests/__snapshots__/test_export.ambr
+++ b/tests/__snapshots__/test_export.ambr
@@ -135,7 +135,7 @@
   </table>
   
   </div>
-          
+  
   '''
 # ---
 # name: test_html_string_generated_inline_css
@@ -198,46 +198,13 @@
   </table>
   
   </div>
-          
   
   
-              </body></html>
+  
+  </body></html>
   '''
 # ---
 # name: test_snap_as_latex
-  '''
-  \begingroup
-  \setlength\LTleft{\dimexpr(0.5\linewidth - 225pt)}
-  \setlength\LTright{\dimexpr(0.5\linewidth - 225pt)}
-  \fontsize{9.0pt}{10.8pt}\selectfont
-  
-  \setlength{\LTpost}{0mm}
-  \begin{longtable}{@{\extracolsep{\fill}}llrrr}
-  \caption*{
-  {\large The \_title\_} \\
-  {\small The subtitle}
-  } \\
-  \toprule
-  \multicolumn{2}{c}{Make \_and\_ Model} & \multicolumn{2}{c}{Performance} &  \\ 
-  \cmidrule(lr){1-2} \cmidrule(lr){3-4}
-  mfr & model & hp & trq & msrp \\ 
-  \midrule\addlinespace[2.5pt]
-  Ford & GT & 647.0 & 550.0 & \$447,000.00 \\
-  Ferrari & 458 Speciale & 597.0 & 398.0 & \$291,744.00 \\
-  Ferrari & 458 Spider & 562.0 & 398.0 & \$263,553.00 \\
-  Ferrari & 458 Italia & 562.0 & 398.0 & \$233,509.00 \\
-  Ferrari & 488 GTB & 661.0 & 561.0 & \$245,400.00 \\
-  \bottomrule
-  \end{longtable}
-  \begin{minipage}{\linewidth}
-  Note 1\\
-  Note 2\\
-  \end{minipage}
-  \endgroup
-  
-  '''
-# ---
-# name: test_snap_render_as_latex
   '''
   \begingroup
   \setlength\LTleft{\dimexpr(0.5\linewidth - 225pt)}

--- a/tests/__snapshots__/test_repr.ambr
+++ b/tests/__snapshots__/test_repr.ambr
@@ -75,7 +75,7 @@
   </table>
   
   </div>
-          
+  
   '''
 # ---
 # name: test_repr_html_default
@@ -154,7 +154,7 @@
   </table>
   
   </div>
-          
+  
   '''
 # ---
 # name: test_repr_html_positron
@@ -239,10 +239,10 @@
   </table>
   
   </div>
-          
+  
   </body>
   </html>
-              
+  
   '''
 # ---
 # name: test_repr_html_quarto
@@ -321,7 +321,7 @@
   </table>
   
   </div>
-          
+  
   '''
 # ---
 # name: test_repr_html_vscode
@@ -400,6 +400,6 @@
   </table>
   
   </div>
-          
+  
   '''
 # ---

--- a/tests/__snapshots__/test_utils_render_html.ambr
+++ b/tests/__snapshots__/test_utils_render_html.ambr
@@ -100,7 +100,7 @@
   </table>
   
   </div>
-          
+  
   '''
 # ---
 # name: test_multiple_spanners_pads_for_stubhead_label


### PR DESCRIPTION
This PR is intended for fixing failing snapshot tests. The dependency library `css_inline` recently updated and now produces HTML with trailing whitespace.