### PR TITLE
test: add failing footnote target regressions

### DIFF
--- a/tests/test_footnotes.py
+++ b/tests/test_footnotes.py
@@ -167,6 +167,62 @@ def test_tab_footnote_all_locations():
     assert re.search(r"Test Subtitle<span[^>]*>2</span>", html)  # Subtitle
 
 
+def test_tab_footnote_row_group_target_gets_mark():
+    gt_table = _create_base_gt().tab_footnote(
+        footnote="Row group note", locations=loc.row_groups(rows=[0])
+    )
+
+    html = gt_table.as_raw_html()
+
+    assert "Row group note" in html
+    assert re.search(
+        r'<th class="gt_group_heading"[^>]*>A'
+        r'<span[^>]*class="gt_footnote_marks"[^>]*>1</span></th>',
+        html,
+    )
+
+
+def test_tab_footnote_grand_summary_target_gets_mark():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    gt_table = (
+        GT(df)
+        .grand_summary_rows(fns={"Average": lambda x: x.mean()})
+        .tab_footnote(
+            footnote="Grand summary note",
+            locations=loc.grand_summary(columns="a", rows=[0]),
+        )
+    )
+
+    html = gt_table.as_raw_html()
+
+    assert "Grand summary note" in html
+    assert re.search(
+        r'<td[^>]*class="[^"]*gt_grand_summary_row[^"]*"[^>]*>'
+        r'<span[^>]*class="gt_footnote_marks"[^>]*>1</span> 1\.5</td>',
+        html,
+    )
+
+
+def test_tab_footnote_spanner_target_uses_spanner_id_not_label():
+    df = pd.DataFrame({"a": [1], "b": [2]})
+    gt_table = (
+        GT(df)
+        .tab_spanner(label="Displayed Group", id="internal_id", columns=["a", "b"])
+        .tab_footnote(
+            footnote="Spanner note",
+            locations=loc.spanner_labels(ids=["internal_id"]),
+        )
+    )
+
+    html = gt_table.as_raw_html()
+
+    assert "Spanner note" in html
+    assert re.search(
+        r'Displayed Group<span[^>]*class="gt_footnote_marks"[^>]*>1</span>',
+        html,
+    )
+
+
 def test_tab_footnote_symbol_marks_standard():
     gt_table = (
         _create_base_gt()


### PR DESCRIPTION
Add regression coverage for footnote targets that currently produce footer entries without rendering a corresponding mark at the target location.

The new tests cover three public API cases:

- row group footnotes created with loc.row_groups(), where the footer note is present but the row group heading does not receive a footnote mark
- grand summary body footnotes created with loc.grand_summary(), where the footer note is present but the targeted grand summary cell does not receive a footnote mark
- spanner footnotes created with loc.spanner_labels(ids=...) when the spanner id differs from the displayed label, where lookup currently misses the target because rendering matches against label text instead of the spanner id

These tests document the expected rendered HTML behavior and should pass once footnote marks are applied to all supported target locations and spanner footnote matching uses stable spanner ids.