### PR TITLE
feat: add specialized `cols_merge_*()` methods

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -179,6 +179,9 @@ quartodoc:
         - GT.cols_hide
         - GT.cols_unhide
         - GT.cols_merge
+        - GT.cols_merge_uncert
+        - GT.cols_merge_range
+        - GT.cols_merge_n_pct
     - title: Adding rows
       desc: >
         The [`grand_summary_rows()`](`great_tables.GT.grand_summary_rows`) function will add rows to

--- a/great_tables/_cols_merge.py
+++ b/great_tables/_cols_merge.py
@@ -51,6 +51,7 @@ class ColMergeInfo:
     rows: list[int]
     type: str
     pattern: str
+    sep: str = ""
 
     @property
     def pattern_columns(self) -> list[str]:
@@ -321,13 +322,15 @@ def _apply_single_col_merge(
     Body
         The modified body data.
     """
-    if col_merge.type != "merge":
+    supported_types = ("merge", "merge_uncert", "merge_range", "merge_n_pct")
+    if col_merge.type not in supported_types:
         raise NotImplementedError(
             f"Column merge type {col_merge.type!r} is not supported. "
-            f"Only 'merge' is currently implemented."
+            f"Supported types are: {supported_types}."
         )
 
-    col_merge.validate_pattern()
+    if col_merge.type == "merge":
+        col_merge.validate_pattern()
 
     target_column = col_merge.vars[0]
 
@@ -355,7 +358,17 @@ def _apply_single_col_merge(
                 # Body has a value (possibly from sub_missing or formatting)
                 values.append(str(formatted_value))
 
-        merged_value = col_merge.merge(*values)
+        # Dispatch to the appropriate merge strategy
+        if col_merge.type == "merge":
+            merged_value = col_merge.merge(*values)
+        elif col_merge.type == "merge_uncert":
+            merged_value = _merge_uncert(values, col_merge.sep)
+        elif col_merge.type == "merge_range":
+            merged_value = _merge_range(values, col_merge.sep)
+        elif col_merge.type == "merge_n_pct":
+            merged_value = _merge_n_pct(values, tbl_data, col_merge.vars, row_idx)
+        else:
+            merged_value = col_merge.merge(*values)
 
         result = _set_cell(body.body, row_idx, target_column, merged_value)
 
@@ -365,3 +378,93 @@ def _apply_single_col_merge(
             body.body = result
 
     return body
+
+
+def _merge_uncert(values: list[Any], sep: str) -> str:
+    """Apply uncertainty merge semantics.
+
+    NA handling:
+    - NA in col_val -> result is NA
+    - NA in col_uncert (but not col_val) -> show only col_val
+    - NA in both -> result is NA
+    - For asymmetric (3 columns): val (+upper/−lower)
+    """
+    col_val = values[0]
+
+    # If the base value is missing, the result is always missing
+    if col_val is None:
+        return ""
+
+    if len(values) == 2:
+        # Symmetric uncertainty: val ± uncert
+        col_uncert = values[1]
+        if col_uncert is None:
+            return str(col_val)
+        return f"{col_val}{sep}{col_uncert}"
+    else:
+        # Asymmetric uncertainty: val (+upper/−lower)
+        col_lower = values[1]
+        col_upper = values[2] if len(values) > 2 else None
+
+        if col_lower is None and col_upper is None:
+            return str(col_val)
+        elif col_lower is None:
+            return f"{col_val} (+{col_upper})"
+        elif col_upper is None:
+            return f"{col_val} (\u2212{col_lower})"
+        elif str(col_lower) == str(col_upper):
+            # When lower == upper, use symmetric format
+            return f"{col_val}{sep}{col_lower}"
+        else:
+            return f"{col_val} (+{col_upper}/\u2212{col_lower})"
+
+
+def _merge_range(values: list[Any], sep: str) -> str:
+    """Apply range merge semantics.
+
+    NA handling:
+    - NA in col_begin (but not col_end) -> show only col_end
+    - NA in col_end (but not col_begin) -> show only col_begin
+    - NA in both -> result is NA
+    """
+    col_begin = values[0]
+    col_end = values[1]
+
+    if col_begin is None and col_end is None:
+        return ""
+    elif col_begin is None:
+        return str(col_end)
+    elif col_end is None:
+        return str(col_begin)
+    else:
+        return f"{col_begin}{sep}{col_end}"
+
+
+def _merge_n_pct(values: list[Any], tbl_data: TblData, vars: list[str], row_idx: int) -> str:
+    """Apply count-and-percentage merge semantics.
+
+    NA handling:
+    - NA in col_n -> result is NA
+    - NA in col_pct (but not col_n) -> show only col_n
+    - NA in both -> result is NA
+    - Zero in col_n (original value) -> show only "0" (no percentage)
+    """
+    col_n = values[0]
+    col_pct = values[1]
+
+    # If the count is missing, the result is always missing
+    if col_n is None:
+        return ""
+
+    # Check if the original value of col_n is zero
+    original_n = _get_cell(tbl_data, row_idx, vars[0])
+    try:
+        if float(original_n) == 0:
+            return str(col_n)
+    except (TypeError, ValueError):
+        pass
+
+    if col_pct is None:
+        return str(col_n)
+
+    return f"{col_n} ({col_pct})"

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -1211,6 +1211,442 @@ def cols_merge(
     return result._replace(_col_merge=[*result._col_merge, col_merge_entry])
 
 
+def cols_merge_uncert(
+    self: GTSelf,
+    col_val: SelectExpr,
+    col_uncert: SelectExpr,
+    rows: int | list[int] | None = None,
+    sep: str = " +/- ",
+    autohide: bool = True,
+) -> GTSelf:
+    """Merge columns to a value-with-uncertainty column.
+
+    `cols_merge_uncert()` is a specialized variant of `cols_merge()`. It takes as input a base
+    value column (`col_val`) and either: (1) a single uncertainty column, or (2) two columns
+    representing lower and upper uncertainty bounds. These columns will be essentially merged into a
+    single column (that of `col_val`). What results is a column with values and associated
+    uncertainties, and any columns specified in `col_uncert` are hidden from appearing in the output
+    table.
+
+    Parameters
+    ----------
+    col_val
+        The column that contains values for the base measurement. While column selection
+        expressions can be used, it's recommended that a single column name be used to ensure that
+        exactly one column is provided here.
+    col_uncert
+        The column or columns that contain uncertainty values. The most common case involves
+        supplying a single column with uncertainties; these values will be combined with those in
+        `col_val`. Less commonly, the lower and upper uncertainty bounds may be different. For that
+        case, two columns representing the lower and upper uncertainty values away from `col_val`,
+        respectively, should be provided as a list.
+    rows
+        In conjunction with `col_val`, we can specify which rows should participate in the merging
+        process. The default is all rows. Alternatively, we can supply a list of row indices.
+    sep
+        The separator text that contains the uncertainty mark for a single uncertainty value. The
+        default value of `" +/- "` indicates that an appropriate plus/minus mark will be used
+        depending on the output context. The plus/minus symbol (±) is used in HTML output.
+    autohide
+        An option to automatically hide any columns specified in `col_uncert`. Any columns with
+        their state changed to hidden will behave the same as before, they just won't be displayed
+        in the finalized table. Defaults to `True`.
+
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+
+    Details
+    -------
+    ### Specialized NA handling
+
+    This function employs specialized semantics for missing value handling that differ from the
+    generic `cols_merge()`:
+
+    1. Missing values in `col_val` result in missing values for the merged column (e.g.,
+       `NA` + `0.1` = `NA`)
+    2. Missing values in `col_uncert` (but not `col_val`) result in base values only for the
+       merged column (e.g., `12.0` + `NA` = `12.0`)
+    3. Missing values in both `col_val` and `col_uncert` result in missing values for the merged
+       column (e.g., `NA` + `NA` = `NA`)
+
+    Examples
+    --------
+    Use the `exibble` dataset to create a simple, two-column table. Merge the `currency` and `num`
+    columns together as a value with uncertainty.
+
+    ```{python}
+    from great_tables import GT
+    from great_tables.data import exibble
+    import polars as pl
+
+    exibble_mini = (
+        pl.from_pandas(exibble)
+        .select("num", "currency")
+        .slice(0, 7)
+    )
+
+    (
+        GT(exibble_mini)
+        .fmt_number(columns="num", decimals=3, use_seps=False)
+        .cols_merge_uncert(col_val="currency", col_uncert="num")
+        .cols_label(currency="value + uncert.")
+    )
+    ```
+
+    When there are missing values in the uncertainty column, the merged result shows only the base
+    value. When the base value itself is missing, the entire merged cell is empty.
+
+    ```{python}
+    df = pl.DataFrame({
+        "measurement": [12.5, 8.3, 15.0, 9.7],
+        "error": [0.2, None, 0.5, None],
+    })
+
+    (
+        GT(df)
+        .fmt_number(columns="error", decimals=2)
+        .cols_merge_uncert(col_val="measurement", col_uncert="error")
+        .cols_label(measurement="Measurement")
+    )
+    ```
+    """
+    # Resolve the col_val column
+    col_val_resolved = resolve_cols_c(data=self, expr=col_val)
+    if len(col_val_resolved) != 1:
+        raise ValueError(
+            f"Column `col_val` must resolve to exactly one column, got {len(col_val_resolved)}."
+        )
+
+    # Resolve the col_uncert column(s)
+    col_uncert_resolved = resolve_cols_c(data=self, expr=col_uncert)
+    if len(col_uncert_resolved) < 1 or len(col_uncert_resolved) > 2:
+        raise ValueError(
+            f"Column `col_uncert` must resolve to one or two columns, "
+            f"got {len(col_uncert_resolved)}."
+        )
+
+    # Build the full column list: [col_val, col_uncert_1, (col_uncert_2)]
+    columns_resolved = col_val_resolved + col_uncert_resolved
+
+    # Resolve rows
+    row_res = resolve_rows_i(self, rows)
+    row_pos = [name_pos[1] for name_pos in row_res]
+
+    # Process the separator: convert " +/- " to the ± symbol for display
+    if sep == " +/- ":
+        display_sep = " \u00b1 "
+    else:
+        display_sep = sep
+
+    # Hide the uncertainty column(s) if autohide is True
+    result = self
+    if autohide:
+        result = cols_hide(result, columns=col_uncert_resolved)
+
+    # Create column merge entry
+    col_merge_entry = ColMergeInfo(
+        vars=columns_resolved,
+        rows=row_pos,
+        type="merge_uncert",
+        pattern="",
+        sep=display_sep,
+    )
+
+    return result._replace(_col_merge=[*result._col_merge, col_merge_entry])
+
+
+def cols_merge_range(
+    self: GTSelf,
+    col_begin: SelectExpr,
+    col_end: SelectExpr,
+    rows: int | list[int] | None = None,
+    sep: str | None = None,
+    autohide: bool = True,
+    locale: str | None = None,
+) -> GTSelf:
+    """Merge two columns to a value range column.
+
+    `cols_merge_range()` is a specialized variant of `cols_merge()`. It operates by taking two
+    columns that constitute a range of values (`col_begin` and `col_end`) and merges them into a
+    single column. What results is a column containing both values separated by an en dash (or a
+    custom separator). The column specified in `col_end` is dropped from the output table.
+
+    Parameters
+    ----------
+    col_begin
+        The column that contains values for the start of the range. While column selection
+        expressions can be used, it's recommended that a single column name be used to ensure that
+        exactly one column is provided here.
+    col_end
+        The column that contains values for the end of the range. While column selection
+        expressions can be used, it's recommended that a single column name be used to ensure that
+        exactly one column is provided here.
+    rows
+        In conjunction with `col_begin`, we can specify which rows should participate in the
+        merging process. The default is all rows. Alternatively, we can supply a list of row
+        indices.
+    sep
+        The separator text that indicates the values are ranged. If not provided, an en dash
+        (`"–"`) will be used. You can use `"--"` for an en dash or `"---"` for an em dash.
+    autohide
+        An option to automatically hide the column specified as `col_end`. Any columns with their
+        state changed to hidden will behave the same as before, they just won't be displayed in
+        the finalized table. Defaults to `True`.
+    locale
+        An optional locale identifier that can be used for applying a separator pattern specific to
+        a locale's rules. Currently reserved for future use.
+
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+
+    Details
+    -------
+    ### Specialized NA handling
+
+    This function employs specialized semantics for missing value handling that differ from the
+    generic `cols_merge()`:
+
+    1. Missing values in `col_begin` (but not `col_end`) result in a display of only the
+       `col_end` value
+    2. Missing values in `col_end` (but not `col_begin`) result in a display of only the
+       `col_begin` value
+    3. Missing values in both `col_begin` and `col_end` result in missing values for the merged
+       column
+
+    Examples
+    --------
+    Use a subset of the `gtcars` dataset to create a table. Merge the `mpg_c` and `mpg_h` columns
+    together as a range.
+
+    ```{python}
+    from great_tables import GT
+    from great_tables.data import gtcars
+    import polars as pl
+
+    gtcars_mini = (
+        pl.from_pandas(gtcars)
+        .select("model", "mpg_c", "mpg_h")
+        .slice(0, 8)
+    )
+
+    (
+        GT(gtcars_mini)
+        .cols_merge_range(col_begin="mpg_c", col_end="mpg_h")
+        .cols_label(mpg_c="MPG")
+    )
+    ```
+
+    When there are missing values, the merged result gracefully degrades: if only one side is
+    missing, the other value is shown alone (without a separator). A custom separator can be
+    provided via the `sep=` argument.
+
+    ```{python}
+    df = pl.DataFrame({
+        "city": ["NYC", "LA", "CHI", "HOU"],
+        "temp_low": [28, 55, None, 45],
+        "temp_high": [35, None, 50, 60],
+    })
+
+    (
+        GT(df)
+        .cols_merge_range(col_begin="temp_low", col_end="temp_high", sep=" to ")
+        .cols_label(temp_low="Temp. Range (°F)")
+    )
+    ```
+    """
+    # Resolve the col_begin column
+    col_begin_resolved = resolve_cols_c(data=self, expr=col_begin)
+    if len(col_begin_resolved) != 1:
+        raise ValueError(
+            f"Column `col_begin` must resolve to exactly one column, "
+            f"got {len(col_begin_resolved)}."
+        )
+
+    # Resolve the col_end column
+    col_end_resolved = resolve_cols_c(data=self, expr=col_end)
+    if len(col_end_resolved) != 1:
+        raise ValueError(
+            f"Column `col_end` must resolve to exactly one column, " f"got {len(col_end_resolved)}."
+        )
+
+    # Build the full column list
+    columns_resolved = col_begin_resolved + col_end_resolved
+
+    # Resolve rows
+    row_res = resolve_rows_i(self, rows)
+    row_pos = [name_pos[1] for name_pos in row_res]
+
+    # Process separator
+    if sep is None:
+        display_sep = "\u2013"
+    elif sep == "--":
+        display_sep = "\u2013"
+    elif sep == "---":
+        display_sep = "\u2014"
+    else:
+        display_sep = sep
+
+    # Hide the end column if autohide is True
+    result = self
+    if autohide:
+        result = cols_hide(result, columns=col_end_resolved)
+
+    # Create column merge entry
+    col_merge_entry = ColMergeInfo(
+        vars=columns_resolved,
+        rows=row_pos,
+        type="merge_range",
+        pattern="",
+        sep=display_sep,
+    )
+
+    return result._replace(_col_merge=[*result._col_merge, col_merge_entry])
+
+
+def cols_merge_n_pct(
+    self: GTSelf,
+    col_n: SelectExpr,
+    col_pct: SelectExpr,
+    rows: int | list[int] | None = None,
+    autohide: bool = True,
+) -> GTSelf:
+    """Merge two columns to combine counts and percentages.
+
+    `cols_merge_n_pct()` is a specialized variant of `cols_merge()`. It operates by taking two
+    columns that constitute both a count (`col_n`) and a fraction of the total population
+    (`col_pct`) and merges them into a single column. What results is a column containing both
+    counts and their associated percentages (e.g., `12 (23.2%)`). The column specified in
+    `col_pct` is dropped from the output table.
+
+    Parameters
+    ----------
+    col_n
+        The column that contains values for the count component. While column selection expressions
+        can be used, it's recommended that a single column name be used to ensure that exactly one
+        column is provided here.
+    col_pct
+        The column that contains values for the percentage component. While column selection
+        expressions can be used, it's recommended that a single column name be used to ensure that
+        exactly one column is provided here. This column should be formatted such that percentages
+        are displayed (e.g., with `fmt_percent()`).
+    rows
+        In conjunction with `col_n`, we can specify which rows should participate in the merging
+        process. The default is all rows. Alternatively, we can supply a list of row indices.
+    autohide
+        An option to automatically hide the column specified as `col_pct`. Any columns with their
+        state changed to hidden will behave the same as before, they just won't be displayed in
+        the finalized table. Defaults to `True`.
+
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+
+    Details
+    -------
+    ### Specialized NA and zero-value handling
+
+    This function employs specialized semantics for missing value and zero-value handling:
+
+    1. Missing values in `col_n` result in missing values for the merged column (e.g.,
+       `NA` + `10.2%` = `NA`)
+    2. Missing values in `col_pct` (but not `col_n`) result in base values only for the merged
+       column (e.g., `13` + `NA` = `13`)
+    3. Missing values in both `col_n` and `col_pct` result in missing values for the merged
+       column (e.g., `NA` + `NA` = `NA`)
+    4. If a zero (`0`) value is in `col_n` then the formatted output will be `"0"` (i.e., no
+       percentage will be shown)
+
+    It is the responsibility of the user to ensure that values are correct in both the `col_n` and
+    `col_pct` columns (this function neither generates nor recalculates values in either).
+    Formatting of each column can be done independently in separate `fmt_number()` and
+    `fmt_percent()` calls.
+
+    Examples
+    --------
+    Create a simple table with counts and percentages, then merge them.
+
+    ```{python}
+    from great_tables import GT
+    import polars as pl
+
+    df = pl.DataFrame({
+        "category": ["A", "B", "C"],
+        "n": [10, 20, 30],
+        "pct": [0.167, 0.333, 0.500],
+    })
+
+    (
+        GT(df)
+        .fmt_percent(columns="pct")
+        .cols_merge_n_pct(col_n="n", col_pct="pct")
+        .cols_label(n="Count (%)")
+    )
+    ```
+
+    Zero values in the count column suppress the percentage display. Missing values in the
+    percentage column result in just the count being shown, and missing counts produce empty cells.
+
+    ```{python}
+    df = pl.DataFrame({
+        "item": ["Alpha", "Beta", "Gamma", "Delta"],
+        "count": [15, 0, 8, None],
+        "frac": [0.375, 0.0, None, 0.125],
+    })
+
+    (
+        GT(df)
+        .fmt_percent(columns="frac", decimals=1)
+        .cols_merge_n_pct(col_n="count", col_pct="frac")
+        .cols_label(count="N (%)")
+    )
+    ```
+    """
+    # Resolve the col_n column
+    col_n_resolved = resolve_cols_c(data=self, expr=col_n)
+    if len(col_n_resolved) != 1:
+        raise ValueError(
+            f"Column `col_n` must resolve to exactly one column, got {len(col_n_resolved)}."
+        )
+
+    # Resolve the col_pct column
+    col_pct_resolved = resolve_cols_c(data=self, expr=col_pct)
+    if len(col_pct_resolved) != 1:
+        raise ValueError(
+            f"Column `col_pct` must resolve to exactly one column, got {len(col_pct_resolved)}."
+        )
+
+    # Build the full column list
+    columns_resolved = col_n_resolved + col_pct_resolved
+
+    # Resolve rows
+    row_res = resolve_rows_i(self, rows)
+    row_pos = [name_pos[1] for name_pos in row_res]
+
+    # Hide the percentage column if autohide is True
+    result = self
+    if autohide:
+        result = cols_hide(result, columns=col_pct_resolved)
+
+    # Create column merge entry
+    col_merge_entry = ColMergeInfo(
+        vars=columns_resolved,
+        rows=row_pos,
+        type="merge_n_pct",
+        pattern="",
+        sep="",
+    )
+
+    return result._replace(_col_merge=[*result._col_merge, col_merge_entry])
+
+
 def cols_reorder(self: GTSelf, columns: SelectExpr) -> GTSelf:
     """Reorder all columns in a specified order.
 

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -57,6 +57,9 @@ from ._source_notes import tab_source_note
 from ._spanners import (
     cols_hide,
     cols_merge,
+    cols_merge_n_pct,
+    cols_merge_range,
+    cols_merge_uncert,
     cols_move,
     cols_move_to_end,
     cols_move_to_start,
@@ -269,6 +272,9 @@ class GT(
     cols_label = cols_label
     cols_label_with = cols_label_with
     cols_merge = cols_merge
+    cols_merge_uncert = cols_merge_uncert
+    cols_merge_range = cols_merge_range
+    cols_merge_n_pct = cols_merge_n_pct
     cols_move = cols_move
     cols_move_to_start = cols_move_to_start
     cols_move_to_end = cols_move_to_end

--- a/tests/test_cols_merge.py
+++ b/tests/test_cols_merge.py
@@ -434,3 +434,547 @@ class TestColsMergeIntegration:
 
         assert "1 (10)" in html or "1(10)" in html
         assert "2<" in html  # The < is from the closing tag, not from the pattern
+
+
+# =============================================================================
+# Tests for cols_merge_uncert
+# =============================================================================
+
+
+class TestColsMergeUncert:
+    """Tests for the cols_merge_uncert() method."""
+
+    def test_basic_symmetric(self):
+        """Test basic symmetric uncertainty merge."""
+        df = pd.DataFrame({"val": [10.0, 20.0, 30.0], "uncert": [0.5, 1.0, 1.5]})
+
+        gt = GT(df).cols_merge_uncert(col_val="val", col_uncert="uncert")
+
+        assert len(gt._col_merge) == 1
+        assert gt._col_merge[0].type == "merge_uncert"
+        assert gt._col_merge[0].vars == ["val", "uncert"]
+
+        html = gt.as_raw_html()
+        # Should contain the ± symbol
+        assert "10.0 \u00b1 0.5" in html
+        assert "20.0 \u00b1 1.0" in html
+        assert "30.0 \u00b1 1.5" in html
+
+    def test_na_in_val(self):
+        """Test that NA in col_val produces empty merged value."""
+        df = pl.DataFrame({"val": [10.0, None, 30.0], "uncert": [0.5, 1.0, 1.5]})
+
+        gt = GT(df).cols_merge_uncert(col_val="val", col_uncert="uncert")
+        html = gt.as_raw_html()
+
+        # First and third rows should have merged values
+        assert "10.0 \u00b1 0.5" in html
+        assert "30.0 \u00b1 1.5" in html
+
+    def test_na_in_uncert(self):
+        """Test that NA in col_uncert shows only the base value."""
+        df = pl.DataFrame({"val": [10.0, 20.0, 30.0], "uncert": [0.5, None, 1.5]})
+
+        gt = GT(df).cols_merge_uncert(col_val="val", col_uncert="uncert")
+        html = gt.as_raw_html()
+
+        # Second row: only base value (no ± symbol)
+        assert "10.0 \u00b1 0.5" in html
+        assert "30.0 \u00b1 1.5" in html
+        # 20.0 should appear without ± symbol
+        assert "20.0 \u00b1" not in html.replace("10.0 \u00b1 0.5", "").replace(
+            "30.0 \u00b1 1.5", ""
+        )
+
+    def test_custom_sep(self):
+        """Test custom separator."""
+        df = pd.DataFrame({"val": [10.0, 20.0], "uncert": [0.5, 1.0]})
+
+        gt = GT(df).cols_merge_uncert(col_val="val", col_uncert="uncert", sep=" ~ ")
+        html = gt.as_raw_html()
+
+        assert "10.0 ~ 0.5" in html
+        assert "20.0 ~ 1.0" in html
+
+    def test_autohide_true(self):
+        """Test that col_uncert is hidden by default."""
+        df = pd.DataFrame({"val": [10.0], "uncert": [0.5]})
+
+        gt = GT(df).cols_merge_uncert(col_val="val", col_uncert="uncert")
+        html = gt.as_raw_html()
+
+        # "uncert" column header should not appear
+        assert ">uncert<" not in html
+
+    def test_autohide_false(self):
+        """Test that col_uncert remains visible when autohide=False."""
+        df = pd.DataFrame({"val": [10.0], "uncert": [0.5]})
+
+        gt = GT(df).cols_merge_uncert(col_val="val", col_uncert="uncert", autohide=False)
+        html = gt.as_raw_html()
+
+        # "uncert" column header should appear
+        assert "uncert" in html
+
+    def test_asymmetric_uncertainty(self):
+        """Test asymmetric uncertainty with two uncertainty columns."""
+        df = pd.DataFrame({"val": [10.0, 20.0], "lower": [0.3, 0.6], "upper": [0.5, 1.0]})
+
+        gt = GT(df).cols_merge_uncert(col_val="val", col_uncert=["lower", "upper"])
+
+        assert gt._col_merge[0].vars == ["val", "lower", "upper"]
+        html = gt.as_raw_html()
+
+        # Should contain asymmetric format
+        assert "+0.5" in html or "+1.0" in html
+
+    def test_with_polars(self):
+        """Test with Polars DataFrame."""
+        df = pl.DataFrame({"val": [10.0, 20.0, 30.0], "uncert": [0.5, 1.0, 1.5]})
+
+        gt = GT(df).cols_merge_uncert(col_val="val", col_uncert="uncert")
+        html = gt.as_raw_html()
+
+        assert "10.0 \u00b1 0.5" in html
+
+    def test_invalid_col_val(self):
+        """Test that multiple columns for col_val raises error."""
+        df = pd.DataFrame({"a": [1], "b": [2], "c": [3]})
+
+        with pytest.raises(ValueError, match="exactly one column"):
+            GT(df).cols_merge_uncert(col_val=["a", "b"], col_uncert="c")
+
+    def test_with_rows(self):
+        """Test with specific rows selected."""
+        df = pd.DataFrame({"val": [10.0, 20.0, 30.0], "uncert": [0.5, 1.0, 1.5]})
+
+        gt = GT(df).cols_merge_uncert(col_val="val", col_uncert="uncert", rows=[0, 2])
+        html = gt.as_raw_html()
+
+        # Only rows 0 and 2 should be merged
+        assert "10.0 \u00b1 0.5" in html
+        assert "30.0 \u00b1 1.5" in html
+
+    def test_chaining_two_uncert_merges(self):
+        """Test applying cols_merge_uncert twice on different column pairs."""
+        df = pl.DataFrame(
+            {"val1": [10.0, 20.0], "unc1": [0.5, 1.0], "val2": [30.0, 40.0], "unc2": [1.5, 2.0]}
+        )
+
+        gt = (
+            GT(df)
+            .cols_merge_uncert(col_val="val1", col_uncert="unc1")
+            .cols_merge_uncert(col_val="val2", col_uncert="unc2")
+        )
+
+        assert len(gt._col_merge) == 2
+        assert gt._col_merge[0].vars == ["val1", "unc1"]
+        assert gt._col_merge[1].vars == ["val2", "unc2"]
+
+        html = gt.as_raw_html()
+        assert "10.0 \u00b1 0.5" in html
+        assert "30.0 \u00b1 1.5" in html
+
+    def test_asymmetric_all_na_combinations(self):
+        """Test asymmetric uncertainty with all NA combinations (matches R gt behavior)."""
+        df = pl.DataFrame(
+            {
+                "value": [34.5, 29.2, 36.3, 31.6, 28.5, 30.9, None, None],
+                "lu": [2.1, 2.4, 2.6, 1.8, None, None, 1.2, None],
+                "uu": [1.8, 2.7, 2.6, None, 1.6, None, None, None],
+            }
+        )
+
+        gt = GT(df).cols_merge_uncert(col_val="value", col_uncert=["lu", "uu"])
+        html = gt.as_raw_html()
+
+        # Row 1: both bounds present, asymmetric → val (+upper/−lower)
+        assert "+1.8" in html
+        assert "\u22122.1" in html  # minus sign
+
+        # Row 3: symmetric (lower == upper == 2.6) → val ± uncert
+        assert "36.3 \u00b1 2.6" in html
+
+        # Row 4: upper is NA → val (−lower)
+        assert "\u22121.8" in html
+
+        # Row 5: lower is NA → val (+upper)
+        assert "+1.6" in html
+
+        # Row 6: both bounds NA but val present → just val
+        assert "30.9" in html
+
+        # Row 7 & 8: val is NA → empty (nothing meaningful rendered)
+
+    def test_symmetric_when_bounds_equal(self):
+        """Test that when lower == upper, symmetric format (±) is used."""
+        df = pl.DataFrame({"val": [100.0], "lower": [2.5], "upper": [2.5]})
+
+        gt = GT(df).cols_merge_uncert(col_val="val", col_uncert=["lower", "upper"])
+        html = gt.as_raw_html()
+
+        assert "100.0 \u00b1 2.5" in html
+
+
+# =============================================================================
+# Tests for cols_merge_range
+# =============================================================================
+
+
+class TestColsMergeRange:
+    """Tests for the cols_merge_range() method."""
+
+    def test_basic(self):
+        """Test basic range merge with en dash."""
+        df = pd.DataFrame({"low": [10, 20, 30], "high": [15, 25, 35]})
+
+        gt = GT(df).cols_merge_range(col_begin="low", col_end="high")
+
+        assert len(gt._col_merge) == 1
+        assert gt._col_merge[0].type == "merge_range"
+        assert gt._col_merge[0].vars == ["low", "high"]
+
+        html = gt.as_raw_html()
+        # Should contain en dash
+        assert "10\u201315" in html
+        assert "20\u201325" in html
+        assert "30\u201335" in html
+
+    def test_na_in_begin(self):
+        """Test that NA in col_begin shows only col_end value."""
+        df = pl.DataFrame({"low": [10, None, 30], "high": [15, 25, 35]})
+
+        gt = GT(df).cols_merge_range(col_begin="low", col_end="high")
+        html = gt.as_raw_html()
+
+        # Second row should show only the end value
+        assert "10\u201315" in html
+        assert "30\u201335" in html
+        # "25" should appear alone (not as part of a range)
+        assert "25" in html
+
+    def test_na_in_end(self):
+        """Test that NA in col_end shows only col_begin value."""
+        df = pl.DataFrame({"low": [10, 20, 30], "high": [15, None, 35]})
+
+        gt = GT(df).cols_merge_range(col_begin="low", col_end="high")
+        html = gt.as_raw_html()
+
+        assert "10\u201315" in html
+        assert "30\u201335" in html
+        # "20" should appear alone
+        assert "20" in html
+
+    def test_na_in_both(self):
+        """Test that NA in both columns produces empty result."""
+        df = pl.DataFrame({"low": [10, None, 30], "high": [15, None, 35]})
+
+        gt = GT(df).cols_merge_range(col_begin="low", col_end="high")
+        html = gt.as_raw_html()
+
+        assert "10\u201315" in html
+        assert "30\u201335" in html
+
+    def test_custom_sep(self):
+        """Test custom separator."""
+        df = pd.DataFrame({"low": [10, 20], "high": [15, 25]})
+
+        gt = GT(df).cols_merge_range(col_begin="low", col_end="high", sep=" to ")
+        html = gt.as_raw_html()
+
+        assert "10 to 15" in html
+        assert "20 to 25" in html
+
+    def test_sep_en_dash(self):
+        """Test that '--' is converted to en dash."""
+        df = pd.DataFrame({"low": [10], "high": [15]})
+
+        gt = GT(df).cols_merge_range(col_begin="low", col_end="high", sep="--")
+        html = gt.as_raw_html()
+
+        assert "10\u201315" in html
+
+    def test_sep_em_dash(self):
+        """Test that '---' is converted to em dash."""
+        df = pd.DataFrame({"low": [10], "high": [15]})
+
+        gt = GT(df).cols_merge_range(col_begin="low", col_end="high", sep="---")
+        html = gt.as_raw_html()
+
+        assert "10\u201415" in html
+
+    def test_autohide_true(self):
+        """Test that col_end is hidden by default."""
+        df = pd.DataFrame({"low": [10], "high": [15]})
+
+        gt = GT(df).cols_merge_range(col_begin="low", col_end="high")
+        html = gt.as_raw_html()
+
+        # "high" column header should not appear
+        assert ">high<" not in html
+
+    def test_autohide_false(self):
+        """Test that col_end remains visible when autohide=False."""
+        df = pd.DataFrame({"low": [10], "high": [15]})
+
+        gt = GT(df).cols_merge_range(col_begin="low", col_end="high", autohide=False)
+        html = gt.as_raw_html()
+
+        # "high" column header should appear
+        assert "high" in html
+
+    def test_with_polars(self):
+        """Test with Polars DataFrame."""
+        df = pl.DataFrame({"low": [10, 20, 30], "high": [15, 25, 35]})
+
+        gt = GT(df).cols_merge_range(col_begin="low", col_end="high")
+        html = gt.as_raw_html()
+
+        assert "10\u201315" in html
+
+    def test_invalid_col_begin(self):
+        """Test that multiple columns for col_begin raises error."""
+        df = pd.DataFrame({"a": [1], "b": [2], "c": [3]})
+
+        with pytest.raises(ValueError, match="exactly one column"):
+            GT(df).cols_merge_range(col_begin=["a", "b"], col_end="c")
+
+    def test_with_formatted_values(self):
+        """Test that formatting is preserved."""
+        df = pl.DataFrame({"mpg_c": [16.0, 18.5], "mpg_h": [20.0, 22.5]})
+
+        gt = (
+            GT(df)
+            .fmt_number(columns=["mpg_c", "mpg_h"], decimals=1)
+            .cols_merge_range(col_begin="mpg_c", col_end="mpg_h")
+        )
+        html = gt.as_raw_html()
+
+        assert "16.0\u201320.0" in html
+        assert "18.5\u201322.5" in html
+
+    def test_chaining_two_range_merges(self):
+        """Test applying cols_merge_range twice on different column pairs."""
+        df = pl.DataFrame(
+            {"col_1": [10, 20], "col_2": [15, 25], "col_3": [100, 200], "col_4": [150, 250]}
+        )
+
+        gt = (
+            GT(df)
+            .cols_merge_range(col_begin="col_1", col_end="col_2")
+            .cols_merge_range(col_begin="col_3", col_end="col_4")
+        )
+
+        assert len(gt._col_merge) == 2
+        assert gt._col_merge[0].vars == ["col_1", "col_2"]
+        assert gt._col_merge[1].vars == ["col_3", "col_4"]
+
+        html = gt.as_raw_html()
+        assert "10\u201315" in html
+        assert "100\u2013150" in html
+
+    def test_equal_values(self):
+        """Test range merge when begin and end are the same value."""
+        df = pl.DataFrame({"low": [10, 20], "high": [10, 25]})
+
+        gt = GT(df).cols_merge_range(col_begin="low", col_end="high")
+        html = gt.as_raw_html()
+
+        # When values are equal, both sides of the dash still appear
+        assert "10\u201310" in html
+        assert "20\u201325" in html
+
+    def test_with_rows(self):
+        """Test with specific rows selected."""
+        df = pl.DataFrame({"low": [10, 20, 30], "high": [15, 25, 35]})
+
+        gt = GT(df).cols_merge_range(col_begin="low", col_end="high", rows=[0, 2])
+        html = gt.as_raw_html()
+
+        # Only rows 0 and 2 should be merged
+        assert "10\u201315" in html
+        assert "30\u201335" in html
+
+
+# =============================================================================
+# Tests for cols_merge_n_pct
+# =============================================================================
+
+
+class TestColsMergeNPct:
+    """Tests for the cols_merge_n_pct() method."""
+
+    def test_basic(self):
+        """Test basic count and percentage merge."""
+        df = pd.DataFrame({"n": [10, 20, 30], "pct": ["16.7%", "33.3%", "50.0%"]})
+
+        gt = GT(df).cols_merge_n_pct(col_n="n", col_pct="pct")
+
+        assert len(gt._col_merge) == 1
+        assert gt._col_merge[0].type == "merge_n_pct"
+        assert gt._col_merge[0].vars == ["n", "pct"]
+
+        html = gt.as_raw_html()
+        assert "10 (16.7%)" in html
+        assert "20 (33.3%)" in html
+        assert "30 (50.0%)" in html
+
+    def test_na_in_n(self):
+        """Test that NA in col_n produces empty result."""
+        df = pl.DataFrame({"n": [10, None, 30], "pct": ["16.7%", "33.3%", "50.0%"]})
+
+        gt = GT(df).cols_merge_n_pct(col_n="n", col_pct="pct")
+        html = gt.as_raw_html()
+
+        assert "10 (16.7%)" in html
+        assert "30 (50.0%)" in html
+
+    def test_na_in_pct(self):
+        """Test that NA in col_pct shows only the count."""
+        df = pl.DataFrame({"n": [10, 20, 30], "pct": ["16.7%", None, "50.0%"]})
+
+        gt = GT(df).cols_merge_n_pct(col_n="n", col_pct="pct")
+        html = gt.as_raw_html()
+
+        assert "10 (16.7%)" in html
+        assert "30 (50.0%)" in html
+        # Row 2 should just show "20" without parens
+        assert "20 (" not in html.replace("10 (16.7%)", "").replace("30 (50.0%)", "")
+
+    def test_na_in_both(self):
+        """Test that NA in both columns produces empty result."""
+        df = pl.DataFrame({"n": [10, None, 30], "pct": ["16.7%", None, "50.0%"]})
+
+        gt = GT(df).cols_merge_n_pct(col_n="n", col_pct="pct")
+        html = gt.as_raw_html()
+
+        assert "10 (16.7%)" in html
+        assert "30 (50.0%)" in html
+
+    def test_zero_in_n(self):
+        """Test that zero in col_n shows only '0' without percentage."""
+        df = pd.DataFrame({"n": [0, 20, 30], "pct": ["0.0%", "33.3%", "50.0%"]})
+
+        gt = GT(df).cols_merge_n_pct(col_n="n", col_pct="pct")
+        html = gt.as_raw_html()
+
+        # Zero should not have percentage
+        assert "0 (0.0%)" not in html
+        # But should have the zero value
+        assert "20 (33.3%)" in html
+        assert "30 (50.0%)" in html
+
+    def test_autohide_true(self):
+        """Test that col_pct is hidden by default."""
+        df = pd.DataFrame({"n": [10], "pct": ["16.7%"]})
+
+        gt = GT(df).cols_merge_n_pct(col_n="n", col_pct="pct")
+        html = gt.as_raw_html()
+
+        # "pct" column header should not appear
+        assert ">pct<" not in html
+
+    def test_autohide_false(self):
+        """Test that col_pct remains visible when autohide=False."""
+        df = pd.DataFrame({"n": [10], "pct": ["16.7%"]})
+
+        gt = GT(df).cols_merge_n_pct(col_n="n", col_pct="pct", autohide=False)
+        html = gt.as_raw_html()
+
+        assert "pct" in html
+
+    def test_with_polars(self):
+        """Test with Polars DataFrame."""
+        df = pl.DataFrame({"n": [10, 20, 30], "pct": ["16.7%", "33.3%", "50.0%"]})
+
+        gt = GT(df).cols_merge_n_pct(col_n="n", col_pct="pct")
+        html = gt.as_raw_html()
+
+        assert "10 (16.7%)" in html
+
+    def test_with_fmt_percent(self):
+        """Test integration with fmt_percent for realistic usage."""
+        df = pl.DataFrame({"n": [10, 20, 30], "pct": [0.167, 0.333, 0.500]})
+
+        gt = (
+            GT(df).fmt_percent(columns="pct", decimals=1).cols_merge_n_pct(col_n="n", col_pct="pct")
+        )
+        html = gt.as_raw_html()
+
+        assert "10 (16.7%)" in html
+        assert "20 (33.3%)" in html
+        assert "30 (50.0%)" in html
+
+    def test_invalid_col_n(self):
+        """Test that multiple columns for col_n raises error."""
+        df = pd.DataFrame({"a": [1], "b": [2], "c": [3]})
+
+        with pytest.raises(ValueError, match="exactly one column"):
+            GT(df).cols_merge_n_pct(col_n=["a", "b"], col_pct="c")
+
+    def test_with_rows(self):
+        """Test with specific rows selected."""
+        df = pd.DataFrame({"n": [10, 20, 30], "pct": ["16.7%", "33.3%", "50.0%"]})
+
+        gt = GT(df).cols_merge_n_pct(col_n="n", col_pct="pct", rows=[0, 2])
+        html = gt.as_raw_html()
+
+        # Only rows 0 and 2 should be merged
+        assert "10 (16.7%)" in html
+        assert "30 (50.0%)" in html
+
+    def test_comprehensive_na_zero_matrix(self):
+        """Test all combinations of NA and zero values (mirrors R gt test matrix).
+
+        R gt expected outputs for this dataset:
+        - (1, 0.0714)  → "1 (7.1%)"
+        - (5, 0.3571)  → "5 (35.7%)"
+        - (0, 0.0)     → "0"           (zero suppresses pct)
+        - (2, 0.1429)  → "2 (14.3%)"
+        - (NA, NA)     → ""            (NA in col_n)
+        - (6, 0.4286)  → "6 (42.9%)"
+        - (5, NA)      → "5"           (NA in col_pct only)
+        - (NA, 1000)   → ""            (NA in col_n)
+        - (0, NA)      → "0"           (zero + NA pct → just zero)
+        - (NA, 0)      → ""            (NA in col_n)
+        """
+        df = pl.DataFrame(
+            {
+                "a": [1, 5, 0, 2, None, 6, 5, None, 0, None],
+                "b": [0.0714, 0.3571, 0.0, 0.1429, None, 0.4286, None, 1000.0, None, 0.0],
+            }
+        )
+
+        gt = GT(df).fmt_percent(columns="b", decimals=1).cols_merge_n_pct(col_n="a", col_pct="b")
+        html = gt.as_raw_html()
+
+        # Positive cases: n with pct
+        assert "1 (7.1%)" in html
+        assert "5 (35.7%)" in html
+        assert "2 (14.3%)" in html
+        assert "6 (42.9%)" in html
+
+        # Zero in col_n: no percentage shown
+        # We check that "0 (" doesn't appear (zero rows don't get parens)
+        # Note: "0" should appear without parentheses for zero rows
+
+        # NA in col_pct only: show just the count
+        # Row 7: n=5, pct=NA → "5" (without parens)
+
+        # NA in col_n: empty result (no meaningful content for that cell)
+
+    def test_chaining_n_pct_and_range(self):
+        """Test combining cols_merge_n_pct with cols_merge_range."""
+        df = pl.DataFrame({"n": [10, 20], "pct": [0.167, 0.333], "low": [5, 10], "high": [15, 25]})
+
+        gt = (
+            GT(df)
+            .fmt_percent(columns="pct", decimals=1)
+            .cols_merge_n_pct(col_n="n", col_pct="pct")
+            .cols_merge_range(col_begin="low", col_end="high")
+        )
+
+        assert len(gt._col_merge) == 2
+        html = gt.as_raw_html()
+        assert "10 (16.7%)" in html
+        assert "5\u201315" in html


### PR DESCRIPTION
This PR adds support for three new column merge types: uncertainty merges, range merges, and count-and-percentage merges. These new merge types allow users to combine columns in more flexible and semantically meaningful ways, handling missing values and special cases appropriately.