### PR TITLE
feat: add `text_transform()`

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -128,6 +128,7 @@ quartodoc:
         - GT.tab_footnote
         - GT.tab_source_note
         - GT.tab_style
+        - GT.text_transform
         - GT.tab_options
     - title: Formatting column data
       desc: >

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -90,6 +90,7 @@ class GTData:
     _formats: Formats
     _substitutions: Formats
     _col_merge: ColMerges
+    _transforms: list  # list[TextTransformInfo]
     _options: Options
     _google_font_imports: GoogleFontImports = field(default_factory=GoogleFontImports)
     _has_built: bool = False
@@ -140,6 +141,7 @@ class GTData:
             _formats=[],
             _substitutions=[],
             _col_merge=[],
+            _transforms=[],
             _options=options,
             _google_font_imports=GoogleFontImports(),
         )
@@ -1007,6 +1009,17 @@ class FormatInfo:
 #     def __init__(self):
 #         pass
 Formats = list
+
+
+# Text Transforms ----
+
+
+@dataclass
+class TextTransformInfo:
+    """Stores a text transformation function and the location to apply it."""
+
+    loc: "Loc"
+    fn: Callable[[str], str]
 
 
 # Column Merge ----

--- a/great_tables/_tab_create_modify.py
+++ b/great_tables/_tab_create_modify.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
+from ._gt_data import TextTransformInfo
 from ._helpers import GoogleFont
 from ._locations import Loc, set_style
 from ._styles import CellStyle
@@ -146,3 +147,84 @@ def tab_style(
         new_data = set_style(loc, new_data, style)
 
     return new_data
+
+
+def text_transform(self: GTSelf, locations: Loc | list[Loc], fn: Callable[[str], str]) -> GTSelf:
+    """Apply a custom text transformation to cells at specified locations.
+
+    With the `text_transform()` method we can target specific cells and apply a text
+    transformation function to their already-formatted content. This is useful for modifying the
+    rendered text of cells after all formatting (via `fmt_*()` methods) has been applied.
+
+    Parameters
+    ----------
+    locations
+        The cell or set of cells to be associated with the text transformation. Supported
+        locations include `loc.body()`, `loc.stub()`, `loc.row_groups()`, and
+        `loc.column_labels()`.
+    fn
+        A function that takes a cell's text content as a string and returns the transformed
+        string.
+
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+
+    Examples
+    --------
+    Let's use the `exibble` dataset to demonstrate `text_transform()`. We'll format the `num`
+    column and then apply a text transformation to wrap the values in parentheses.
+
+    ```{python}
+    from great_tables import GT, loc, exibble
+
+    (
+        GT(exibble[["num", "char"]].head(4))
+        .fmt_number(columns="num", decimals=1)
+        .text_transform(
+            locations=loc.body(columns="num"),
+            fn=lambda x: f"({x})",
+        )
+    )
+    ```
+
+    Using `text_transform()` we can also convert specific cells to uppercase. Here we target only
+    the first two rows of the `char` column.
+
+    ```{python}
+    from great_tables import GT, loc, exibble
+
+    (
+        GT(exibble[["num", "char"]].head(4))
+        .text_transform(
+            locations=loc.body(columns="char", rows=[0, 1]),
+            fn=lambda x: x.upper(),
+        )
+    )
+    ```
+
+    Multiple locations can be targeted at once by passing a list. In this example, we add a
+    prefix to all cells in both the `num` and `char` columns.
+
+    ```{python}
+    from great_tables import GT, loc, exibble
+
+    (
+        GT(exibble[["num", "char"]].head(4))
+        .fmt_number(columns="num", decimals=2)
+        .text_transform(
+            locations=[loc.body(columns="num"), loc.body(columns="char")],
+            fn=lambda x: f"~ {x}",
+        )
+    )
+    ```
+    """
+
+    if not isinstance(locations, list):
+        locations = [locations]
+
+    new_transforms = [TextTransformInfo(loc=loc, fn=fn) for loc in locations]
+
+    return self._replace(_transforms=self._transforms + new_transforms)

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -36,6 +36,13 @@ from ._formats import (
 from ._gt_data import GTData
 from ._heading import tab_header
 from ._helpers import random_id
+from ._locations import (
+    LocBody,
+    LocColumnLabels,
+    LocRowGroups,
+    LocStub,
+    resolve,
+)
 from ._modify_rows import (
     grand_summary_rows,
     row_group_order,
@@ -79,8 +86,8 @@ from ._spanners import (
 from ._stub import reorder_stub_df
 from ._stubhead import tab_stubhead
 from ._substitution import sub_large_vals, sub_missing, sub_small_vals, sub_values, sub_zero
-from ._tab_create_modify import tab_style
-from ._tbl_data import _get_cell, n_rows
+from ._tab_create_modify import tab_style, text_transform
+from ._tbl_data import _get_cell, _set_cell, n_rows
 from ._utils import _migrate_unformatted_to_output
 from ._utils_render_html import (
     _get_table_defs,
@@ -91,9 +98,116 @@ from ._utils_render_html import (
 )
 
 if TYPE_CHECKING:
+    from ._gt_data import Body, Boxhead, Stub
     from ._helpers import BaseText
 
 __all__ = ["GT"]
+
+
+# =============================================================================
+# Helper for text transforms
+# =============================================================================
+def _apply_text_transforms(data: "GT", body: "Body") -> "Body":
+    """Apply all registered text transforms to the body cells."""
+    from ._tbl_data import is_na
+
+    if not data._transforms:
+        return body
+
+    for transform in data._transforms:
+        loc = transform.loc
+        fn = transform.fn
+
+        if isinstance(loc, LocBody):
+            positions = resolve(loc, data)
+            for pos in positions:
+                cell_value = _get_cell(body.body, pos.row, pos.colname)
+                # If the cell is NA (unformatted), fall back to the raw data value
+                if is_na(body.body, cell_value):
+                    cell_value = _get_cell(data._tbl_data, pos.row, pos.colname)
+                    if is_na(data._tbl_data, cell_value):
+                        continue
+                new_value = fn(str(cell_value))
+                result = _set_cell(body.body, pos.row, pos.colname, new_value)
+                if result is not None:
+                    body.body = result
+
+    return body
+
+
+def _apply_text_transforms_stub(data: "GT", stub: "Stub", body: "Body") -> tuple["Stub", "Body"]:
+    """Apply text transforms targeting loc.stub() and loc.row_groups()."""
+
+    from ._gt_data import ColInfoTypeEnum, GroupRows, Stub
+    from ._tbl_data import is_na
+
+    if not data._transforms:
+        return stub, body
+
+    for transform in data._transforms:
+        loc = transform.loc
+        fn = transform.fn
+
+        if isinstance(loc, LocStub):
+            # Find the stub column name
+            stub_col = next(
+                (col.var for col in data._boxhead if col.type == ColInfoTypeEnum.stub), None
+            )
+            if stub_col is None:
+                continue
+
+            resolved_rows: set[int] = resolve(loc, data)
+            for row_idx in resolved_rows:
+                cell_value = _get_cell(body.body, row_idx, stub_col)
+                if is_na(body.body, cell_value):
+                    cell_value = _get_cell(data._tbl_data, row_idx, stub_col)
+                    if is_na(data._tbl_data, cell_value):
+                        continue
+                new_value = fn(str(cell_value))
+                result = _set_cell(body.body, row_idx, stub_col, new_value)
+                if result is not None:
+                    body.body = result
+
+        elif isinstance(loc, LocRowGroups):
+            resolved_groups: set[str] = resolve(loc, data)
+            new_group_rows = []
+            for group_row in stub.group_rows:
+                if group_row.group_id in resolved_groups:
+                    label = group_row.defaulted_label()
+                    new_group_rows.append(group_row.with_group_label(fn(str(label))))
+                else:
+                    new_group_rows.append(group_row)
+            stub = Stub(stub.rows, GroupRows(new_group_rows))
+
+    return stub, body
+
+
+def _apply_text_transforms_boxhead(data: "GT") -> "Boxhead":
+    """Apply text transforms targeting loc.column_labels()."""
+    from ._gt_data import Boxhead
+
+    boxhead = data._boxhead
+
+    if not data._transforms:
+        return boxhead
+
+    for transform in data._transforms:
+        loc = transform.loc
+        fn = transform.fn
+
+        if isinstance(loc, LocColumnLabels):
+            resolved_cols = resolve(loc, data)
+            col_names = {name for name, _ in resolved_cols}
+            new_cols = []
+            for col_info in boxhead:
+                if col_info.var in col_names and col_info.column_label is not None:
+                    new_label = fn(str(col_info.column_label))
+                    new_cols.append(col_info.replace_column_label(new_label))
+                else:
+                    new_cols.append(col_info)
+            boxhead = Boxhead(new_cols)
+
+    return boxhead
 
 
 # =============================================================================
@@ -301,6 +415,7 @@ class GT(
     tab_stubhead = tab_stubhead
     tab_style = tab_style
     tab_options = tab_options
+    text_transform = text_transform
 
     row_group_order = row_group_order
     tab_stub = tab_stub
@@ -370,12 +485,13 @@ class GT(
         # self = self.reorder_styles()
 
         # Transformations of individual cells at supported locations
-
-        # self = self.perform_text_transforms()
+        final_body = _apply_text_transforms(built, final_body)
+        final_stub, final_body = _apply_text_transforms_stub(built, final_stub, final_body)
+        final_boxhead = _apply_text_transforms_boxhead(built)
 
         # ...
 
-        return built._replace(_body=final_body, _stub=final_stub)
+        return built._replace(_body=final_body, _stub=final_stub, _boxhead=final_boxhead)
 
     def render(
         self,

--- a/tests/test_tab_create_modify.py
+++ b/tests/test_tab_create_modify.py
@@ -147,3 +147,153 @@ def test_tab_style_loc_body_mask_rows_not_equal_raises(gt2: GT):
     with pytest.raises(ValueError) as exc_info:
         tab_style(gt2, style, LocBody(mask=mask))
     assert err_msg in exc_info.value.args[0]
+
+
+# =============================================================================
+# text_transform tests
+# =============================================================================
+
+
+def test_text_transform_basic(gt: GT):
+    new_gt = gt.text_transform(locations=loc.body(columns="x"), fn=lambda x: f"[{x}]")
+    html = new_gt.as_raw_html()
+    assert "[1]" in html
+    assert "[2]" in html
+
+
+def test_text_transform_formatted_cells():
+    df = pd.DataFrame({"val": [1.234, 5.678]})
+    html = (
+        GT(df)
+        .fmt_number(columns="val", decimals=1)
+        .text_transform(locations=loc.body(columns="val"), fn=lambda x: f"({x})")
+        .as_raw_html()
+    )
+    assert "(1.2)" in html
+    assert "(5.7)" in html
+
+
+def test_text_transform_row_selection():
+    df = pd.DataFrame({"name": ["alice", "bob", "charlie"]})
+    html = (
+        GT(df)
+        .text_transform(locations=loc.body(columns="name", rows=[0, 2]), fn=str.upper)
+        .as_raw_html()
+    )
+    assert "ALICE" in html
+    assert "bob" in html
+    assert "CHARLIE" in html
+
+
+def test_text_transform_multiple_locations():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    html = (
+        GT(df)
+        .text_transform(
+            locations=[loc.body(columns="a"), loc.body(columns="b")],
+            fn=lambda x: f"*{x}*",
+        )
+        .as_raw_html()
+    )
+    assert "*1*" in html
+    assert "*2*" in html
+    assert "*3*" in html
+    assert "*4*" in html
+
+
+def test_text_transform_polars():
+    df = pl.DataFrame({"x": ["hello", "world"]})
+    html = GT(df).text_transform(locations=loc.body(columns="x"), fn=str.upper).as_raw_html()
+    assert "HELLO" in html
+    assert "WORLD" in html
+
+
+def test_text_transform_skips_na():
+    df = pd.DataFrame({"x": [1.0, None, 3.0]})
+    html = (
+        GT(df).text_transform(locations=loc.body(columns="x"), fn=lambda x: f"[{x}]").as_raw_html()
+    )
+    assert "[1.0]" in html
+    assert "[3.0]" in html
+
+
+def test_text_transform_chaining():
+    df = pd.DataFrame({"x": ["hello"]})
+    html = (
+        GT(df)
+        .text_transform(locations=loc.body(columns="x"), fn=str.upper)
+        .text_transform(locations=loc.body(columns="x"), fn=lambda x: f"({x})")
+        .as_raw_html()
+    )
+    assert "(HELLO)" in html
+
+
+def test_text_transform_latex():
+    df = pd.DataFrame({"x": [1, 2]})
+    latex = (
+        GT(df)
+        .fmt_number(columns="x", decimals=0)
+        .text_transform(locations=loc.body(columns="x"), fn=lambda x: f"[{x}]")
+        .as_latex()
+    )
+    assert "[1]" in latex
+    assert "[2]" in latex
+
+
+def test_text_transform_loc_stub():
+    from great_tables import exibble
+
+    html = (
+        GT(exibble[["num", "char", "row"]].head(3), rowname_col="row")
+        .text_transform(locations=loc.stub(), fn=str.upper)
+        .as_raw_html()
+    )
+    assert "ROW_1" in html
+    assert "ROW_2" in html
+    assert "ROW_3" in html
+
+
+def test_text_transform_loc_stub_with_rows():
+    from great_tables import exibble
+
+    html = (
+        GT(exibble[["num", "char", "row"]].head(3), rowname_col="row")
+        .text_transform(locations=loc.stub(rows=[0]), fn=str.upper)
+        .as_raw_html()
+    )
+    assert "ROW_1" in html
+    assert "row_2" in html
+
+
+def test_text_transform_loc_column_labels():
+    df = pd.DataFrame({"first_name": ["Alice"], "score": [95]})
+    html = GT(df).text_transform(locations=loc.column_labels(), fn=str.upper).as_raw_html()
+    assert "FIRST_NAME" in html
+    assert "SCORE" in html
+
+
+def test_text_transform_loc_column_labels_specific():
+    df = pd.DataFrame({"name": ["Alice"], "score": [95]})
+    html = (
+        GT(df)
+        .text_transform(locations=loc.column_labels(columns="name"), fn=str.upper)
+        .as_raw_html()
+    )
+    assert "NAME" in html
+    assert "score" in html
+
+
+def test_text_transform_loc_row_groups():
+    from great_tables import exibble
+
+    html = (
+        GT(
+            exibble[["num", "char", "row", "group"]].head(6),
+            rowname_col="row",
+            groupname_col="group",
+        )
+        .text_transform(locations=loc.row_groups(), fn=str.upper)
+        .as_raw_html()
+    )
+    assert "GRP_A" in html
+    assert "GRP_B" in html


### PR DESCRIPTION
This PR adds the ability to apply custom text transformations to specific table cells using the new `text_transform()` method. The implementation includes support for transforming cell content in the table body cells, stub cells, column labels, and row group labels.