### PR TITLE
fix: remove pandas requirement

### DIFF
--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -120,10 +120,6 @@ def _raise_not_implemented(data: Any):
     raise NotImplementedError(f"Unsupported data type: {type(data)}")
 
 
-def _raise_pandas_required(msg: Any):
-    raise ImportError(msg)
-
-
 def _re_version(raw_version: str) -> tuple[int, int, int]:
     """Return a semver-like version string as a 3-tuple of integers.
 
@@ -843,24 +839,31 @@ def _(df: PyArrowTable) -> PyArrowTable:
 
 @singledispatch
 def to_frame(ser: "list[Any] | SeriesLike", name: Optional[str] = None) -> DataFrameLike:
-    # TODO: remove pandas. currently, we support converting a list to a pd.DataFrame
-    # in order to support backwards compatibility in the vals.fmt_* functions.
-
-    try:
-        import pandas as pd
-    except ImportError:
-        _raise_pandas_required(
-            "Passing a plain list of values currently requires the library pandas. "
-            "You can avoid this error by passing a polars Series."
-        )
-
     if not isinstance(ser, list):
         raise NotImplementedError(f"Unsupported type: {type(ser)}")
 
     if not name:
         raise ValueError("name must be specified, when converting a list to a DataFrame.")
 
-    return pd.DataFrame({name: ser})
+    # Try available DataFrame libraries: prefer polars, then pandas
+    try:
+        import polars as pl
+
+        return pl.DataFrame({name: ser})
+    except ImportError:
+        pass
+
+    try:
+        import pandas as pd
+
+        return pd.DataFrame({name: ser})
+    except ImportError:
+        pass
+
+    raise ImportError(
+        "Passing a plain list of values requires either polars or pandas to be installed. "
+        "You can also pass a polars Series or pandas Series directly."
+    )
 
 
 @to_frame.register

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -849,7 +849,7 @@ def to_frame(ser: "list[Any] | SeriesLike", name: Optional[str] = None) -> DataF
     try:
         import polars as pl
 
-        return pl.DataFrame({name: ser})
+        return pl.DataFrame({name: ser}, strict=False)
     except ImportError:
         pass
 

--- a/great_tables/data/__init__.py
+++ b/great_tables/data/__init__.py
@@ -5,30 +5,40 @@ from typing import Any
 from importlib_resources import files
 
 
+def _read_csv_pandas(fname: Any, dtype: dict[str, str] | None = None) -> Any:
+    """Read a CSV file as a pandas DataFrame."""
+    import pandas as pd
+
+    return pd.read_csv(fname, dtype=dtype)
+
+
+def _read_csv_polars(fname: Any, dtype: dict[str, str] | None = None) -> Any:
+    """Read a CSV file as a polars DataFrame."""
+    import polars as pl
+
+    schema_overrides = None
+    if dtype is not None:
+        _PD_TO_PL = {
+            "object": pl.Utf8,
+            "int64": pl.Int64,
+            "Int64": pl.Int64,
+            "float64": pl.Float64,
+        }
+        schema_overrides = {col: _PD_TO_PL[t] for col, t in dtype.items()}
+
+    return pl.read_csv(fname, schema_overrides=schema_overrides)
+
+
 def _read_csv(fname: Any, dtype: dict[str, str] | None = None) -> Any:
     """Read a CSV file using pandas (preferred for backward compat) or polars."""
 
     try:
-        import pandas as pd
-
-        return pd.read_csv(fname, dtype=dtype)
+        return _read_csv_pandas(fname, dtype=dtype)
     except ImportError:
         pass
 
     try:
-        import polars as pl
-
-        schema_overrides = None
-        if dtype is not None:
-            _PD_TO_PL = {
-                "object": pl.Utf8,
-                "int64": pl.Int64,
-                "Int64": pl.Int64,
-                "float64": pl.Float64,
-            }
-            schema_overrides = {col: _PD_TO_PL[t] for col, t in dtype.items()}
-
-        return pl.read_csv(fname, schema_overrides=schema_overrides)
+        return _read_csv_polars(fname, dtype=dtype)
     except ImportError:
         pass
 
@@ -1381,3 +1391,63 @@ _x_locales_dtype = {
 }
 
 __x_locales = _read_csv(_x_locales_fname, dtype=_x_locales_dtype)  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Backend-scoped dataset access: data.pd.<name> and data.pl.<name>
+# ---------------------------------------------------------------------------
+
+# Registry mapping dataset names to (fname, dtype) pairs
+_DATASETS: dict[str, tuple[Any, dict[str, str] | None]] = {
+    "countrypops": (_countrypops_fname, _countrypops_dtype),
+    "sza": (_sza_fname, _sza_dtype),
+    "gtcars": (_gtcars_fname, _gtcars_dtype),
+    "sp500": (_sp500_fname, _sp500_dtype),
+    "pizzaplace": (_pizzaplace_fname, _pizzaplace_dtype),
+    "exibble": (_exibble_fname, _exibble_dtype),
+    "towny": (_towny_fname, _towny_dtype),
+    "peeps": (_peeps_fname, _peeps_dtype),
+    "films": (_films_fname, _films_dtype),
+    "metro": (_metro_fname, _metro_dtype),
+    "gibraltar": (_gibraltar_fname, _gibraltar_dtype),
+    "constants": (_constants_fname, _constants_dtype),
+    "illness": (_illness_fname, _illness_dtype),
+    "reactions": (_reactions_fname, _reactions_dtype),
+    "photolysis": (_photolysis_fname, _photolysis_dtype),
+    "nuclides": (_nuclides_fname, _nuclides_dtype),
+    "islands": (_islands_fname, None),
+    "airquality": (_airquality_fname, None),
+}
+
+
+class _BackendNamespace:
+    """Lazy namespace that loads datasets using a specific backend (pandas or polars).
+
+    Accessed as ``great_tables.data.pd.<dataset>`` or ``great_tables.data.pl.<dataset>``.
+    Datasets are loaded on first access and cached for subsequent use.
+    """
+
+    def __init__(self, reader: Any) -> None:
+        self._reader = reader
+        self._cache: dict[str, Any] = {}
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        if name in self._cache:
+            return self._cache[name]
+        if name not in _DATASETS:
+            raise AttributeError(
+                f"Dataset {name!r} not found. Available datasets: {', '.join(sorted(_DATASETS))}"
+            )
+        fname, dtype = _DATASETS[name]
+        df = self._reader(fname, dtype=dtype)
+        self._cache[name] = df
+        return df
+
+    def __dir__(self) -> list[str]:
+        return sorted(_DATASETS)
+
+
+pd = _BackendNamespace(_read_csv_pandas)
+pl = _BackendNamespace(_read_csv_polars)

--- a/great_tables/data/__init__.py
+++ b/great_tables/data/__init__.py
@@ -1,11 +1,39 @@
+from __future__ import annotations
+
+from typing import Any
+
 from importlib_resources import files
 
-try:
-    import pandas as pd
-except ModuleNotFoundError:
-    raise ModuleNotFoundError(
-        "Currently, importing great_tables.data requires pandas. "
-        "This will change in the future. Most of great_tables can be used without pandas."
+
+def _read_csv(fname: Any, dtype: dict[str, str] | None = None) -> Any:
+    """Read a CSV file using pandas (preferred for backward compat) or polars."""
+
+    try:
+        import pandas as pd
+
+        return pd.read_csv(fname, dtype=dtype)
+    except ImportError:
+        pass
+
+    try:
+        import polars as pl
+
+        schema_overrides = None
+        if dtype is not None:
+            _PD_TO_PL = {
+                "object": pl.Utf8,
+                "int64": pl.Int64,
+                "Int64": pl.Int64,
+                "float64": pl.Float64,
+            }
+            schema_overrides = {col: _PD_TO_PL[t] for col, t in dtype.items()}
+
+        return pl.read_csv(fname, schema_overrides=schema_overrides)
+    except ImportError:
+        pass
+
+    raise ImportError(
+        "Importing great_tables.data requires either pandas or polars to be installed."
     )
 
 
@@ -289,7 +317,7 @@ _nuclides_dtype = {
 _islands_fname = DATA_MOD / "x-islands.csv"
 _airquality_fname = DATA_MOD / "x-airquality.csv"
 
-countrypops: pd.DataFrame = pd.read_csv(_countrypops_fname, dtype=_countrypops_dtype)  # type: ignore
+countrypops = _read_csv(_countrypops_fname, dtype=_countrypops_dtype)  # type: ignore
 countrypops.__doc__ = """
 Yearly populations of countries from 1960 to 2022.
 
@@ -325,7 +353,7 @@ Source
 <https://data.worldbank.org/indicator/SP.POP.TOTL>
 """
 
-sza: pd.DataFrame = pd.read_csv(_sza_fname, dtype=_sza_dtype)  # type: ignore
+sza = _read_csv(_sza_fname, dtype=_sza_dtype)  # type: ignore
 sza.__doc__ = """
 Twice hourly solar zenith angles by month & latitude.
 
@@ -372,7 +400,7 @@ Calculated Actinic Fluxes (290 - 700 nm) for Air Pollution Photochemistry Applic
 1976), available at: <https://nepis.epa.gov/Exe/ZyPURL.cgi?Dockey=9100JA26.txt>.
 """
 
-gtcars: pd.DataFrame = pd.read_csv(_gtcars_fname, dtype=_gtcars_dtype)  # type: ignore
+gtcars = _read_csv(_gtcars_fname, dtype=_gtcars_dtype)  # type: ignore
 gtcars.__doc__ = """
 Deluxe automobiles from the 2014-2017 period.
 
@@ -431,7 +459,7 @@ $ msrp        <f64> 447000.0, 291744.0, 263553.0
 
 """
 
-sp500: pd.DataFrame = pd.read_csv(_sp500_fname, dtype=_sp500_dtype)  # type: ignore
+sp500 = _read_csv(_sp500_fname, dtype=_sp500_dtype)  # type: ignore
 sp500.__doc__ = """
 Daily S&P 500 Index data from 1950 to 2015.
 
@@ -465,7 +493,7 @@ $ adj_close <f64> 2043.9399, 2063.3601, 2078.3601
 
 """
 
-pizzaplace: pd.DataFrame = pd.read_csv(_pizzaplace_fname, dtype=_pizzaplace_dtype)  # type: ignore
+pizzaplace = _read_csv(_pizzaplace_fname, dtype=_pizzaplace_dtype)  # type: ignore
 pizzaplace.__doc__ = """
 A year of pizza sales from a pizza place.
 
@@ -582,7 +610,7 @@ $ price <f64> 13.25, 16.0, 16.0
 
 """
 
-exibble: pd.DataFrame = pd.read_csv(_exibble_fname, dtype=_exibble_dtype)  # type: ignore
+exibble = _read_csv(_exibble_fname, dtype=_exibble_dtype)  # type: ignore
 exibble.__doc__ = """
 A toy example table for testing with great_tables: exibble.
 
@@ -625,7 +653,7 @@ $ group    <str> 'grp_a', 'grp_a', 'grp_a'
 
 """
 
-towny: pd.DataFrame = pd.read_csv(_towny_fname, dtype=_towny_dtype)  # type: ignore
+towny = _read_csv(_towny_fname, dtype=_towny_dtype)  # type: ignore
 towny.__doc__ = """
 Populations of all municipalities in Ontario from 1996 to 2021.
 
@@ -703,7 +731,7 @@ $ pop_change_2016_2021_pct <f64> 0.0932, 0.007, 0.0013
 
 """
 
-peeps: pd.DataFrame = pd.read_csv(_peeps_fname, dtype=_peeps_dtype)  # type: ignore
+peeps = _read_csv(_peeps_fname, dtype=_peeps_dtype)  # type: ignore
 peeps.__doc__ = """
 A table of personal information for people all over the world.
 
@@ -759,7 +787,7 @@ $ weight_kg    <f64> 76.4, 74.9, 61.6
 
 """
 
-films: pd.DataFrame = pd.read_csv(_films_fname, dtype=_films_dtype)  # type: ignore
+films = _read_csv(_films_fname, dtype=_films_dtype)  # type: ignore
 films.__doc__ = """
 Feature films in competition at the Cannes Film Festival.
 
@@ -807,7 +835,7 @@ $ imdb_url            <str> 'https://www.imdb.com/title/tt0038297/',
 
 """
 
-metro: pd.DataFrame = pd.read_csv(_metro_fname, dtype=_metro_dtype)  # type: ignore
+metro = _read_csv(_metro_fname, dtype=_metro_dtype)  # type: ignore
 metro.__doc__ = """
 The stations of the Paris Metro.
 
@@ -875,7 +903,7 @@ $ location           <str> 'Paris 16th, Paris 17th',
 
 """
 
-gibraltar: pd.DataFrame = pd.read_csv(_gibraltar_fname, dtype=_gibraltar_dtype)  # type: ignore
+gibraltar = _read_csv(_gibraltar_fname, dtype=_gibraltar_dtype)  # type: ignore
 gibraltar.__doc__ = """
 Weather conditions in Gibraltar, May 2023.
 
@@ -917,7 +945,7 @@ $ condition  <str> 'Fair', 'Fair', 'Fair'
 
 """
 
-constants: pd.DataFrame = pd.read_csv(_constants_fname, dtype=_constants_dtype)  # type: ignore
+constants = _read_csv(_constants_fname, dtype=_constants_dtype)  # type: ignore
 constants.__doc__ = """
 The fundamental physical constants.
 
@@ -958,7 +986,7 @@ $ units     <str> None, 'kg', 'J'
 
 """
 
-illness: pd.DataFrame = pd.read_csv(_illness_fname, dtype=_illness_dtype)  # type: ignore
+illness = _read_csv(_illness_fname, dtype=_illness_dtype)  # type: ignore
 illness.__doc__ = """
 Lab tests for one suffering from an illness.
 
@@ -1043,7 +1071,7 @@ $ norm_u <f64> None, 10.0, 8.0
 
 """
 
-reactions: pd.DataFrame = pd.read_csv(_reactions_fname, dtype=_reactions_dtype)  # type: ignore
+reactions = _read_csv(_reactions_fname, dtype=_reactions_dtype)  # type: ignore
 reactions.__doc__ = """
 Reaction rates for gas-phase atmospheric reactions of organic compounds.
 
@@ -1162,7 +1190,7 @@ $ Cl_t_high     <f64> 300.0, 500.0, 950.0
 
 """
 
-photolysis: pd.DataFrame = pd.read_csv(_photolysis_fname, dtype=_photolysis_dtype)  # type: ignore
+photolysis = _read_csv(_photolysis_fname, dtype=_photolysis_dtype)  # type: ignore
 photolysis.__doc__ = """
 Data on photolysis rates for gas-phase organic compounds.
 
@@ -1217,7 +1245,7 @@ $ sigma_298_cm2 <str> '1.43E-18,1.27E-18,1.11E-18,...',
 
 """
 
-nuclides: pd.DataFrame = pd.read_csv(_nuclides_fname, dtype=_nuclides_dtype)  # type: ignore
+nuclides = _read_csv(_nuclides_fname, dtype=_nuclides_dtype)  # type: ignore
 nuclides.__doc__ = """
 Nuclide data.
 
@@ -1292,8 +1320,8 @@ $ mass_excess_uncert         <f64> 1.3e-05, 1.5e-05, 8e-05
 
 """
 
-islands: pd.DataFrame = pd.read_csv(_islands_fname)  # type: ignore
-airquality: pd.DataFrame = pd.read_csv(_airquality_fname)  # type: ignore
+islands = _read_csv(_islands_fname)  # type: ignore
+airquality = _read_csv(_airquality_fname)  # type: ignore
 
 
 _x_locales_fname = DATA_MOD / "x_locales.csv"
@@ -1352,4 +1380,4 @@ _x_locales_dtype = {
     "page_size_options_label_text": "object",
 }
 
-__x_locales: pd.DataFrame = pd.read_csv(_x_locales_fname, dtype=_x_locales_dtype)  # type: ignore
+__x_locales = _read_csv(_x_locales_fname, dtype=_x_locales_dtype)  # type: ignore

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,30 +1,82 @@
 import pandas as pd
+import polars as pl
 import pytest
 
 from great_tables import data
 
 
-@pytest.mark.parametrize(
-    "name",
-    [
-        "countrypops",
-        "sza",
-        "gtcars",
-        "sp500",
-        "pizzaplace",
-        "exibble",
-        "towny",
-        "peeps",
-        "films",
-        "metro",
-        "gibraltar",
-        "constants",
-        "illness",
-        "reactions",
-        "photolysis",
-        "nuclides",
-    ],
-)
+_DATASET_NAMES = [
+    "countrypops",
+    "sza",
+    "gtcars",
+    "sp500",
+    "pizzaplace",
+    "exibble",
+    "towny",
+    "peeps",
+    "films",
+    "metro",
+    "gibraltar",
+    "constants",
+    "illness",
+    "reactions",
+    "photolysis",
+    "nuclides",
+]
+
+
+@pytest.mark.parametrize("name", _DATASET_NAMES)
 def test_datasets(name: str):
     df = getattr(data, name)
     assert isinstance(df, pd.DataFrame)
+
+
+@pytest.mark.parametrize("name", _DATASET_NAMES)
+def test_datasets_pd_namespace(name: str):
+    df = getattr(data.pd, name)
+    assert isinstance(df, pd.DataFrame)
+    assert df.shape[0] > 0
+
+
+@pytest.mark.parametrize("name", _DATASET_NAMES)
+def test_datasets_pl_namespace(name: str):
+    df = getattr(data.pl, name)
+    assert isinstance(df, pl.DataFrame)
+    assert df.shape[0] > 0
+
+
+@pytest.mark.parametrize("name", _DATASET_NAMES)
+def test_datasets_pd_pl_same_shape(name: str):
+    pd_df = getattr(data.pd, name)
+    pl_df = getattr(data.pl, name)
+    assert pd_df.shape == pl_df.shape
+
+
+def test_pd_namespace_caches_results():
+    df1 = data.pd.exibble
+    df2 = data.pd.exibble
+    assert df1 is df2
+
+
+def test_pl_namespace_caches_results():
+    df1 = data.pl.exibble
+    df2 = data.pl.exibble
+    assert df1 is df2
+
+
+def test_pd_namespace_invalid_dataset():
+    with pytest.raises(AttributeError, match="not found"):
+        data.pd.nonexistent_dataset
+
+
+def test_pl_namespace_invalid_dataset():
+    with pytest.raises(AttributeError, match="not found"):
+        data.pl.nonexistent_dataset
+
+
+def test_namespace_dir():
+    pd_datasets = dir(data.pd)
+    pl_datasets = dir(data.pl)
+    assert pd_datasets == pl_datasets
+    for name in _DATASET_NAMES:
+        assert name in pd_datasets

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -11,9 +11,11 @@ def test_no_pandas_import_fails():
         import pandas
 
 
-def test_no_pandas_import_exibble_raises():
-    with pytest.raises(ModuleNotFoundError):
-        from great_tables import exibble
+def test_no_pandas_import_exibble_works_with_polars():
+    from great_tables import exibble
+    import polars as pl
+
+    assert isinstance(exibble, pl.DataFrame)
 
 
 def test_no_pandas_import():


### PR DESCRIPTION
This PR refactors the `great_tables.data` module to support both pandas and polars backends for all built-in datasets, and introduces a new, backend-agnostic API for dataset access. We also add new tests to ensure correct behavior and caching for both backends.