### PR TITLE
Simple captions in Latex and table labels.

### DIFF
--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -257,7 +257,12 @@ def as_raw_html(
     return table_html
 
 
-def as_latex(self: GT, use_longtable: bool = False, tbl_pos: str | None = None) -> str:
+def as_latex(
+        self: GT,
+        use_longtable: bool = False,
+        tbl_pos: str | None = None,
+        tbl_label: str | None = None
+    ) -> str:
     """
     Output a GT object as LaTeX
 
@@ -345,7 +350,7 @@ def as_latex(self: GT, use_longtable: bool = False, tbl_pos: str | None = None) 
     """
     built_table = self._build_data(context="latex")
 
-    latex_table = _render_as_latex(data=built_table, use_longtable=use_longtable, tbl_pos=tbl_pos)
+    latex_table = _render_as_latex(data=built_table, use_longtable=use_longtable, tbl_pos=tbl_pos, tbl_label=tbl_label)
 
     return latex_table
 

--- a/great_tables/_export.py
+++ b/great_tables/_export.py
@@ -287,6 +287,9 @@ def as_latex(
         table will be placed at the top of the page; if in the Quarto render then the table
         positioning option will be ignored in favor of any setting within the Quarto rendering
         environment.
+    tbl_label
+        The label for the table in LaTeX output. This is used for referencing the table in the document.
+        If a value is not provided then no label will be included in the LaTeX output.
 
     Returns
     -------

--- a/great_tables/_utils_render_latex.py
+++ b/great_tables/_utils_render_latex.py
@@ -205,7 +205,7 @@ def create_table_start_l(data: GTData, use_longtable: bool) -> str:
     return table_start
 
 
-def create_heading_component_l(data: GTData, use_longtable: bool) -> str:
+def create_heading_component_l(data: GTData, use_longtable: bool, tbl_label: str | None = None) -> str:
     """
     Create the heading component for LaTeX output.
 
@@ -217,6 +217,9 @@ def create_heading_component_l(data: GTData, use_longtable: bool) -> str:
     ----------
     data : GTData
         The GTData object that contains all the information about the table.
+
+    tbl_label : str | None
+        The label for the table in LaTeX output. This is used for referencing the table in the document.
 
     Returns
     -------
@@ -233,7 +236,11 @@ def create_heading_component_l(data: GTData, use_longtable: bool) -> str:
 
     # If there is no title, then return an empty string
     if not has_title:
-        return ""
+        if tbl_label is None:
+            return ""
+        else:
+            # Labels need a caption to work correctly in LaTeX
+            return f"\\caption{{}}\n\\label{{{tbl_label}}}"
 
     title_str = _process_text(title, context="latex")
 
@@ -249,6 +256,9 @@ def create_heading_component_l(data: GTData, use_longtable: bool) -> str:
 
     else:
         header_component = f"""\\caption{{{title_row}}} {line_continuation if use_longtable else ""}"""
+
+    if tbl_label is not None:
+        header_component += f"\n\\label{{{tbl_label}}}"
 
     return header_component
 
@@ -730,7 +740,6 @@ def _render_as_latex(
         use_longtable: bool = False,
         tbl_pos: str | None = None,
         tbl_label: str | None = None
-
     ) -> str:
     # Check for styles (not yet supported so warn user)
     if data._styles:
@@ -747,7 +756,7 @@ def _render_as_latex(
     table_start = create_table_start_l(data=data, use_longtable=use_longtable)
 
     # Create the heading component
-    heading_component = create_heading_component_l(data=data, use_longtable=use_longtable)
+    heading_component = create_heading_component_l(data=data, use_longtable=use_longtable, tbl_label=tbl_label)
 
     # Create the columns component
     columns_component = create_columns_component_l(data=data)
@@ -760,9 +769,6 @@ def _render_as_latex(
 
     # Create a LaTeX fragment for the ending tabular statement
     table_end = create_table_end_l(use_longtable=use_longtable)
-
-    # Create the table label statement
-    label_statement = f"\\label{{{tbl_label}}}" if tbl_label is not None else ""
 
     # Create a LaTeX fragment for the table width statement
     table_width_statement = derive_table_width_statement_l(data=data, use_longtable=use_longtable)
@@ -777,7 +783,6 @@ def _render_as_latex(
     # Compose the LaTeX table
     if use_longtable:
         finalized_table = f"""{wrap_start_statement}
-{label_statement}
 {table_width_statement}
 {fontsize_statement}
 {table_start}
@@ -791,7 +796,6 @@ def _render_as_latex(
 
     else:
         finalized_table = f"""{wrap_start_statement}
-{label_statement}
 {heading_component}
 {table_width_statement}
 {fontsize_statement}

--- a/great_tables/_utils_render_latex.py
+++ b/great_tables/_utils_render_latex.py
@@ -237,24 +237,18 @@ def create_heading_component_l(data: GTData, use_longtable: bool) -> str:
 
     title_str = _process_text(title, context="latex")
 
-    title_row = f"{{\\large {title_str}}}"
+    title_row = f"{title_str}"
 
     has_subtitle = heading_has_subtitle(subtitle)
 
     if has_subtitle:
         subtitle_str = _process_text(subtitle, context="latex")
+        subtitle_row = f"{subtitle_str}"
 
-        subtitle_row = f"{{\\small {subtitle_str}}}"
-
-        header_component = f"""\\caption*{{
-{title_row} \\\\
-{subtitle_row}
-}} {line_continuation if use_longtable else ""}"""
+        header_component = f"""\\caption{{{title_row} {subtitle_row}}} {line_continuation if use_longtable else ""}"""
 
     else:
-        header_component = f"""\\caption*{{
-{title_row}
-}} {line_continuation if use_longtable else ""}"""
+        header_component = f"""\\caption{{{title_row}}} {line_continuation if use_longtable else ""}"""
 
     return header_component
 
@@ -688,6 +682,10 @@ def derive_table_width_statement_l(data: GTData, use_longtable: bool) -> str:
 def create_fontsize_statement_l(data: GTData) -> str:
     table_font_size = data._options.table_font_size.value
 
+    # skip the font size statement when the default (16px) is used
+    if table_font_size == "16px":
+        return ""
+
     fs_fmt = "\\fontsize{%3.1fpt}{%3.1fpt}\\selectfont\n"
 
     if table_font_size.endswith("%"):
@@ -727,7 +725,13 @@ def create_wrap_end_l(use_longtable: bool) -> str:
     return wrap_end
 
 
-def _render_as_latex(data: GTData, use_longtable: bool = False, tbl_pos: str | None = None) -> str:
+def _render_as_latex(
+        data: GTData,
+        use_longtable: bool = False,
+        tbl_pos: str | None = None,
+        tbl_label: str | None = None
+
+    ) -> str:
     # Check for styles (not yet supported so warn user)
     if data._styles:
         _not_implemented("Styles are not yet supported in LaTeX output.")
@@ -757,6 +761,9 @@ def _render_as_latex(data: GTData, use_longtable: bool = False, tbl_pos: str | N
     # Create a LaTeX fragment for the ending tabular statement
     table_end = create_table_end_l(use_longtable=use_longtable)
 
+    # Create the table label statement
+    label_statement = f"\\label{{{tbl_label}}}" if tbl_label is not None else ""
+
     # Create a LaTeX fragment for the table width statement
     table_width_statement = derive_table_width_statement_l(data=data, use_longtable=use_longtable)
 
@@ -770,6 +777,7 @@ def _render_as_latex(data: GTData, use_longtable: bool = False, tbl_pos: str | N
     # Compose the LaTeX table
     if use_longtable:
         finalized_table = f"""{wrap_start_statement}
+{label_statement}
 {table_width_statement}
 {fontsize_statement}
 {table_start}
@@ -783,6 +791,7 @@ def _render_as_latex(data: GTData, use_longtable: bool = False, tbl_pos: str | N
 
     else:
         finalized_table = f"""{wrap_start_statement}
+{label_statement}
 {heading_component}
 {table_width_statement}
 {fontsize_statement}

--- a/tests/test_utils_render_latex.py
+++ b/tests/test_utils_render_latex.py
@@ -1,31 +1,28 @@
-import pytest
-from unittest import mock
-import pandas as pd
 import os
+from unittest import mock
+
+import pandas as pd
+import pytest
 
 from great_tables import GT, exibble, loc
+from great_tables._utils_render_latex import (_render_as_latex, convert_to_pt,
+                                              convert_to_px,
+                                              create_body_component_l,
+                                              create_columns_component_l,
+                                              create_fontsize_statement_l,
+                                              create_footer_component_l,
+                                              create_heading_component_l,
+                                              create_table_end_l,
+                                              create_table_start_l,
+                                              create_wrap_end_l,
+                                              create_wrap_start_l,
+                                              css_length_has_supported_units,
+                                              derive_table_width_statement_l,
+                                              get_px_conversion,
+                                              get_units_from_length_string,
+                                              is_css_length_string,
+                                              is_number_without_units)
 from great_tables.data import gtcars
-
-from great_tables._utils_render_latex import (
-    is_css_length_string,
-    is_number_without_units,
-    css_length_has_supported_units,
-    get_px_conversion,
-    get_units_from_length_string,
-    convert_to_px,
-    convert_to_pt,
-    create_wrap_start_l,
-    create_fontsize_statement_l,
-    create_heading_component_l,
-    create_body_component_l,
-    create_columns_component_l,
-    create_footer_component_l,
-    create_wrap_end_l,
-    create_table_end_l,
-    create_table_start_l,
-    derive_table_width_statement_l,
-    _render_as_latex,
-)
 
 
 @pytest.fixture
@@ -111,7 +108,7 @@ def test_convert_to_pt():
 
 
 def test_create_fontsize_statement_l(gt_tbl: GT):
-    assert create_fontsize_statement_l(gt_tbl) == "\\fontsize{12.0pt}{14.4pt}\\selectfont\n"
+    assert create_fontsize_statement_l(gt_tbl) == ""
 
 
 def test_create_fontsize_statement_l_pt(gt_tbl: GT):
@@ -182,11 +179,11 @@ def test_create_heading_component_l():
     assert create_heading_component_l(gt_tbl_no_heading, use_longtable=False) == ""
     assert (
         create_heading_component_l(gt_tbl_title, use_longtable=False)
-        == "\\caption*{\n{\\large Title}\n} "
+        == "\\caption{Title} "
     )
     assert (
         create_heading_component_l(gt_tbl_title_subtitle, use_longtable=False)
-        == "\\caption*{\n{\\large Title} \\\\\n{\\small Subtitle}\n} "
+        == "\\caption{Title Subtitle} "
     )
 
 
@@ -633,3 +630,9 @@ def test_snap_render_as_latex_stub_and_groups_as_column(snapshot):
     latex_str = _render_as_latex(data=gt_tbl._build_data(context="latex"))
 
     assert snapshot == latex_str
+
+def test_render_as_latex_with_table_label():
+    gt_tbl = GT(exibble)
+    latex_str = _render_as_latex(data=gt_tbl._build_data(context="latex"), tbl_label="tab:table1")
+
+    assert "\\label{tab:table1}" in latex_str


### PR DESCRIPTION
# Summary

Improved `as_latex()` output to allow the use of labels for in-text references to the tables created using `great_tables` and to delegate more to the document formatting unless explicitly needed.

The following table:
<img width="524" height="323" alt="image" src="https://github.com/user-attachments/assets/0fec527b-7acf-4497-821a-f859e49e7071" />

Results in
<img width="557" height="222" alt="image" src="https://github.com/user-attachments/assets/f1cb75db-aa31-4c8d-8d64-d74fd3854f79" />


# Related GitHub Issues and PRs

- Ref: #646

# Checklist

- [X] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [ X] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [X] I have added **pytest** unit tests for any new functionality.
