### PR TITLE
feat: add the `tab_stub_indent()` method

### DIFF
--- a/great-docs.yml
+++ b/great-docs.yml
@@ -99,6 +99,7 @@ reference:
         - GT.tab_spanner_delim
         - GT.tab_stub
         - GT.tab_stubhead
+        - GT.tab_stub_indent
         - GT.tab_footnote
         - GT.tab_source_note
         - GT.rm_header

--- a/great_tables/__init__.py
+++ b/great_tables/__init__.py
@@ -7,23 +7,23 @@ del _v
 
 # Main gt imports ----
 
-from .gt import GT
-from . import vals, loc, style
-from ._styles import FromColumn as from_column
+from . import loc, style, vals
 from ._helpers import (
-    letters,
     LETTERS,
-    px,
-    pct,
-    md,
-    html,
-    google_font,
-    random_id,
-    system_fonts,
     define_units,
+    google_font,
+    html,
+    letters,
+    md,
     nanoplot_options,
+    pct,
+    px,
+    random_id,
+    stub,
+    system_fonts,
 )
-
+from ._styles import FromColumn as from_column
+from .gt import GT
 
 __all__ = (
     "GT",
@@ -32,6 +32,7 @@ __all__ = (
     "LETTERS",
     "px",
     "pct",
+    "stub",
     "md",
     "html",
     "google_font",

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -541,6 +541,7 @@ class RowInfo:
     rowname: str | None = None
     group_label: str | None = None
     built: bool = False
+    indent: int = 0
 
     # The components of the stub are:
     # `rownum_i` (The initial row indices for the table at ingest time)
@@ -548,6 +549,7 @@ class RowInfo:
     # `rowname` = None
     # `group_label` = None
     # `built` = False
+    # `indent` = 0
 
 
 class Stub:
@@ -623,6 +625,15 @@ class Stub:
     def reorder_rows(self, indices) -> Self:
         new_rows = [self.rows[ii] for ii in indices]
 
+        return self.__class__(new_rows, self.group_rows)
+
+    def set_row_indent(self, row_positions: list[int], indent: int) -> Self:
+        """Return a new Stub with the indent set on the specified row positions."""
+        position_set = set(row_positions)
+        new_rows = [
+            replace(row, indent=indent) if ii in position_set else row
+            for ii, row in enumerate(self.rows)
+        ]
         return self.__class__(new_rows, self.group_rows)
 
     def order_groups(self, group_order: RowGroups) -> Self:

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -1397,6 +1397,7 @@ class Options:
     stub_border_style: OptionsInfo = OptionsInfo(True, "stub", "value", "solid")
     stub_border_width: OptionsInfo = OptionsInfo(True, "stub", "px", "2px")
     stub_border_color: OptionsInfo = OptionsInfo(True, "stub", "value", "#D3D3D3")
+    stub_indent_length: OptionsInfo = OptionsInfo(True, "stub", "px", "5px")
     stub_row_group_background_color: OptionsInfo = OptionsInfo(True, "stub", "value", None)
     stub_row_group_font_size: OptionsInfo = OptionsInfo(True, "stub", "px", "100%")
     stub_row_group_font_weight: OptionsInfo = OptionsInfo(True, "stub", "value", "initial")

--- a/great_tables/_helpers.py
+++ b/great_tables/_helpers.py
@@ -152,6 +152,46 @@ FONT_STACKS = {
 }
 
 
+class _StubSentinel:
+    """Sentinel that refers to the stub column in column-selection helpers.
+
+    Use the module-level `stub` instance (importable from `great_tables`) rather than instantiating
+    this class directly. The sentinel is hashable and can therefore be used as a dictionary key,
+    (e.g., `cols_width(cases={stub: "250px"})`).
+    """
+
+    _instance: "_StubSentinel | None" = None
+
+    def __new__(cls) -> "_StubSentinel":
+        # Singleton so that `stub is stub` holds everywhere.
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "stub"
+
+    def __hash__(self) -> int:
+        return hash("__great_tables_stub__")
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _StubSentinel)
+
+
+stub = _StubSentinel()
+"""Sentinel for selecting the stub column in `~great_tables.GT.cols_width`.
+
+Pass this as a dictionary key to set the width of the stub column without risking a collision with a
+data column named `"stub"`:
+
+```python
+from great_tables import GT, stub, px
+
+GT(df, rowname_col="row").cols_width(cases={stub: "200px", "value": "100px"})
+```
+"""
+
+
 def px(x: int | float) -> str:
     """
     Helper for providing a CSS length value in pixels.

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -63,7 +63,7 @@ def footnotes_split_style_list(
 # Misc Types ===========================================================================
 
 PlacementOptions: TypeAlias = Literal["auto", "left", "right"]
-RowSelectExpr: TypeAlias = 'list[int] | int | PlExpr | Callable[["TblData"], bool] | None'
+RowSelectExpr: TypeAlias = 'bool | list[int] | int | PlExpr | Callable[["TblData"], bool] | None'
 
 # Locations ============================================================================
 # TODO: these are called cells_* in gt. I prefixed them with Loc just to keep things
@@ -1041,6 +1041,13 @@ def resolve_rows_i(
     Unlike tidyselect::eval_select, this function returns names in
     the order they appear in the data (rather than ordered by selectors).
     """
+
+    # bool is a subclass of int; handle it before the int check to avoid True/False
+    # being interpreted as row indices 1/0.
+    if expr is True:
+        expr = None  # Treated as "select everything"
+    elif expr is False:
+        return []
 
     if isinstance(expr, (str, int)):
         expr: list[str | int] = [expr]

--- a/great_tables/_options.py
+++ b/great_tables/_options.py
@@ -117,6 +117,7 @@ def tab_options(
     stub_border_style: str | None = None,
     stub_border_width: str | None = None,
     stub_border_color: str | None = None,
+    stub_indent_length: str | None = None,
     stub_row_group_font_size: str | None = None,
     stub_row_group_font_weight: str | int | float | None = None,
     stub_row_group_text_transform: str | None = None,
@@ -430,6 +431,9 @@ def tab_options(
         The width of the vertical border of the table stub.
     stub_border_color
         The color of the vertical border of the table stub.
+    stub_indent_length
+        The width of each indentation level for row labels set by
+        [`tab_stub_indent()`](`great_tables.GT.tab_stub_indent`). Defaults to `"5px"`.
     stub_row_group_font_size
         The font size for the row group column in the stub.
     stub_row_group_font_weight

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -895,7 +895,9 @@ def cols_width(self: GTSelf, cases: dict[str, str] | None = None, **kwargs: str)
     ----------
     cases
         A dictionary where the keys are column names and the values are the widths. Widths can be
-        specified in pixels (e.g., `"50px"`) or as percentages (e.g., `"20%"`).
+        specified in pixels (e.g., `"50px"`) or as percentages (e.g., `"20%"`). Use the
+        [`stub`](`great_tables.stub`) sentinel as a key to set the width of the stub column without
+        risk of collision with a data column named `"stub"`.
 
     **kwargs
         Keyword arguments to specify column widths. Each keyword corresponds to a column name, with
@@ -991,6 +993,28 @@ def cols_width(self: GTSelf, cases: dict[str, str] | None = None, **kwargs: str)
     overflows. When not specifying the width of all columns, the table will automatically adjust the
     column widths based on the content (and you wouldn't get the overflowing behavior seen in the
     previous example).
+
+    When a table has a stub (row labels), use the [`stub`](`great_tables.stub`) sentinel to set its
+    width. This avoids any ambiguity with a data column that happens to be named `"stub"`.
+
+    ```{python}
+    from great_tables import GT, stub
+    from great_tables.data import gtcars
+
+    gtcars_mini = gtcars[["model", "year", "hp", "msrp"]].head(6)
+
+    (
+        GT(gtcars_mini, rowname_col="model")
+        .cols_width(
+            cases={
+                stub: "200px",
+                "year": "60px",
+                "hp": "60px",
+                "msrp": "120px",
+            }
+        )
+    )
+    ```
     """
     cases = cases if cases is not None else {}
     new_cases = cases | kwargs
@@ -1000,6 +1024,20 @@ def cols_width(self: GTSelf, cases: dict[str, str] | None = None, **kwargs: str)
         return self
 
     curr_boxhead = self._boxhead
+
+    # Resolve a stub sentinel key to the actual stub column variable name
+    from ._helpers import _StubSentinel
+
+    stub_keys = [k for k in new_cases if isinstance(k, _StubSentinel)]
+    if stub_keys:
+        stub_col = curr_boxhead._get_stub_column()
+        if stub_col is not None:
+            stub_width = new_cases.pop(stub_keys[0])
+            new_cases = {stub_col.var: stub_width} | new_cases
+        else:
+            # No stub column present — drop the sentinel key silently
+            for k in stub_keys:
+                new_cases.pop(k)
 
     # Get the full list of column names for the data
     column_names = curr_boxhead._get_columns()

--- a/great_tables/_tab_stub_indent.py
+++ b/great_tables/_tab_stub_indent.py
@@ -57,6 +57,48 @@ def tab_stub_indent(
         .tab_stub_indent(rows=True, indent=2)
     )
     ```
+
+    Here's a more advanced example using the `constants` dataset. We filter for three groups of
+    physical constants and rename the sub-entries to start with `"..."` so it's clear they belong
+    to a parent constant. Then `tab_stub_indent()` targets those sub-rows (via a Polars expression)
+    and indents them by 4 levels.
+
+    ```{python}
+    from great_tables import GT, stub
+    from great_tables.data import constants
+    import polars as pl
+
+    constants_mini = (
+        pl.from_pandas(constants)
+        .select(["name", "value", "uncert", "units"])
+        .filter(
+            pl.col("name").str.starts_with("atomic mass constant")
+            | pl.col("name").str.starts_with("Rydberg constant")
+            | pl.col("name").str.starts_with("Bohr magneton")
+        )
+        .with_columns(
+            name=pl.when(
+                pl.col("name").str.contains("constant ")
+                | pl.col("name").str.contains("magneton ")
+            )
+            .then(pl.col("name").str.replace(r".*?(?:constant |magneton )", "..."))
+            .otherwise(pl.col("name"))
+        )
+    )
+
+    (
+        GT(constants_mini, rowname_col="name")
+        .tab_stubhead(label="Physical Constant")
+        .tab_stub_indent(
+            rows=pl.col("name").str.starts_with("..."),
+            indent=4,
+        )
+        .fmt_scientific(columns=["value", "uncert"])
+        .fmt_units(columns="units")
+        .cols_label(value="Value", uncert="Uncertainty", units="Units")
+        .cols_width(cases={stub: "250px", "value": "150px", "uncert": "150px", "units": "80px"})
+    )
+    ```
     """
 
     row_res = resolve_rows_i(self, rows)

--- a/great_tables/_tab_stub_indent.py
+++ b/great_tables/_tab_stub_indent.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING, Literal, Union
+
+from ._gt_data import Stub
+from ._locations import RowSelectExpr, resolve_rows_i
+
+if TYPE_CHECKING:
+    from ._types import GTSelf
+
+
+def tab_stub_indent(
+    self: GTSelf,
+    rows: RowSelectExpr,
+    indent: Union[int, Literal["increase", "decrease"]] = "increase",
+) -> GTSelf:
+    """
+    Control indentation of row labels in the stub.
+
+    Indentation of row labels is an effective way to establish visual hierarchy in a table stub.
+    `tab_stub_indent()` allows for fine-grained control over row label indentation in the stub.
+    You can use an explicit integer indentation level (between `0` and `5`), or use a keyword
+    directive: `"increase"` (the default) or `"decrease"`.
+
+    Parameters
+    ----------
+    rows
+        The rows to target for the indentation change. We can supply a list of row indices, a
+        single row index integer, or a callable that takes the table data and returns a boolean
+        Series. When targeting rows by name, provide a list of row label strings.
+    indent
+        An indentation directive or explicit integer level. The keyword `"increase"` (the default)
+        increments the indentation level by `1`; `"decrease"` decrements it by `1`. The minimum
+        indentation level is `0` (no indentation) and the maximum is `5`. An integer value
+        directly sets the indentation level (clamped to the `0`–`5` range).
+
+    Returns
+    -------
+    GT
+        The GT object is returned. This is the same object that the method is called on so that we
+        can facilitate method chaining.
+
+    Examples
+    --------
+    Let's use a subset of the `exibble` dataset to create a gt table with row groups and row
+    labels. We'll use `tab_stub_indent()` to add indentation to all the row labels in the stub.
+
+    ```{python}
+    from great_tables import GT
+    from great_tables.data import exibble
+
+    exibble_mini = exibble[["num", "char", "row", "group"]].head(8)
+
+    (
+        GT(exibble_mini, rowname_col="row", groupname_col="group")
+        .tab_stub_indent(rows=True, indent=2)
+    )
+    ```
+    """
+
+    row_res = resolve_rows_i(self, rows)
+    row_positions = [ii for _, ii in row_res]
+
+    if isinstance(indent, str):
+        position_set = set(row_positions)
+        new_rows = []
+        for ii, row in enumerate(self._stub.rows):
+            if ii in position_set:
+                if indent == "increase":
+                    new_indent = min(5, row.indent + 1)
+                else:  # "decrease"
+                    new_indent = max(0, row.indent - 1)
+                new_rows.append(replace(row, indent=new_indent))
+            else:
+                new_rows.append(row)
+        new_stub = Stub(new_rows, self._stub.group_rows)
+    else:
+        indent_val = max(0, min(5, int(indent)))
+        new_stub = self._stub.set_row_indent(row_positions, indent_val)
+
+    return self._replace(_stub=new_stub)

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -1053,18 +1053,14 @@ def _create_row_component_h(
             if apply_body_striping:
                 classes.append("gt_striped")
 
-        classes_str = " ".join(classes)
-        cell_styles = _flatten_styles(_body_styles + _rowname_styles, wrap=True)
-
-        # Apply stub indent padding for regular (non-summary) data rows
+        # Apply stub indent CSS class for regular (non-summary) data rows
         if colinfo.is_stub and not is_summary_row and data is not None and row_index is not None:
             indent_level = data._stub.rows[row_index].indent
-            if indent_level > 0:
-                indent_css = f"padding-left: {indent_level * 10}px;"
-                if cell_styles:
-                    cell_styles = cell_styles[:-1] + f' {indent_css}"'
-                else:
-                    cell_styles = f' style="{indent_css}"'
+            if 1 <= indent_level <= 5:
+                classes.append(f"gt_indent_{indent_level}")
+
+        classes_str = " ".join(classes)
+        cell_styles = _flatten_styles(_body_styles + _rowname_styles, wrap=True)
 
         body_cells.append(
             f"""    <{el_name}{cell_styles} class="{classes_str}">{cell_str}</{el_name}>"""

--- a/great_tables/_utils_render_html.py
+++ b/great_tables/_utils_render_html.py
@@ -1056,6 +1056,16 @@ def _create_row_component_h(
         classes_str = " ".join(classes)
         cell_styles = _flatten_styles(_body_styles + _rowname_styles, wrap=True)
 
+        # Apply stub indent padding for regular (non-summary) data rows
+        if colinfo.is_stub and not is_summary_row and data is not None and row_index is not None:
+            indent_level = data._stub.rows[row_index].indent
+            if indent_level > 0:
+                indent_css = f"padding-left: {indent_level * 10}px;"
+                if cell_styles:
+                    cell_styles = cell_styles[:-1] + f' {indent_css}"'
+                else:
+                    cell_styles = f' style="{indent_css}"'
+
         body_cells.append(
             f"""    <{el_name}{cell_styles} class="{classes_str}">{cell_str}</{el_name}>"""
         )

--- a/great_tables/css/gt_styles_default.scss
+++ b/great_tables/css/gt_styles_default.scss
@@ -241,6 +241,26 @@ p {
   padding-right: $data_row_padding_horizontal;
 }
 
+.gt_indent_1 {
+  text-indent: $stub_indent_length;
+}
+
+.gt_indent_2 {
+  text-indent: calc($stub_indent_length * 2);
+}
+
+.gt_indent_3 {
+  text-indent: calc($stub_indent_length * 3);
+}
+
+.gt_indent_4 {
+  text-indent: calc($stub_indent_length * 4);
+}
+
+.gt_indent_5 {
+  text-indent: calc($stub_indent_length * 5);
+}
+
 .gt_stub_row_group {
   color: $font_color_stub_row_group_background_color;
   background-color: $stub_row_group_background_color;

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -95,6 +95,7 @@ from ._tab_create_modify import (
     text_replace,
     text_transform,
 )
+from ._tab_stub_indent import tab_stub_indent
 from ._tbl_data import _get_cell, _set_cell, n_rows
 from ._utils import _migrate_unformatted_to_output
 from ._utils_render_html import (
@@ -422,6 +423,7 @@ class GT(
     tab_spanner = tab_spanner
     tab_spanner_delim = tab_spanner_delim
     tab_stubhead = tab_stubhead
+    tab_stub_indent = tab_stub_indent
     tab_style = tab_style
     tab_options = tab_options
 

--- a/tests/__snapshots__/test_export.ambr
+++ b/tests/__snapshots__/test_export.ambr
@@ -31,6 +31,11 @@
    #test_table .gt_from_md> :last-child { margin-bottom: 0; }
    #test_table .gt_row { padding-top: 8px; padding-bottom: 8px; padding-left: 5px; padding-right: 5px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
    #test_table .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; }
+   #test_table .gt_indent_1 { text-indent: 5px; }
+   #test_table .gt_indent_2 { text-indent: calc(5px * 2); }
+   #test_table .gt_indent_3 { text-indent: calc(5px * 3); }
+   #test_table .gt_indent_4 { text-indent: calc(5px * 4); }
+   #test_table .gt_indent_5 { text-indent: calc(5px * 5); }
    #test_table .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
    #test_table .gt_row_group_first td { border-top-width: 2px; }
    #test_table .gt_row_group_first th { border-top-width: 2px; }

--- a/tests/__snapshots__/test_options.ambr
+++ b/tests/__snapshots__/test_options.ambr
@@ -286,6 +286,26 @@
     padding-right: 5px;
   }
   
+  #abc .gt_indent_1 {
+    text-indent: 5px;
+  }
+  
+  #abc .gt_indent_2 {
+    text-indent: calc(5px * 2);
+  }
+  
+  #abc .gt_indent_3 {
+    text-indent: calc(5px * 3);
+  }
+  
+  #abc .gt_indent_4 {
+    text-indent: calc(5px * 4);
+  }
+  
+  #abc .gt_indent_5 {
+    text-indent: calc(5px * 5);
+  }
+  
   #abc .gt_stub_row_group {
     color: #333333;
     background-color: #FFFFFF;
@@ -726,6 +746,26 @@
     border-right-color: #0076BA;
     padding-left: 5px;
     padding-right: 5px;
+  }
+  
+  #abc .gt_indent_1 {
+    text-indent: 5px;
+  }
+  
+  #abc .gt_indent_2 {
+    text-indent: calc(5px * 2);
+  }
+  
+  #abc .gt_indent_3 {
+    text-indent: calc(5px * 3);
+  }
+  
+  #abc .gt_indent_4 {
+    text-indent: calc(5px * 4);
+  }
+  
+  #abc .gt_indent_5 {
+    text-indent: calc(5px * 5);
   }
   
   #abc .gt_stub_row_group {
@@ -1278,6 +1318,26 @@
     padding-right: 5px;
   }
   
+  #abc .gt_indent_1 {
+    text-indent: 5px;
+  }
+  
+  #abc .gt_indent_2 {
+    text-indent: calc(5px * 2);
+  }
+  
+  #abc .gt_indent_3 {
+    text-indent: calc(5px * 3);
+  }
+  
+  #abc .gt_indent_4 {
+    text-indent: calc(5px * 4);
+  }
+  
+  #abc .gt_indent_5 {
+    text-indent: calc(5px * 5);
+  }
+  
   #abc .gt_stub_row_group {
     color: #000000;
     background-color: red;
@@ -1718,6 +1778,26 @@
     border-right-color: #D3D3D3;
     padding-left: 5px;
     padding-right: 5px;
+  }
+  
+  #abc .gt_indent_1 {
+    text-indent: 5px;
+  }
+  
+  #abc .gt_indent_2 {
+    text-indent: calc(5px * 2);
+  }
+  
+  #abc .gt_indent_3 {
+    text-indent: calc(5px * 3);
+  }
+  
+  #abc .gt_indent_4 {
+    text-indent: calc(5px * 4);
+  }
+  
+  #abc .gt_indent_5 {
+    text-indent: calc(5px * 5);
   }
   
   #abc .gt_stub_row_group {

--- a/tests/__snapshots__/test_repr.ambr
+++ b/tests/__snapshots__/test_repr.ambr
@@ -31,6 +31,11 @@
    #test .gt_from_md> :last-child { margin-bottom: 0; }
    #test .gt_row { padding-top: 8px; padding-bottom: 8px; padding-left: 5px; padding-right: 5px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
    #test .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; }
+   #test .gt_indent_1 { text-indent: 5px; }
+   #test .gt_indent_2 { text-indent: calc(5px * 2); }
+   #test .gt_indent_3 { text-indent: calc(5px * 3); }
+   #test .gt_indent_4 { text-indent: calc(5px * 4); }
+   #test .gt_indent_5 { text-indent: calc(5px * 5); }
    #test .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
    #test .gt_row_group_first td { border-top-width: 2px; }
    #test .gt_row_group_first th { border-top-width: 2px; }
@@ -116,6 +121,11 @@
    #test .gt_from_md> :last-child { margin-bottom: 0; }
    #test .gt_row { padding-top: 8px; padding-bottom: 8px; padding-left: 5px; padding-right: 5px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
    #test .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; }
+   #test .gt_indent_1 { text-indent: 5px; }
+   #test .gt_indent_2 { text-indent: calc(5px * 2); }
+   #test .gt_indent_3 { text-indent: calc(5px * 3); }
+   #test .gt_indent_4 { text-indent: calc(5px * 4); }
+   #test .gt_indent_5 { text-indent: calc(5px * 5); }
    #test .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
    #test .gt_row_group_first td { border-top-width: 2px; }
    #test .gt_row_group_first th { border-top-width: 2px; }
@@ -207,6 +217,11 @@
    #test .gt_from_md> :last-child { margin-bottom: 0 !important; }
    #test .gt_row { padding-top: 8px !important; padding-bottom: 8px !important; padding-left: 5px !important; padding-right: 5px !important; margin: 10px !important; border-top-style: solid !important; border-top-width: 1px !important; border-top-color: #D3D3D3 !important; border-left-style: none !important; border-left-width: 1px !important; border-left-color: #D3D3D3 !important; border-right-style: none !important; border-right-width: 1px !important; border-right-color: #D3D3D3 !important; vertical-align: middle !important; overflow-x: hidden !important; }
    #test .gt_stub { color: #333333 !important; background-color: #FFFFFF !important; font-size: 100% !important; font-weight: initial !important; text-transform: inherit !important; border-right-style: solid !important; border-right-width: 2px !important; border-right-color: #D3D3D3 !important; padding-left: 5px !important; padding-right: 5px !important; }
+   #test .gt_indent_1 { text-indent: 5px !important; }
+   #test .gt_indent_2 { text-indent: calc(5px * 2) !important; }
+   #test .gt_indent_3 { text-indent: calc(5px * 3) !important; }
+   #test .gt_indent_4 { text-indent: calc(5px * 4) !important; }
+   #test .gt_indent_5 { text-indent: calc(5px * 5) !important; }
    #test .gt_stub_row_group { color: #333333 !important; background-color: #FFFFFF !important; font-size: 100% !important; font-weight: initial !important; text-transform: inherit !important; border-right-style: solid !important; border-right-width: 2px !important; border-right-color: #D3D3D3 !important; padding-left: 5px !important; padding-right: 5px !important; vertical-align: top !important; }
    #test .gt_row_group_first td { border-top-width: 2px !important; }
    #test .gt_row_group_first th { border-top-width: 2px !important; }
@@ -295,6 +310,11 @@
    #test .gt_from_md> :last-child { margin-bottom: 0; }
    #test .gt_row { padding-top: 8px; padding-bottom: 8px; padding-left: 5px; padding-right: 5px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
    #test .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; }
+   #test .gt_indent_1 { text-indent: 5px; }
+   #test .gt_indent_2 { text-indent: calc(5px * 2); }
+   #test .gt_indent_3 { text-indent: calc(5px * 3); }
+   #test .gt_indent_4 { text-indent: calc(5px * 4); }
+   #test .gt_indent_5 { text-indent: calc(5px * 5); }
    #test .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 5px; padding-right: 5px; vertical-align: top; }
    #test .gt_row_group_first td { border-top-width: 2px; }
    #test .gt_row_group_first th { border-top-width: 2px; }
@@ -380,6 +400,11 @@
    #test .gt_from_md> :last-child { margin-bottom: 0 !important; }
    #test .gt_row { padding-top: 8px !important; padding-bottom: 8px !important; padding-left: 5px !important; padding-right: 5px !important; margin: 10px !important; border-top-style: solid !important; border-top-width: 1px !important; border-top-color: #D3D3D3 !important; border-left-style: none !important; border-left-width: 1px !important; border-left-color: #D3D3D3 !important; border-right-style: none !important; border-right-width: 1px !important; border-right-color: #D3D3D3 !important; vertical-align: middle !important; overflow-x: hidden !important; }
    #test .gt_stub { color: #333333 !important; background-color: #FFFFFF !important; font-size: 100% !important; font-weight: initial !important; text-transform: inherit !important; border-right-style: solid !important; border-right-width: 2px !important; border-right-color: #D3D3D3 !important; padding-left: 5px !important; padding-right: 5px !important; }
+   #test .gt_indent_1 { text-indent: 5px !important; }
+   #test .gt_indent_2 { text-indent: calc(5px * 2) !important; }
+   #test .gt_indent_3 { text-indent: calc(5px * 3) !important; }
+   #test .gt_indent_4 { text-indent: calc(5px * 4) !important; }
+   #test .gt_indent_5 { text-indent: calc(5px * 5) !important; }
    #test .gt_stub_row_group { color: #333333 !important; background-color: #FFFFFF !important; font-size: 100% !important; font-weight: initial !important; text-transform: inherit !important; border-right-style: solid !important; border-right-width: 2px !important; border-right-color: #D3D3D3 !important; padding-left: 5px !important; padding-right: 5px !important; vertical-align: top !important; }
    #test .gt_row_group_first td { border-top-width: 2px !important; }
    #test .gt_row_group_first th { border-top-width: 2px !important; }

--- a/tests/__snapshots__/test_scss.ambr
+++ b/tests/__snapshots__/test_scss.ambr
@@ -250,6 +250,26 @@
     padding-right: 5px;
   }
   
+  #abc .gt_indent_1 {
+    text-indent: 5px;
+  }
+  
+  #abc .gt_indent_2 {
+    text-indent: calc(5px * 2);
+  }
+  
+  #abc .gt_indent_3 {
+    text-indent: calc(5px * 3);
+  }
+  
+  #abc .gt_indent_4 {
+    text-indent: calc(5px * 4);
+  }
+  
+  #abc .gt_indent_5 {
+    text-indent: calc(5px * 5);
+  }
+  
   #abc .gt_stub_row_group {
     color: #333333;
     background-color: #FFFFFF;

--- a/tests/test__tab_stub_indent.py
+++ b/tests/test__tab_stub_indent.py
@@ -1,0 +1,90 @@
+import pytest
+import pandas as pd
+import great_tables as gt
+
+
+@pytest.fixture
+def gt_with_stub():
+    df = pd.DataFrame(
+        {
+            "row": ["a", "b", "c", "d"],
+            "group": ["x", "x", "y", "y"],
+            "val": [1, 2, 3, 4],
+        }
+    )
+    return gt.GT(df, rowname_col="row", groupname_col="group")
+
+
+def test_tab_stub_indent_integer(gt_with_stub):
+    result = gt_with_stub.tab_stub_indent(rows=[0, 1], indent=3)
+    assert result._stub.rows[0].indent == 3
+    assert result._stub.rows[1].indent == 3
+    assert result._stub.rows[2].indent == 0
+    assert result._stub.rows[3].indent == 0
+
+
+def test_tab_stub_indent_increase(gt_with_stub):
+    # Start at 0, increase by 1
+    result = gt_with_stub.tab_stub_indent(rows=[0], indent="increase")
+    assert result._stub.rows[0].indent == 1
+    assert result._stub.rows[1].indent == 0
+
+    # Increase again from 1
+    result2 = result.tab_stub_indent(rows=[0], indent="increase")
+    assert result2._stub.rows[0].indent == 2
+
+
+def test_tab_stub_indent_decrease(gt_with_stub):
+    # Set to 2, then decrease
+    result = gt_with_stub.tab_stub_indent(rows=[0], indent=2)
+    result2 = result.tab_stub_indent(rows=[0], indent="decrease")
+    assert result2._stub.rows[0].indent == 1
+
+
+def test_tab_stub_indent_clamps_to_zero(gt_with_stub):
+    # Decrease from 0 stays at 0
+    result = gt_with_stub.tab_stub_indent(rows=[0], indent="decrease")
+    assert result._stub.rows[0].indent == 0
+
+
+def test_tab_stub_indent_clamps_to_five(gt_with_stub):
+    # Integer beyond 5 is clamped to 5
+    result = gt_with_stub.tab_stub_indent(rows=[0], indent=10)
+    assert result._stub.rows[0].indent == 5
+
+
+def test_tab_stub_indent_increase_at_max(gt_with_stub):
+    # Increase from 5 stays at 5
+    result = gt_with_stub.tab_stub_indent(rows=[0], indent=5)
+    result2 = result.tab_stub_indent(rows=[0], indent="increase")
+    assert result2._stub.rows[0].indent == 5
+
+
+def test_tab_stub_indent_html_output(gt_with_stub):
+    result = gt_with_stub.tab_stub_indent(rows=[0], indent=2)
+    html = result.as_raw_html()
+    # 2 levels * 10px = 20px padding-left
+    assert "padding-left: 20px" in html
+
+
+def test_tab_stub_indent_zero_no_inline_style(gt_with_stub):
+    result = gt_with_stub.tab_stub_indent(rows=[0], indent=0)
+    html = result.as_raw_html()
+    # Stub cells should not have a stub-indent padding-left style applied at level 0
+    assert "padding-left: 0px" not in html
+
+
+@pytest.mark.parametrize(
+    "indent,expected",
+    [
+        (1, 10),
+        (2, 20),
+        (3, 30),
+        (4, 40),
+        (5, 50),
+    ],
+)
+def test_tab_stub_indent_pixel_values(gt_with_stub, indent, expected):
+    result = gt_with_stub.tab_stub_indent(rows=[0], indent=indent)
+    html = result.as_raw_html()
+    assert f"padding-left: {expected}px" in html

--- a/tests/test__tab_stub_indent.py
+++ b/tests/test__tab_stub_indent.py
@@ -73,28 +73,17 @@ def test_tab_stub_indent_increase_at_max(gt_with_stub):
 def test_tab_stub_indent_html_output(gt_with_stub):
     result = gt_with_stub.tab_stub_indent(rows=[0], indent=2)
     html = result.as_raw_html()
-    # 2 levels * 10px = 20px padding-left
-    assert "padding-left: 20px" in html
+    assert "gt_indent_2" in html
 
 
-def test_tab_stub_indent_zero_no_inline_style(gt_with_stub):
+def test_tab_stub_indent_zero_no_class(gt_with_stub):
     result = gt_with_stub.tab_stub_indent(rows=[0], indent=0)
     html = result.as_raw_html()
-    # Stub cells should not have a stub-indent padding-left style applied at level 0
-    assert "padding-left: 0px" not in html
+    assert "gt_indent_0" not in html
 
 
-@pytest.mark.parametrize(
-    "indent,expected",
-    [
-        (1, 10),
-        (2, 20),
-        (3, 30),
-        (4, 40),
-        (5, 50),
-    ],
-)
-def test_tab_stub_indent_pixel_values(gt_with_stub, indent, expected):
+@pytest.mark.parametrize("indent", [1, 2, 3, 4, 5])
+def test_tab_stub_indent_css_classes(gt_with_stub, indent):
     result = gt_with_stub.tab_stub_indent(rows=[0], indent=indent)
     html = result.as_raw_html()
-    assert f"padding-left: {expected}px" in html
+    assert f"gt_indent_{indent}" in html

--- a/tests/test__tab_stub_indent.py
+++ b/tests/test__tab_stub_indent.py
@@ -15,6 +15,16 @@ def gt_with_stub():
     return gt.GT(df, rowname_col="row", groupname_col="group")
 
 
+def test_tab_stub_indent_rows_true_selects_all(gt_with_stub):
+    result = gt_with_stub.tab_stub_indent(rows=True, indent=2)
+    assert all(row.indent == 2 for row in result._stub.rows)
+
+
+def test_tab_stub_indent_rows_false_selects_none(gt_with_stub):
+    result = gt_with_stub.tab_stub_indent(rows=False, indent=2)
+    assert all(row.indent == 0 for row in result._stub.rows)
+
+
 def test_tab_stub_indent_integer(gt_with_stub):
     result = gt_with_stub.tab_stub_indent(rows=[0, 1], indent=3)
     assert result._stub.rows[0].indent == 3

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -296,6 +296,40 @@ def test_cols_width_html_colgroup_stub():
     )
 
 
+def test_cols_width_stub_key():
+    # `stub` sentinel resolves to the stub column's variable name
+    from great_tables import stub
+
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    gt_tbl = GT(df, rowname_col="b").cols_width({stub: "20px", "a": "10px", "c": "30px"})
+
+    tbl_built = gt_tbl._build_data(context="html")
+    table_defs = _get_table_defs(tbl_built)
+
+    assert (
+        str(table_defs["table_colgroups"])
+        == '<colgroup>\n  <col style="width:20px;"/>\n  <col style="width:10px;"/>\n  <col style="width:30px;"/>\n</colgroup>'
+    )
+
+
+def test_cols_width_stub_key_no_stub():
+    # `stub` sentinel with no stub column is silently ignored
+    from great_tables import stub
+
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    gt_tbl = GT(df).cols_width({stub: "99px", "a": "10px", "b": "20px"})
+    assert gt_tbl._boxhead._get_column_widths() == ["10px", "20px"]
+
+
+def test_cols_width_stub_key_no_collision():
+    # A data column actually named "stub" is NOT treated as the sentinel
+    from great_tables import stub
+
+    df = pd.DataFrame({"stub": [1, 2], "a": [3, 4]})
+    gt_tbl = GT(df).cols_width({"stub": "10px", "a": "20px"})
+    assert gt_tbl._boxhead._get_column_widths() == ["10px", "20px"]
+
+
 def test_cols_width_html_colgroup_complex():
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6], "d": [7, 8], "e": [9, 10]})
     gt_tbl = (


### PR DESCRIPTION
This PR introduces the ability to control the indentation of row labels (i.e., stub labels). It allows users to visually group or nest rows for improved table hierarchy by adding the `tab_stub_indent()` method. You can set, increase, or decrease indentation levels for specific rows.