### PR TITLE
Fix three docstring parameter names

### DIFF
--- a/great_tables/_formats_vals.py
+++ b/great_tables/_formats_vals.py
@@ -66,7 +66,7 @@ def _make_one_col_table(vals: X) -> GT:
 
     Parameters
     ----------
-    x
+    vals
         The list of values to be converted into a table.
 
     Returns

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -898,7 +898,7 @@ def eval_aggregate(df, expr) -> dict[str, Any]:
 
     Parameters
     ----------
-    data
+    df
         The input data (DataFrame)
     expr
         The expression to evaluate (Polars expression or callable)

--- a/great_tables/_utils_render_latex.py
+++ b/great_tables/_utils_render_latex.py
@@ -639,8 +639,8 @@ def create_table_end_l(use_longtable: bool) -> str:
 
     Parameters
     ----------
-    data : GTData
-        The GTData object that contains all the information about the table.
+    use_longtable : bool
+        Whether the table uses the `longtable` environment.
 
     Returns
     -------


### PR DESCRIPTION
# Summary

Three docstrings name a parameter the function does not take.

| Where | Says | Takes |
|---|---|---|
| `_formats_vals.py` `_make_one_col_table` | `x` | `vals` |
| `_tbl_data.py` `eval_aggregate` | `data` | `df` |
| `_utils_render_latex.py` `create_table_end_l` | `data : GTData` | `use_longtable : bool` |

The first two are renames the docstring did not follow. The third is a different argument of a different type, so I wrote a one-line description for it, taken from the summary right above: "The output is different depending on whether the table uses the `longtable` environment or not."

Documentation only, no behaviour change.

# Related GitHub Issues and PRs

- Ref: #

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ ] I have added **pytest** unit tests for any new functionality. No new functionality: this is docstring text.
